### PR TITLE
Add IEC 62443 complete policy library (all 51 SRs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rego Policy Libraries
 
-> **332 production-ready OPA policies** covering CIS Benchmarks, NIST, SOC 2, PCI-DSS, ISO 27001, NERC-CIP, HIPAA, FedRAMP, and more — all in Rego v1 syntax, ready to load into any OPA instance.
+> **343 production-ready OPA policies** covering CIS Benchmarks, NIST, SOC 2, PCI-DSS, ISO 27001, NERC-CIP, IEC 62443, HIPAA, FedRAMP, and more — all in Rego v1 syntax, ready to load into any OPA instance.
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![OPA](https://img.shields.io/badge/OPA-v0.60%2B-blue)](https://www.openpolicyagent.org/)
@@ -14,7 +14,7 @@
 | Domain | Policies | Coverage |
 |--------|----------|----------|
 | **CIS Benchmarks** | 217 | 22 platforms: Linux, Windows, Cloud, Containers, Databases, Network |
-| **Regulatory Frameworks** | 103 | ISO 27001, SOC 2, PCI-DSS, SOX, FISMA, FedRAMP, CMMC, GDPR, HIPAA, NERC-CIP, IEC 62443, Digital Sovereignty |
+| **Regulatory Frameworks** | 114 | ISO 27001, SOC 2, PCI-DSS, SOX, FISMA, FedRAMP, CMMC, GDPR, HIPAA, NERC-CIP, IEC 62443, Digital Sovereignty |
 | **Enforcement** | 6 | Ansible, Terraform, Dockerfile, Kubernetes, Git |
 | **Governance** | 4 | AI agent authorization, MCP tool-call enforcement |
 | **Threat Detection** | 2 | Cryptocurrency miner detection |
@@ -31,7 +31,7 @@ git clone https://github.com/ynotbhatc/rego_policy_libraries.git
 cd rego_policy_libraries
 
 # Start OPA
-docker run -d --name opa -p 8181:8181 openpolicyagent/opa run --server --addr :8181
+podman run -d --name opa -p 8181:8181 openpolicyagent/opa run --server --addr :8181
 
 # Load all CIS RHEL 9 policies
 for f in benchmarks/cis/os/linux/rhel_9/*.rego; do
@@ -105,6 +105,57 @@ rego_policy_libraries/
 
 ---
 
+## IEC 62443 Coverage
+
+Full library for IEC 62443 Industrial Automation and Control Systems (IACS) Security — all 51 System Requirements (SRs) from Part 3-3 plus Part 2 management requirements.
+
+| File | Part | Title | SRs |
+|------|------|-------|-----|
+| `fr1_identification_authentication.rego` | 3-3 FR 1 | Identification & Authentication Control (IAC) | SR 1.1–1.13 (13) |
+| `fr2_use_control.rego` | 3-3 FR 2 | Use Control (UC) | SR 2.1–2.12 (12) |
+| `fr3_system_integrity.rego` | 3-3 FR 3 | System Integrity (SI) | SR 3.1–3.9 (9) |
+| `fr4_data_confidentiality.rego` | 3-3 FR 4 | Data Confidentiality (DC) | SR 4.1–4.3 (3) |
+| `fr5_restricted_data_flow.rego` | 3-3 FR 5 | Restricted Data Flow / Zone & Conduit (RDF) | SR 5.1–5.4 (4) |
+| `fr6_timely_response.rego` | 3-3 FR 6 | Timely Response to Events (TRE) | SR 6.1–6.2 (2) |
+| `fr7_resource_availability.rego` | 3-3 FR 7 | Resource Availability (RA) | SR 7.1–7.8 (8) |
+| `part2_security_management.rego` | 2-1 | Security Management System (CSMS) | — |
+| `part2_patch_management.rego` | 2-3 | Patch Management in IACS Environments | — |
+| `part2_service_provider.rego` | 2-4 | Security Program for IACS Service Providers (SP.01–SP.10) | — |
+| `part3_risk_assessment.rego` | 3-2 | Security Risk Assessment (ZCR 1–5) | — |
+| `iec_62443_main.rego` | All | Main orchestrator — aggregates all parts | 51 total |
+
+**Security Level (SL) tiering:** All FR modules enforce SL-differentiated requirements — violations are tagged with the SL at which they apply (SL 1 baseline through SL 4 state-sponsored threat protection).
+
+**OPA endpoint:** `POST /v1/data/iec_62443_main/iec_62443_compliance_report`
+
+```json
+{
+  "standard": "IEC 62443",
+  "target_sl": 2,
+  "compliant": false,
+  "fr_compliance_score": 71,
+  "sr_compliance_score": 84,
+  "passing_frs": 5,
+  "total_frs": 7,
+  "passing_srs": 43,
+  "total_srs": 51,
+  "part3_3_foundational_requirements": {
+    "FR1_identification_authentication": { "compliant": true, "passing_srs": 13 },
+    "FR5_restricted_data_flow": { "compliant": false, "violations": ["..."] }
+  }
+}
+```
+
+---
+
+## NERC-CIP Coverage
+
+Full library covering all active CIP standards (CIP-002 through CIP-015) in `frameworks/critical_infrastructure/nerc_cip/`.
+
+**OPA endpoint:** `POST /v1/data/nerc_cip_main`
+
+---
+
 ## Loading Policies into OPA
 
 ### Single policy
@@ -123,17 +174,17 @@ done
 
 ### Recommended 3-container pattern (domain isolation)
 ```bash
-# Security benchmarks
+# Security benchmarks (CIS, NIST, DISA STIGs)
 podman run -d --name opa-security -p 8181:8181 openpolicyagent/opa run --server --addr :8181
 
-# Regulatory frameworks
+# Regulatory frameworks (ISO 27001, SOC 2, PCI-DSS, SOX, FISMA, GDPR, HIPAA)
 podman run -d --name opa-compliance -p 8182:8182 openpolicyagent/opa run --server --addr :8182
 
-# OT / Critical infrastructure
+# OT / Critical infrastructure (NERC-CIP, IEC 62443, NIST IR 7628, AMI)
 podman run -d --name opa-ot -p 8183:8183 openpolicyagent/opa run --server --addr :8183
 ```
 
-Load `benchmarks/` into `:8181`, `frameworks/` into `:8182`, `frameworks/critical_infrastructure/` + `governance/` into `:8183`.
+Load `benchmarks/` into `:8181`, `frameworks/` (minus critical_infrastructure) into `:8182`, `frameworks/critical_infrastructure/` + `governance/` into `:8183`.
 
 ---
 

--- a/frameworks/critical_infrastructure/iec_62443/fr1_identification_authentication.rego
+++ b/frameworks/critical_infrastructure/iec_62443/fr1_identification_authentication.rego
@@ -1,0 +1,390 @@
+package iec_62443.fr1
+
+import rego.v1
+
+# =============================================================================
+# IEC 62443-3-3 FR 1 — Identification and Authentication Control (IAC)
+#
+# Purpose: Identify and authenticate all users (humans, software processes,
+# and devices) before allowing them to access the IACS.
+#
+# Security Requirements (SRs):
+#   SR 1.1  — Human user identification and authentication
+#   SR 1.2  — Software process and device identification and authentication
+#   SR 1.3  — Account management
+#   SR 1.4  — Identifier management
+#   SR 1.5  — Authenticator management
+#   SR 1.6  — Wireless access management
+#   SR 1.7  — Strength of password-based authentication
+#   SR 1.8  — Public key infrastructure (PKI) certificates
+#   SR 1.9  — Strength of public key authentication
+#   SR 1.10 — Authenticator feedback
+#   SR 1.11 — Unsuccessful login attempts
+#   SR 1.12 — System use notification
+#   SR 1.13 — Access via untrusted networks
+#
+# Input shape:
+#   input.target_sl                            - int (1–4)
+#   input.ics_systems[]
+#     .name                                    - string
+#     .unique_identification                   - bool
+#     .mfa_enabled                             - bool
+#     .default_credentials_unchanged           - bool
+#     .password_min_length                     - int
+#     .password_complexity                     - bool
+#     .account_lockout_threshold               - int
+#     .wireless_access                         - bool
+#     .wireless_encrypted                      - bool
+#     .system_use_notification                 - bool
+#     .audit_logging_enabled                   - bool
+#   input.authentication
+#     .pki_or_certificate_based                - bool
+#     .centralized_identity_management         - bool
+#     .session_timeout_minutes                 - int
+# =============================================================================
+
+default compliant := false
+
+# ---------------------------------------------------------------------------
+# SR 1.1 — Human user identification and authentication
+# All human users must be uniquely identified and authenticated before access.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.unique_identification
+    msg := sprintf(
+        "IEC 62443 SR 1.1 (IAC): ICS system '%v' does not enforce unique user identification. Every human user must have a unique identifier.",
+        [system.name]
+    )
+}
+
+# SR 1.1 RE 1 (SL 2+): Multi-factor authentication for all interfaces
+violations contains msg if {
+    input.target_sl >= 2
+    some system in input.ics_systems
+    not system.mfa_enabled
+    msg := sprintf(
+        "IEC 62443 SR 1.1 RE 1 SL%v (IAC): ICS system '%v' does not enforce multi-factor authentication. MFA is required at Security Level 2+.",
+        [input.target_sl, system.name]
+    )
+}
+
+# SR 1.1 RE 2 (SL 3+): Hardware token-based authentication
+violations contains msg if {
+    input.target_sl >= 3
+    not input.authentication.hardware_token_authentication
+    msg := sprintf(
+        "IEC 62443 SR 1.1 RE 2 SL%v (IAC): Hardware token-based authentication is not implemented. Required at Security Level 3+.",
+        [input.target_sl]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 1.2 — Software process and device identification and authentication
+# Software processes and devices must be identified and authenticated.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.device_authentication
+    msg := sprintf(
+        "IEC 62443 SR 1.2 (IAC): ICS system '%v' does not authenticate software processes or devices. Device-to-device authentication is required.",
+        [system.name]
+    )
+}
+
+# SR 1.2 RE 1 (SL 2+): Unique identification for all devices
+violations contains msg if {
+    input.target_sl >= 2
+    some system in input.ics_systems
+    not system.device_unique_id
+    msg := sprintf(
+        "IEC 62443 SR 1.2 RE 1 SL%v (IAC): ICS system '%v' devices do not have unique identifiers. All IACS devices must have unique IDs at SL 2+.",
+        [input.target_sl, system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 1.3 — Account management
+# Manage accounts for human users, software processes, and devices.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.authentication.centralized_identity_management
+    msg := "IEC 62443 SR 1.3 (IAC): No centralized account management. IACS accounts must be centrally managed, reviewed, and deprovisioned promptly."
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.account_review_process
+    msg := sprintf(
+        "IEC 62443 SR 1.3 (IAC): ICS system '%v' has no periodic account review process. Accounts must be reviewed regularly for continued business need.",
+        [system.name]
+    )
+}
+
+# SR 1.3 RE 1 (SL 2+): Unified account management policy
+violations contains msg if {
+    input.target_sl >= 2
+    not input.authentication.unified_account_policy
+    msg := sprintf(
+        "IEC 62443 SR 1.3 RE 1 SL%v (IAC): No unified account management policy across all IACS components. Required at Security Level 2+.",
+        [input.target_sl]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 1.4 — Identifier management
+# Manage identifiers by uniqueness, re-use prevention, and revocation.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.default_credentials_unchanged
+    msg := sprintf(
+        "IEC 62443 SR 1.4 (IAC): ICS system '%v' uses unchanged default credentials. Default identifiers are a critical vulnerability — change all defaults before deployment.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    not input.authentication.identifier_reuse_prevented
+    msg := "IEC 62443 SR 1.4 (IAC): IACS does not prevent identifier reuse for a defined period. Deactivated identifiers must not be reassigned for at least 90 days."
+}
+
+# ---------------------------------------------------------------------------
+# SR 1.5 — Authenticator management
+# Manage authenticators (passwords, tokens, keys) through their lifecycle.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.authenticator_lifecycle_managed
+    msg := sprintf(
+        "IEC 62443 SR 1.5 (IAC): ICS system '%v' has no authenticator lifecycle management. Passwords, keys, and tokens must have defined issuance, rotation, and revocation policies.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    not input.authentication.initial_authenticator_secure_distribution
+    msg := "IEC 62443 SR 1.5 (IAC): Authenticators are not distributed via secure channels. Initial credentials must be delivered through a secure out-of-band mechanism."
+}
+
+# ---------------------------------------------------------------------------
+# SR 1.6 — Wireless access management
+# Authenticate wireless connections to the IACS.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.wireless_access == true
+    not system.wireless_encrypted
+    msg := sprintf(
+        "IEC 62443 SR 1.6 (IAC): ICS system '%v' has unencrypted wireless access. All wireless connections to IACS must use strong authentication and encryption.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.wireless_access == true
+    not system.wireless_authentication
+    msg := sprintf(
+        "IEC 62443 SR 1.6 (IAC): ICS system '%v' wireless access lacks authentication. Mutual authentication is required for all IACS wireless connections.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    not input.network.wireless_policy_documented
+    msg := "IEC 62443 SR 1.6 (IAC): No wireless access policy for IACS. A documented policy defining allowed wireless use is required."
+}
+
+# ---------------------------------------------------------------------------
+# SR 1.7 — Strength of password-based authentication
+# Enforce minimum password strength requirements.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.password_min_length < 8
+    msg := sprintf(
+        "IEC 62443 SR 1.7 (IAC): ICS system '%v' has minimum password length of %v characters. Minimum 8 characters required (12+ recommended for SL 2+).",
+        [system.name, system.password_min_length]
+    )
+}
+
+violations contains msg if {
+    input.target_sl >= 2
+    some system in input.ics_systems
+    system.password_min_length < 12
+    msg := sprintf(
+        "IEC 62443 SR 1.7 RE 1 SL%v (IAC): ICS system '%v' has minimum password length of %v. Minimum 12 characters required at Security Level 2+.",
+        [input.target_sl, system.name, system.password_min_length]
+    )
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.password_complexity
+    msg := sprintf(
+        "IEC 62443 SR 1.7 (IAC): ICS system '%v' does not enforce password complexity. Passwords must include uppercase, lowercase, digits, and special characters.",
+        [system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 1.8 — Public key infrastructure (PKI) certificates
+# Validate PKI certificates used for authentication.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    input.target_sl >= 3
+    not input.authentication.pki_or_certificate_based
+    msg := sprintf(
+        "IEC 62443 SR 1.8 SL%v (IAC): PKI/certificate-based authentication is not implemented. Required at Security Level 3+ for strong identity assurance.",
+        [input.target_sl]
+    )
+}
+
+violations contains msg if {
+    input.authentication.pki_or_certificate_based
+    not input.authentication.certificate_revocation_checking
+    msg := "IEC 62443 SR 1.8 (IAC): Certificate revocation checking (CRL/OCSP) is not implemented. Revoked certificates must be detected and rejected."
+}
+
+# ---------------------------------------------------------------------------
+# SR 1.9 — Strength of public key authentication
+# Enforce cryptographic algorithm and key length requirements.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    input.authentication.pki_or_certificate_based
+    not input.authentication.strong_cryptography
+    msg := "IEC 62443 SR 1.9 (IAC): Public key authentication uses weak cryptographic algorithms. Use RSA 2048+, ECDSA 256+, or equivalent strength algorithms."
+}
+
+# ---------------------------------------------------------------------------
+# SR 1.10 — Authenticator feedback
+# Obscure authentication feedback (e.g., mask passwords during entry).
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.authenticator_feedback_obscured == false
+    msg := sprintf(
+        "IEC 62443 SR 1.10 (IAC): ICS system '%v' displays authenticator feedback in plaintext. Authentication information (passwords, tokens) must be obscured during entry.",
+        [system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 1.11 — Unsuccessful login attempts
+# Enforce lockout after a defined number of failed authentication attempts.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.account_lockout_threshold > 10
+    msg := sprintf(
+        "IEC 62443 SR 1.11 (IAC): ICS system '%v' allows %v failed login attempts before lockout. Threshold must be 10 or fewer.",
+        [system.name, system.account_lockout_threshold]
+    )
+}
+
+violations contains msg if {
+    input.target_sl >= 2
+    some system in input.ics_systems
+    system.account_lockout_threshold > 5
+    msg := sprintf(
+        "IEC 62443 SR 1.11 RE 1 SL%v (IAC): ICS system '%v' allows %v failed login attempts. Threshold must be 5 or fewer at Security Level 2+.",
+        [input.target_sl, system.name, system.account_lockout_threshold]
+    )
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.account_lockout_enabled
+    msg := sprintf(
+        "IEC 62443 SR 1.11 (IAC): ICS system '%v' has no account lockout policy. Account lockout after failed attempts is required.",
+        [system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 1.12 — System use notification
+# Display a warning banner before authentication.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.system_use_notification
+    msg := sprintf(
+        "IEC 62443 SR 1.12 (IAC): ICS system '%v' does not display a system use notification. A warning banner indicating authorized use only must be displayed before login.",
+        [system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 1.13 — Access via untrusted networks
+# Authenticate and monitor access via untrusted networks (e.g., Internet, WiFi).
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.remote_access_enabled
+    not system.remote_access_controlled
+    msg := sprintf(
+        "IEC 62443 SR 1.13 (IAC): ICS system '%v' has uncontrolled remote access. Remote access via untrusted networks must use VPN, jump host, or equivalent controls.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    input.target_sl >= 2
+    some system in input.ics_systems
+    system.remote_access_enabled
+    not system.remote_access_mfa
+    msg := sprintf(
+        "IEC 62443 SR 1.13 RE 1 SL%v (IAC): ICS system '%v' remote access does not enforce MFA. Multi-factor authentication is required for all remote IACS access at SL 2+.",
+        [input.target_sl, system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Compliance Aggregation
+# ---------------------------------------------------------------------------
+
+compliant if { count(violations) == 0 }
+
+fr1_passing_srs := count([sr |
+    sr := [
+        count([v | some v in violations; contains(v, "SR 1.1")]) == 0,
+        count([v | some v in violations; contains(v, "SR 1.2")]) == 0,
+        count([v | some v in violations; contains(v, "SR 1.3")]) == 0,
+        count([v | some v in violations; contains(v, "SR 1.4")]) == 0,
+        count([v | some v in violations; contains(v, "SR 1.5")]) == 0,
+        count([v | some v in violations; contains(v, "SR 1.6")]) == 0,
+        count([v | some v in violations; contains(v, "SR 1.7")]) == 0,
+        count([v | some v in violations; contains(v, "SR 1.8")]) == 0,
+        count([v | some v in violations; contains(v, "SR 1.9")]) == 0,
+        count([v | some v in violations; contains(v, "SR 1.10")]) == 0,
+        count([v | some v in violations; contains(v, "SR 1.11")]) == 0,
+        count([v | some v in violations; contains(v, "SR 1.12")]) == 0,
+        count([v | some v in violations; contains(v, "SR 1.13")]) == 0,
+    ][_]
+    sr == true
+])
+
+compliance_report := {
+    "foundational_requirement": "FR 1",
+    "title":                    "Identification and Authentication Control (IAC)",
+    "standard":                 "IEC 62443-3-3",
+    "target_sl":                input.target_sl,
+    "total_srs":                13,
+    "passing_srs":              fr1_passing_srs,
+    "compliant":                compliant,
+    "violations":               violations,
+}

--- a/frameworks/critical_infrastructure/iec_62443/fr2_use_control.rego
+++ b/frameworks/critical_infrastructure/iec_62443/fr2_use_control.rego
@@ -1,0 +1,380 @@
+package iec_62443.fr2
+
+import rego.v1
+
+# =============================================================================
+# IEC 62443-3-3 FR 2 — Use Control (UC)
+#
+# Purpose: Enforce authorized use of the IACS by ensuring that only authorized
+# actions are permitted and that all actions by authenticated users are audited.
+#
+# Security Requirements (SRs):
+#   SR 2.1  — Authorization enforcement
+#   SR 2.2  — Wireless use control
+#   SR 2.3  — Use control for portable and mobile devices
+#   SR 2.4  — Mobile code
+#   SR 2.5  — Session lock
+#   SR 2.6  — Remote session termination
+#   SR 2.7  — Concurrent session control
+#   SR 2.8  — Auditable events
+#   SR 2.9  — Audit storage capacity
+#   SR 2.10 — Response to audit processing failures
+#   SR 2.11 — Timestamps
+#   SR 2.12 — Non-repudiation
+#
+# Input shape:
+#   input.target_sl                          - int (1–4)
+#   input.ics_systems[]
+#     .name                                  - string
+#     .least_privilege_enforced              - bool
+#     .remote_access_enabled                 - bool
+#     .remote_access_controlled              - bool
+#     .wireless_access                       - bool
+#     .portable_device_policy                - bool
+#     .mobile_code_controlled                - bool
+#     .session_lock_timeout_minutes          - int
+#     .concurrent_session_limit              - int
+#     .audit_logging_enabled                 - bool
+#     .non_repudiation_enabled               - bool
+#   input.authentication
+#     .audit_trail_for_privileged_access     - bool
+#   input.monitoring
+#     .audit_storage_adequate                - bool
+#     .audit_processing_failure_alerts       - bool
+#     .timestamps_synchronized               - bool
+# =============================================================================
+
+default compliant := false
+
+# ---------------------------------------------------------------------------
+# SR 2.1 — Authorization enforcement
+# Enforce assigned authorizations; deny access by default (least privilege).
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.least_privilege_enforced
+    msg := sprintf(
+        "IEC 62443 SR 2.1 (UC): ICS system '%v' does not enforce least privilege. Users must only have the access rights required to perform their authorized functions.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    not input.authentication.audit_trail_for_privileged_access
+    msg := "IEC 62443 SR 2.1 (UC): Privileged access is not audited. All privileged actions on IACS must generate an audit record."
+}
+
+# SR 2.1 RE 1 (SL 2+): Separate permission levels for different roles
+violations contains msg if {
+    input.target_sl >= 2
+    not input.authentication.role_based_access_control
+    msg := sprintf(
+        "IEC 62443 SR 2.1 RE 1 SL%v (UC): Role-based access control (RBAC) is not implemented. Separate authorization roles are required at Security Level 2+.",
+        [input.target_sl]
+    )
+}
+
+# SR 2.1 RE 2 (SL 3+): Dual approval for high-impact actions
+violations contains msg if {
+    input.target_sl >= 3
+    not input.authentication.dual_approval_for_critical_actions
+    msg := sprintf(
+        "IEC 62443 SR 2.1 RE 2 SL%v (UC): No dual-approval mechanism for high-impact IACS actions. Required at Security Level 3+ for critical system changes.",
+        [input.target_sl]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 2.2 — Wireless use control
+# Authorize, monitor, and restrict wireless use in the IACS.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.wireless_access == true
+    not system.wireless_use_authorized
+    msg := sprintf(
+        "IEC 62443 SR 2.2 (UC): Wireless use on ICS system '%v' is not explicitly authorized. All wireless connections must be documented and approved.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.wireless_access == true
+    not system.wireless_monitored
+    msg := sprintf(
+        "IEC 62443 SR 2.2 (UC): Wireless connections on ICS system '%v' are not monitored. Wireless activity must be continuously monitored for unauthorized access.",
+        [system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 2.3 — Use control for portable and mobile devices
+# Enforce security controls on portable and mobile devices connected to IACS.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.portable_device_policy
+    msg := sprintf(
+        "IEC 62443 SR 2.3 (UC): ICS system '%v' has no portable/mobile device use policy. USB drives, laptops, and tablets connecting to IACS must be governed by a formal policy.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.removable_media_controlled
+    msg := sprintf(
+        "IEC 62443 SR 2.3 (UC): ICS system '%v' does not control removable media. Removable media must be scanned for malware before use and restricted to authorized devices.",
+        [system.name]
+    )
+}
+
+# SR 2.3 RE 1 (SL 2+): Central management of portable device authorizations
+violations contains msg if {
+    input.target_sl >= 2
+    not input.authentication.portable_device_central_mgmt
+    msg := sprintf(
+        "IEC 62443 SR 2.3 RE 1 SL%v (UC): Portable device authorizations are not centrally managed. Centralized control is required at Security Level 2+.",
+        [input.target_sl]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 2.4 — Mobile code
+# Control mobile code (scripts, macros, executables) executed in the IACS.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.mobile_code_controlled
+    msg := sprintf(
+        "IEC 62443 SR 2.4 (UC): ICS system '%v' does not control mobile code execution. Scripts, active content, and macros must be restricted to explicitly authorized code.",
+        [system.name]
+    )
+}
+
+# SR 2.4 RE 1 (SL 2+): Application whitelisting
+violations contains msg if {
+    input.target_sl >= 2
+    some system in input.ics_systems
+    not system.application_whitelisting
+    not system.malware_protection
+    msg := sprintf(
+        "IEC 62443 SR 2.4 RE 1 SL%v (UC): ICS system '%v' has neither application whitelisting nor malware protection. One of these is required at Security Level 2+.",
+        [input.target_sl, system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 2.5 — Session lock
+# Automatically lock sessions after a period of inactivity.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.session_lock_timeout_minutes > 30
+    msg := sprintf(
+        "IEC 62443 SR 2.5 (UC): ICS system '%v' session lock timeout is %v minutes. Maximum inactivity timeout before lock must be 30 minutes or less.",
+        [system.name, system.session_lock_timeout_minutes]
+    )
+}
+
+violations contains msg if {
+    input.target_sl >= 2
+    some system in input.ics_systems
+    system.session_lock_timeout_minutes > 15
+    msg := sprintf(
+        "IEC 62443 SR 2.5 RE 1 SL%v (UC): ICS system '%v' session lock timeout is %v minutes. Maximum 15 minutes is required at Security Level 2+.",
+        [input.target_sl, system.name, system.session_lock_timeout_minutes]
+    )
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.session_lock_enabled
+    msg := sprintf(
+        "IEC 62443 SR 2.5 (UC): ICS system '%v' does not enforce session locking. Automatic session lock after inactivity is required.",
+        [system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 2.6 — Remote session termination
+# Provide the capability to terminate remote sessions.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.remote_access_enabled
+    not system.remote_session_termination
+    msg := sprintf(
+        "IEC 62443 SR 2.6 (UC): ICS system '%v' does not support remote session termination. Authorized users must be able to terminate remote sessions at any time.",
+        [system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 2.7 — Concurrent session control
+# Limit the number of concurrent sessions per user or device.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    input.target_sl >= 2
+    some system in input.ics_systems
+    system.concurrent_session_limit == 0
+    msg := sprintf(
+        "IEC 62443 SR 2.7 SL%v (UC): ICS system '%v' has no concurrent session limit. Limiting concurrent sessions reduces the risk of session hijacking.",
+        [input.target_sl, system.name]
+    )
+}
+
+violations contains msg if {
+    input.target_sl >= 3
+    some system in input.ics_systems
+    system.concurrent_session_limit > 3
+    msg := sprintf(
+        "IEC 62443 SR 2.7 RE 1 SL%v (UC): ICS system '%v' allows up to %v concurrent sessions. Strict session limits (≤3) are recommended at Security Level 3+.",
+        [input.target_sl, system.name, system.concurrent_session_limit]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 2.8 — Auditable events
+# Generate audit records for defined security-relevant events.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.audit_logging_enabled
+    msg := sprintf(
+        "IEC 62443 SR 2.8 (UC): ICS system '%v' does not have audit logging enabled. Security-relevant events must be logged: login attempts, privilege use, configuration changes, and errors.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.audit_logging_enabled
+    not system.audit_log_includes_required_fields
+    msg := sprintf(
+        "IEC 62443 SR 2.8 (UC): ICS system '%v' audit logs are missing required fields. Logs must include: event type, timestamp, source identity, outcome, and affected resource.",
+        [system.name]
+    )
+}
+
+# SR 2.8 RE 1 (SL 2+): Centralized audit log collection
+violations contains msg if {
+    input.target_sl >= 2
+    not input.monitoring.centralized_log_collection
+    msg := sprintf(
+        "IEC 62443 SR 2.8 RE 1 SL%v (UC): Audit logs are not centrally collected. Centralized log aggregation is required at Security Level 2+ to enable correlation.",
+        [input.target_sl]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 2.9 — Audit storage capacity
+# Allocate sufficient storage for audit records.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.monitoring.audit_storage_adequate
+    msg := "IEC 62443 SR 2.9 (UC): Audit log storage capacity is insufficient. The system must allocate sufficient storage and alert when approaching capacity limits."
+}
+
+violations contains msg if {
+    input.monitoring.ics_log_retention_days < 90
+    msg := sprintf(
+        "IEC 62443 SR 2.9 (UC): IACS audit logs are retained for only %v days. Minimum 90-day retention is required (1 year recommended for regulatory compliance).",
+        [input.monitoring.ics_log_retention_days]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 2.10 — Response to audit processing failures
+# Alert and respond when audit processing failures occur.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.monitoring.audit_processing_failure_alerts
+    msg := "IEC 62443 SR 2.10 (UC): No alerting for audit processing failures. The system must alert personnel when audit subsystem failures occur (storage full, process crash, etc.)."
+}
+
+violations contains msg if {
+    not input.monitoring.audit_failure_response_defined
+    msg := "IEC 62443 SR 2.10 (UC): No defined response procedure for audit processing failures. A documented response procedure is required."
+}
+
+# ---------------------------------------------------------------------------
+# SR 2.11 — Timestamps
+# Provide reliable timestamps for all audit records.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.monitoring.timestamps_synchronized
+    msg := "IEC 62443 SR 2.11 (UC): IACS timestamps are not synchronized. All systems must use a reliable time source (NTP/PTP) to ensure audit record integrity."
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.audit_logging_enabled
+    not system.ntp_configured
+    msg := sprintf(
+        "IEC 62443 SR 2.11 (UC): ICS system '%v' does not have NTP configured. Accurate timestamps are required for audit trail integrity and incident correlation.",
+        [system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 2.12 — Non-repudiation
+# Ensure actions cannot be repudiated by the originator.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    input.target_sl >= 2
+    some system in input.ics_systems
+    not system.non_repudiation_enabled
+    msg := sprintf(
+        "IEC 62443 SR 2.12 SL%v (UC): ICS system '%v' does not provide non-repudiation. Cryptographic signing or equivalent mechanism is required at Security Level 2+ for critical actions.",
+        [input.target_sl, system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Compliance Aggregation
+# ---------------------------------------------------------------------------
+
+compliant if { count(violations) == 0 }
+
+fr2_passing_srs := count([sr |
+    sr := [
+        count([v | some v in violations; contains(v, "SR 2.1")]) == 0,
+        count([v | some v in violations; contains(v, "SR 2.2")]) == 0,
+        count([v | some v in violations; contains(v, "SR 2.3")]) == 0,
+        count([v | some v in violations; contains(v, "SR 2.4")]) == 0,
+        count([v | some v in violations; contains(v, "SR 2.5")]) == 0,
+        count([v | some v in violations; contains(v, "SR 2.6")]) == 0,
+        count([v | some v in violations; contains(v, "SR 2.7")]) == 0,
+        count([v | some v in violations; contains(v, "SR 2.8")]) == 0,
+        count([v | some v in violations; contains(v, "SR 2.9")]) == 0,
+        count([v | some v in violations; contains(v, "SR 2.10")]) == 0,
+        count([v | some v in violations; contains(v, "SR 2.11")]) == 0,
+        count([v | some v in violations; contains(v, "SR 2.12")]) == 0,
+    ][_]
+    sr == true
+])
+
+compliance_report := {
+    "foundational_requirement": "FR 2",
+    "title":                    "Use Control (UC)",
+    "standard":                 "IEC 62443-3-3",
+    "target_sl":                input.target_sl,
+    "total_srs":                12,
+    "passing_srs":              fr2_passing_srs,
+    "compliant":                compliant,
+    "violations":               violations,
+}

--- a/frameworks/critical_infrastructure/iec_62443/fr3_system_integrity.rego
+++ b/frameworks/critical_infrastructure/iec_62443/fr3_system_integrity.rego
@@ -1,0 +1,312 @@
+package iec_62443.fr3
+
+import rego.v1
+
+# =============================================================================
+# IEC 62443-3-3 FR 3 — System Integrity (SI)
+#
+# Purpose: Ensure the integrity of the IACS by protecting against unauthorized
+# modification of hardware, software, and data in transit and at rest.
+#
+# Security Requirements (SRs):
+#   SR 3.1 — Communication integrity
+#   SR 3.2 — Malicious code protection
+#   SR 3.3 — Security functionality verification
+#   SR 3.4 — Software and information integrity
+#   SR 3.5 — Input validation
+#   SR 3.6 — Deterministic output
+#   SR 3.7 — Error handling
+#   SR 3.8 — Session integrity
+#   SR 3.9 — Protection of audit information
+#
+# Input shape:
+#   input.target_sl                              - int (1–4)
+#   input.ics_systems[]
+#     .name                                      - string
+#     .communication_integrity                   - bool
+#     .malware_protection                        - bool
+#     .application_whitelisting                  - bool
+#     .firmware_integrity_checking               - bool
+#     .software_integrity_verification           - bool
+#     .input_validation                          - bool
+#     .deterministic_output_verification         - bool
+#     .error_handling_implemented                - bool
+#     .session_integrity                         - bool
+#     .audit_log_tamper_protection               - bool
+#     .os_version_current                        - bool
+#   input.patch_management
+#     .process_documented                        - bool
+#     .max_patch_delay_days                      - int
+#     .tested_before_deployment                  - bool
+#     .rollback_capability                       - bool
+# =============================================================================
+
+default compliant := false
+
+# ---------------------------------------------------------------------------
+# SR 3.1 — Communication integrity
+# Protect the integrity of transmitted information.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.communication_integrity
+    msg := sprintf(
+        "IEC 62443 SR 3.1 (SI): ICS system '%v' does not protect communication integrity. IACS communications must use mechanisms (checksums, MACs, digital signatures) to detect unauthorized modification.",
+        [system.name]
+    )
+}
+
+# SR 3.1 RE 1 (SL 2+): Cryptographic integrity protection
+violations contains msg if {
+    input.target_sl >= 2
+    some system in input.ics_systems
+    not system.cryptographic_integrity_protection
+    msg := sprintf(
+        "IEC 62443 SR 3.1 RE 1 SL%v (SI): ICS system '%v' does not use cryptographic mechanisms for communication integrity. HMAC or digital signatures are required at Security Level 2+.",
+        [input.target_sl, system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 3.2 — Malicious code protection
+# Protect against malware and unauthorized software.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    input.target_sl >= 2
+    some system in input.ics_systems
+    not system.malware_protection
+    not system.application_whitelisting
+    msg := sprintf(
+        "IEC 62443 SR 3.2 SL%v (SI): ICS system '%v' has neither malware protection nor application whitelisting. One of these controls is required at Security Level 2+.",
+        [input.target_sl, system.name]
+    )
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.malware_protection
+    not system.malware_definitions_current
+    msg := sprintf(
+        "IEC 62443 SR 3.2 (SI): ICS system '%v' malware definitions are not current. Malware signatures must be updated at least weekly, or more frequently if the system is Internet-connected.",
+        [system.name]
+    )
+}
+
+# SR 3.2 RE 1 (SL 3+): Malware protection at all entry points
+violations contains msg if {
+    input.target_sl >= 3
+    not input.network.malware_protection_at_boundaries
+    msg := sprintf(
+        "IEC 62443 SR 3.2 RE 1 SL%v (SI): Malware protection is not deployed at all IACS network entry points. Boundary-level malware scanning is required at Security Level 3+.",
+        [input.target_sl]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 3.3 — Security functionality verification
+# Verify that security functions operate correctly.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.security_function_testing
+    msg := sprintf(
+        "IEC 62443 SR 3.3 (SI): ICS system '%v' has no security function verification process. Security controls must be periodically tested to confirm they operate as intended.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    input.target_sl >= 2
+    not input.security_management.security_testing_schedule_documented
+    msg := sprintf(
+        "IEC 62443 SR 3.3 RE 1 SL%v (SI): No documented schedule for security function verification. A formal testing schedule is required at Security Level 2+.",
+        [input.target_sl]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 3.4 — Software and information integrity
+# Detect unauthorized changes to software and data.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.software_integrity_verification
+    msg := sprintf(
+        "IEC 62443 SR 3.4 (SI): ICS system '%v' does not verify software integrity. File integrity monitoring or hash verification must be implemented to detect unauthorized changes.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.firmware_integrity_checking == false
+    msg := sprintf(
+        "IEC 62443 SR 3.4 (SI): ICS system '%v' does not verify firmware integrity. Firmware must be verified against known-good hashes before and after updates.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    not input.patch_management.process_documented
+    msg := "IEC 62443 SR 3.4 (SI): No patch management process documented. Security patches for IACS components must be evaluated and applied through a controlled process."
+}
+
+violations contains msg if {
+    input.patch_management.process_documented
+    input.patch_management.max_patch_delay_days > 90
+    msg := sprintf(
+        "IEC 62443 SR 3.4 (SI): Critical IACS patches are delayed up to %v days. Critical security patches must be evaluated within 30 days and applied within 90 days.",
+        [input.patch_management.max_patch_delay_days]
+    )
+}
+
+# SR 3.4 RE 1 (SL 2+): Automated integrity checking
+violations contains msg if {
+    input.target_sl >= 2
+    some system in input.ics_systems
+    not system.automated_integrity_checking
+    msg := sprintf(
+        "IEC 62443 SR 3.4 RE 1 SL%v (SI): ICS system '%v' lacks automated integrity checking. Automated file integrity monitoring is required at Security Level 2+.",
+        [input.target_sl, system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 3.5 — Input validation
+# Validate input to protect against injection and malformed data attacks.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.input_validation
+    msg := sprintf(
+        "IEC 62443 SR 3.5 (SI): ICS system '%v' does not validate inputs. All external inputs (HMI, APIs, data feeds) must be validated to prevent injection attacks and unexpected behavior.",
+        [system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 3.6 — Deterministic output
+# Ensure outputs remain within expected ranges under all conditions.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.deterministic_output_verification
+    msg := sprintf(
+        "IEC 62443 SR 3.6 (SI): ICS system '%v' does not enforce output range checking. Control outputs must remain within safe operational bounds even under error or attack conditions.",
+        [system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 3.7 — Error handling
+# Handle errors without exposing sensitive information or failing unsafely.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.error_handling_implemented
+    msg := sprintf(
+        "IEC 62443 SR 3.7 (SI): ICS system '%v' does not implement secure error handling. Errors must not expose sensitive information and must fail to a known safe state.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.error_messages_expose_sensitive_data
+    msg := sprintf(
+        "IEC 62443 SR 3.7 (SI): ICS system '%v' error messages expose sensitive system information. Error messages must be sanitized before display to operators.",
+        [system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 3.8 — Session integrity
+# Protect the integrity of active sessions against hijacking and replay.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.session_integrity
+    msg := sprintf(
+        "IEC 62443 SR 3.8 (SI): ICS system '%v' does not protect session integrity. Session tokens must be cryptographically protected against hijacking and replay attacks.",
+        [system.name]
+    )
+}
+
+# SR 3.8 RE 1 (SL 2+): Invalidate sessions on privilege change
+violations contains msg if {
+    input.target_sl >= 2
+    some system in input.ics_systems
+    not system.session_invalidated_on_privilege_change
+    msg := sprintf(
+        "IEC 62443 SR 3.8 RE 1 SL%v (SI): ICS system '%v' does not invalidate sessions when privileges change. Sessions must be re-established after any privilege modification.",
+        [input.target_sl, system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 3.9 — Protection of audit information
+# Protect audit records from unauthorized access, modification, and deletion.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.audit_log_tamper_protection
+    msg := sprintf(
+        "IEC 62443 SR 3.9 (SI): ICS system '%v' audit logs are not tamper-protected. Audit records must be write-protected and access-controlled to preserve their evidential value.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    not input.monitoring.log_access_controlled
+    msg := "IEC 62443 SR 3.9 (SI): IACS audit log access is not controlled. Only authorized personnel should be able to read audit logs; no one should be able to modify or delete them."
+}
+
+violations contains msg if {
+    input.target_sl >= 2
+    not input.monitoring.logs_sent_to_immutable_store
+    msg := sprintf(
+        "IEC 62443 SR 3.9 RE 1 SL%v (SI): Audit logs are not forwarded to an immutable store. Write-once log forwarding (SIEM, syslog-ng with WORM storage) is required at Security Level 2+.",
+        [input.target_sl]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Compliance Aggregation
+# ---------------------------------------------------------------------------
+
+compliant if { count(violations) == 0 }
+
+fr3_passing_srs := count([sr |
+    sr := [
+        count([v | some v in violations; contains(v, "SR 3.1")]) == 0,
+        count([v | some v in violations; contains(v, "SR 3.2")]) == 0,
+        count([v | some v in violations; contains(v, "SR 3.3")]) == 0,
+        count([v | some v in violations; contains(v, "SR 3.4")]) == 0,
+        count([v | some v in violations; contains(v, "SR 3.5")]) == 0,
+        count([v | some v in violations; contains(v, "SR 3.6")]) == 0,
+        count([v | some v in violations; contains(v, "SR 3.7")]) == 0,
+        count([v | some v in violations; contains(v, "SR 3.8")]) == 0,
+        count([v | some v in violations; contains(v, "SR 3.9")]) == 0,
+    ][_]
+    sr == true
+])
+
+compliance_report := {
+    "foundational_requirement": "FR 3",
+    "title":                    "System Integrity (SI)",
+    "standard":                 "IEC 62443-3-3",
+    "target_sl":                input.target_sl,
+    "total_srs":                9,
+    "passing_srs":              fr3_passing_srs,
+    "compliant":                compliant,
+    "violations":               violations,
+}

--- a/frameworks/critical_infrastructure/iec_62443/fr4_data_confidentiality.rego
+++ b/frameworks/critical_infrastructure/iec_62443/fr4_data_confidentiality.rego
@@ -1,0 +1,187 @@
+package iec_62443.fr4
+
+import rego.v1
+
+# =============================================================================
+# IEC 62443-3-3 FR 4 — Data Confidentiality (DC)
+#
+# Purpose: Ensure confidentiality of information on communication channels
+# and in data repositories used by or within the IACS.
+#
+# Security Requirements (SRs):
+#   SR 4.1 — Information confidentiality
+#   SR 4.2 — Information persistence
+#   SR 4.3 — Use of cryptography
+#
+# Input shape:
+#   input.target_sl                              - int (1–4)
+#   input.ics_systems[]
+#     .name                                      - string
+#     .sensitive_data_transmitted                - bool
+#     .data_encrypted_in_transit                 - bool
+#     .data_at_rest_protected                    - bool
+#     .media_sanitization_procedure              - bool
+#     .approved_cryptographic_algorithms         - bool
+#     .cryptographic_key_management              - bool
+#     .fips_140_2_compliant                      - bool
+# =============================================================================
+
+default compliant := false
+
+# ---------------------------------------------------------------------------
+# SR 4.1 — Information confidentiality
+# Protect the confidentiality of information at rest and in transit.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    input.target_sl >= 2
+    some system in input.ics_systems
+    system.sensitive_data_transmitted
+    not system.data_encrypted_in_transit
+    msg := sprintf(
+        "IEC 62443 SR 4.1 SL%v (DC): ICS system '%v' transmits sensitive data without encryption. All sensitive IACS communications must be encrypted in transit at Security Level 2+.",
+        [input.target_sl, system.name]
+    )
+}
+
+violations contains msg if {
+    input.target_sl >= 2
+    some system in input.ics_systems
+    not system.data_at_rest_protected
+    msg := sprintf(
+        "IEC 62443 SR 4.1 SL%v (DC): ICS system '%v' does not protect data at rest. Configuration databases, historian data, and operational data must be encrypted or access-controlled at Security Level 2+.",
+        [input.target_sl, system.name]
+    )
+}
+
+# SR 4.1 RE 1 (SL 3+): Encryption of all IACS data in transit
+violations contains msg if {
+    input.target_sl >= 3
+    some system in input.ics_systems
+    not system.data_encrypted_in_transit
+    msg := sprintf(
+        "IEC 62443 SR 4.1 RE 1 SL%v (DC): ICS system '%v' does not encrypt all communications in transit. At Security Level 3+, all IACS data in transit must be encrypted regardless of sensitivity classification.",
+        [input.target_sl, system.name]
+    )
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.data_encrypted_in_transit
+    not system.tls_version_current
+    msg := sprintf(
+        "IEC 62443 SR 4.1 (DC): ICS system '%v' uses outdated TLS version. TLS 1.2 minimum is required; TLS 1.3 is recommended for IACS communications.",
+        [system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 4.2 — Information persistence
+# Protect residual information from leaking through reuse of resources.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.media_sanitization_procedure
+    msg := sprintf(
+        "IEC 62443 SR 4.2 (DC): ICS system '%v' has no media sanitization procedure. Storage media must be securely sanitized before reuse or disposal to prevent residual data leakage.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.memory_scrubbing_on_deallocation
+    msg := sprintf(
+        "IEC 62443 SR 4.2 (DC): ICS system '%v' does not clear sensitive data from memory on deallocation. Cryptographic keys, passwords, and process data must be zeroed before memory is released.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    input.target_sl >= 2
+    some system in input.ics_systems
+    not system.secure_deletion_capability
+    msg := sprintf(
+        "IEC 62443 SR 4.2 RE 1 SL%v (DC): ICS system '%v' has no secure deletion capability. Overwrite or cryptographic erasure of sensitive data must be available at Security Level 2+.",
+        [input.target_sl, system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 4.3 — Use of cryptography
+# Use approved cryptographic algorithms and manage cryptographic keys.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.approved_cryptographic_algorithms
+    msg := sprintf(
+        "IEC 62443 SR 4.3 (DC): ICS system '%v' does not use approved cryptographic algorithms. Cryptography must be based on vetted algorithms (AES-128+, SHA-256+, RSA-2048+, or NIST-approved equivalents).",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.cryptographic_key_management
+    msg := sprintf(
+        "IEC 62443 SR 4.3 (DC): ICS system '%v' has no cryptographic key management. Keys must have defined generation, distribution, storage, rotation, and revocation procedures.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    input.target_sl >= 3
+    some system in input.ics_systems
+    not system.fips_140_2_compliant
+    msg := sprintf(
+        "IEC 62443 SR 4.3 RE 1 SL%v (DC): ICS system '%v' cryptographic modules are not FIPS 140-2 validated. FIPS 140-2 Level 2+ is required for cryptographic implementations at Security Level 3+.",
+        [input.target_sl, system.name]
+    )
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.cryptographic_key_management
+    not system.key_rotation_policy
+    msg := sprintf(
+        "IEC 62443 SR 4.3 (DC): ICS system '%v' has no key rotation policy. Cryptographic keys must be rotated on a defined schedule and immediately upon suspected compromise.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.uses_deprecated_ciphers
+    msg := sprintf(
+        "IEC 62443 SR 4.3 (DC): ICS system '%v' uses deprecated cryptographic ciphers (DES, 3DES, RC4, MD5). These must be replaced with currently approved algorithms.",
+        [system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Compliance Aggregation
+# ---------------------------------------------------------------------------
+
+compliant if { count(violations) == 0 }
+
+fr4_passing_srs := count([sr |
+    sr := [
+        count([v | some v in violations; contains(v, "SR 4.1")]) == 0,
+        count([v | some v in violations; contains(v, "SR 4.2")]) == 0,
+        count([v | some v in violations; contains(v, "SR 4.3")]) == 0,
+    ][_]
+    sr == true
+])
+
+compliance_report := {
+    "foundational_requirement": "FR 4",
+    "title":                    "Data Confidentiality (DC)",
+    "standard":                 "IEC 62443-3-3",
+    "target_sl":                input.target_sl,
+    "total_srs":                3,
+    "passing_srs":              fr4_passing_srs,
+    "compliant":                compliant,
+    "violations":               violations,
+}

--- a/frameworks/critical_infrastructure/iec_62443/fr5_restricted_data_flow.rego
+++ b/frameworks/critical_infrastructure/iec_62443/fr5_restricted_data_flow.rego
@@ -1,0 +1,223 @@
+package iec_62443.fr5
+
+import rego.v1
+
+# =============================================================================
+# IEC 62443-3-3 FR 5 — Restricted Data Flow (RDF)
+#
+# Purpose: Restrict and control the flow of information within and between
+# IACS zones and conduits, and between the IACS and external networks.
+# The zone and conduit model is the cornerstone of IEC 62443 network architecture.
+#
+# Security Requirements (SRs):
+#   SR 5.1 — Network segmentation
+#   SR 5.2 — Zone boundary protection
+#   SR 5.3 — General purpose person-to-person communication restrictions
+#   SR 5.4 — Application partitioning
+#
+# Input shape:
+#   input.target_sl                             - int (1–4)
+#   input.zones[]
+#     .name                                     - string
+#     .security_level_defined                   - bool
+#     .security_level                           - int
+#     .assets_inventoried                       - bool
+#   input.conduits[]
+#     .source_zone                              - string
+#     .dest_zone                                - string
+#     .firewall_or_dmz                          - bool
+#     .unidirectional_gateway                   - bool
+#     .encrypted                                - bool
+#     .traffic_filtered                         - bool
+#   input.network
+#     .it_ot_segmentation                       - bool
+#     .direct_internet_connectivity_to_ics      - bool
+#     .dmz_implemented                          - bool
+#     .network_inventory_documented             - bool
+#     .wireless_policy_documented               - bool
+# =============================================================================
+
+default compliant := false
+
+# ---------------------------------------------------------------------------
+# SR 5.1 — Network segmentation
+# Segment the IACS network into zones and define conduits between zones.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    count(input.zones) == 0
+    msg := "IEC 62443 SR 5.1 (RDF): No network zones defined. IEC 62443 requires the IACS to be segmented into security zones with clearly defined boundaries."
+}
+
+violations contains msg if {
+    not input.network.it_ot_segmentation
+    msg := "IEC 62443 SR 5.1 (RDF): IT and OT networks are not segmented. Industrial control systems must be isolated from corporate IT networks to prevent lateral movement."
+}
+
+violations contains msg if {
+    not input.network.network_inventory_documented
+    msg := "IEC 62443 SR 5.1 (RDF): Network inventory is not documented. A complete inventory of all IACS network assets and their zone assignments is required."
+}
+
+violations contains msg if {
+    input.network.direct_internet_connectivity_to_ics
+    msg := "IEC 62443 SR 5.1 (RDF): ICS systems have direct Internet connectivity. IACS must never be directly accessible from the Internet — air-gap or multi-layer DMZ is required."
+}
+
+# SR 5.1 RE 1 (SL 2+): Independence of security zones
+violations contains msg if {
+    input.target_sl >= 2
+    count(input.zones) < 3
+    msg := sprintf(
+        "IEC 62443 SR 5.1 RE 1 SL%v (RDF): Insufficient zone segmentation. At Security Level 2+, at minimum three distinct zones are required: corporate IT, DMZ, and OT/ICS control.",
+        [input.target_sl]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 5.2 — Zone boundary protection
+# Protect zone boundaries through security controls on all conduits.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some zone in input.zones
+    not zone.security_level_defined
+    msg := sprintf(
+        "IEC 62443 SR 5.2 (RDF): Zone '%v' does not have a defined security level. Every zone must have an assigned Security Level (SL) target and capability documented.",
+        [zone.name]
+    )
+}
+
+violations contains msg if {
+    some conduit in input.conduits
+    not conduit.firewall_or_dmz
+    msg := sprintf(
+        "IEC 62443 SR 5.2 (RDF): Conduit between zones '%v' and '%v' has no firewall or DMZ. Every zone boundary must be protected by a firewall or equivalent boundary control.",
+        [conduit.source_zone, conduit.dest_zone]
+    )
+}
+
+violations contains msg if {
+    some conduit in input.conduits
+    not conduit.traffic_filtered
+    msg := sprintf(
+        "IEC 62443 SR 5.2 (RDF): Conduit between zones '%v' and '%v' does not filter traffic. Only explicitly authorized traffic flows must be permitted across zone boundaries.",
+        [conduit.source_zone, conduit.dest_zone]
+    )
+}
+
+# IT/OT boundary requires unidirectional gateway at SL 3+
+violations contains msg if {
+    input.target_sl >= 3
+    some conduit in input.conduits
+    conduit.source_zone == "corporate_it"
+    conduit.dest_zone == "ics_control"
+    not conduit.unidirectional_gateway
+    msg := sprintf(
+        "IEC 62443 SR 5.2 RE 1 SL%v (RDF): The IT/OT boundary between corporate and ICS control zones lacks a unidirectional gateway (data diode). Required at Security Level 3+ for critical infrastructure.",
+        [input.target_sl]
+    )
+}
+
+violations contains msg if {
+    not input.network.dmz_implemented
+    msg := "IEC 62443 SR 5.2 (RDF): No DMZ is implemented between corporate IT and OT networks. A DMZ with controlled ingress/egress is required to isolate IACS from external networks."
+}
+
+# SR 5.2 RE 2 (SL 3+): Encrypted zone-to-zone communications
+violations contains msg if {
+    input.target_sl >= 3
+    some conduit in input.conduits
+    not conduit.encrypted
+    msg := sprintf(
+        "IEC 62443 SR 5.2 RE 2 SL%v (RDF): Conduit between zones '%v' and '%v' is not encrypted. All inter-zone IACS communications must be encrypted at Security Level 3+.",
+        [input.target_sl, conduit.source_zone, conduit.dest_zone]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 5.3 — General purpose person-to-person communication restrictions
+# Restrict general-purpose communication (email, chat) within IACS zones.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some zone in input.zones
+    zone.security_level >= 2
+    zone.general_purpose_comms_unrestricted
+    msg := sprintf(
+        "IEC 62443 SR 5.3 (RDF): Zone '%v' (SL %v) permits unrestricted general-purpose communications (email, instant messaging). These must be restricted or prohibited within high-security IACS zones.",
+        [zone.name, zone.security_level]
+    )
+}
+
+violations contains msg if {
+    input.target_sl >= 2
+    not input.network.general_purpose_comms_policy
+    msg := sprintf(
+        "IEC 62443 SR 5.3 SL%v (RDF): No policy governing general-purpose communications within IACS zones. Permitted communication types must be explicitly defined and restricted.",
+        [input.target_sl]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 5.4 — Application partitioning
+# Separate IACS applications from non-IACS applications.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.application_partitioning
+    msg := sprintf(
+        "IEC 62443 SR 5.4 (RDF): ICS system '%v' does not partition IACS applications from general-purpose applications. Business applications must not run on the same platform as control applications.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    input.target_sl >= 2
+    some system in input.ics_systems
+    not system.virtualization_isolation
+    system.uses_shared_platform
+    msg := sprintf(
+        "IEC 62443 SR 5.4 RE 1 SL%v (RDF): ICS system '%v' uses a shared platform without virtualization isolation. Hypervisor-based isolation is required when IACS and non-IACS workloads share hardware at SL 2+.",
+        [input.target_sl, system.name]
+    )
+}
+
+violations contains msg if {
+    input.target_sl >= 3
+    some system in input.ics_systems
+    not system.dedicated_hardware
+    system.criticality == "high"
+    msg := sprintf(
+        "IEC 62443 SR 5.4 RE 2 SL%v (RDF): High-criticality ICS system '%v' does not run on dedicated hardware. Physical hardware separation from non-IACS workloads is required for high-criticality systems at SL 3+.",
+        [input.target_sl, system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Compliance Aggregation
+# ---------------------------------------------------------------------------
+
+compliant if { count(violations) == 0 }
+
+fr5_passing_srs := count([sr |
+    sr := [
+        count([v | some v in violations; contains(v, "SR 5.1")]) == 0,
+        count([v | some v in violations; contains(v, "SR 5.2")]) == 0,
+        count([v | some v in violations; contains(v, "SR 5.3")]) == 0,
+        count([v | some v in violations; contains(v, "SR 5.4")]) == 0,
+    ][_]
+    sr == true
+])
+
+compliance_report := {
+    "foundational_requirement": "FR 5",
+    "title":                    "Restricted Data Flow (RDF)",
+    "standard":                 "IEC 62443-3-3",
+    "target_sl":                input.target_sl,
+    "total_srs":                4,
+    "passing_srs":              fr5_passing_srs,
+    "compliant":                compliant,
+    "violations":               violations,
+}

--- a/frameworks/critical_infrastructure/iec_62443/fr6_timely_response.rego
+++ b/frameworks/critical_infrastructure/iec_62443/fr6_timely_response.rego
@@ -1,0 +1,173 @@
+package iec_62443.fr6
+
+import rego.v1
+
+# =============================================================================
+# IEC 62443-3-3 FR 6 — Timely Response to Events (TRE)
+#
+# Purpose: Respond to security violations and incidents in a timely manner.
+# This includes detecting incidents, generating notifications, and providing
+# the capability to report violations to appropriate personnel.
+#
+# Security Requirements (SRs):
+#   SR 6.1 — Audit log accessibility
+#   SR 6.2 — Continuous monitoring
+#
+# Input shape:
+#   input.target_sl                              - int (1–4)
+#   input.ics_systems[]
+#     .name                                      - string
+#     .audit_logging_enabled                     - bool
+#   input.monitoring
+#     .security_event_monitoring                 - bool
+#     .incident_response_plan_for_ics            - bool
+#     .ics_log_retention_days                    - int
+#     .continuous_monitoring                     - bool
+#     .log_access_controlled                     - bool
+#     .automated_alerts_configured               - bool
+#     .mean_time_to_detect_hours                 - number
+#     .mean_time_to_respond_hours                - number
+#     .threat_intelligence_integrated            - bool
+#     .ics_specific_soc_capability               - bool
+# =============================================================================
+
+default compliant := false
+
+# ---------------------------------------------------------------------------
+# SR 6.1 — Audit log accessibility
+# Ensure audit logs are accessible to authorized personnel in a timely manner.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.monitoring.log_access_controlled
+    msg := "IEC 62443 SR 6.1 (TRE): IACS audit log access is not controlled. Logs must be accessible to authorized security and operations personnel while protected against unauthorized access."
+}
+
+violations contains msg if {
+    input.monitoring.ics_log_retention_days < 90
+    msg := sprintf(
+        "IEC 62443 SR 6.1 (TRE): IACS audit logs are retained for only %v days. Minimum 90-day retention is required to support incident investigations (1 year recommended for regulatory environments).",
+        [input.monitoring.ics_log_retention_days]
+    )
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.audit_logging_enabled
+    msg := sprintf(
+        "IEC 62443 SR 6.1 (TRE): ICS system '%v' does not have audit logging enabled. Security event logs are required to enable timely detection and response.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    not input.monitoring.incident_response_plan_for_ics
+    msg := "IEC 62443 SR 6.1 (TRE): No ICS-specific incident response plan. OT/ICS incidents require specialized response procedures distinct from IT IR plans — a documented plan is required."
+}
+
+# SR 6.1 RE 1 (SL 2+): Centralized audit log access
+violations contains msg if {
+    input.target_sl >= 2
+    not input.monitoring.centralized_log_collection
+    msg := sprintf(
+        "IEC 62443 SR 6.1 RE 1 SL%v (TRE): Audit logs are not centrally collected. Centralized log management with correlation capability is required at Security Level 2+ for timely incident detection.",
+        [input.target_sl]
+    )
+}
+
+violations contains msg if {
+    input.target_sl >= 2
+    not input.monitoring.automated_alerts_configured
+    msg := sprintf(
+        "IEC 62443 SR 6.1 RE 1 SL%v (TRE): No automated security alerting configured. Automated detection and alerting on security events is required at Security Level 2+.",
+        [input.target_sl]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 6.2 — Continuous monitoring
+# Monitor the IACS on a continuous basis for security events.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.monitoring.security_event_monitoring
+    msg := "IEC 62443 SR 6.2 (TRE): No security event monitoring for IACS. Real-time or near-real-time monitoring of the IACS is required to enable timely response to incidents."
+}
+
+violations contains msg if {
+    not input.monitoring.continuous_monitoring
+    msg := "IEC 62443 SR 6.2 (TRE): IACS security monitoring is not continuous (24/7). Continuous monitoring is required — gaps in monitoring create windows of undetected intrusion."
+}
+
+# SR 6.2 RE 1 (SL 2+): Automated monitoring with alert response
+violations contains msg if {
+    input.target_sl >= 2
+    input.monitoring.mean_time_to_detect_hours > 24
+    msg := sprintf(
+        "IEC 62443 SR 6.2 RE 1 SL%v (TRE): Mean time to detect IACS security incidents is %v hours. Target is less than 24 hours at Security Level 2+; real-time detection recommended.",
+        [input.target_sl, input.monitoring.mean_time_to_detect_hours]
+    )
+}
+
+violations contains msg if {
+    input.target_sl >= 2
+    input.monitoring.mean_time_to_respond_hours > 4
+    msg := sprintf(
+        "IEC 62443 SR 6.2 RE 1 SL%v (TRE): Mean time to respond to IACS security incidents is %v hours. Target is less than 4 hours at Security Level 2+.",
+        [input.target_sl, input.monitoring.mean_time_to_respond_hours]
+    )
+}
+
+# SR 6.2 RE 2 (SL 3+): ICS-specific SOC capability
+violations contains msg if {
+    input.target_sl >= 3
+    not input.monitoring.ics_specific_soc_capability
+    msg := sprintf(
+        "IEC 62443 SR 6.2 RE 2 SL%v (TRE): No ICS-specific Security Operations Center (SOC) capability. At Security Level 3+, OT-aware monitoring personnel or an OT-SOC is required.",
+        [input.target_sl]
+    )
+}
+
+# SR 6.2 RE 3 (SL 3+): Threat intelligence integration
+violations contains msg if {
+    input.target_sl >= 3
+    not input.monitoring.threat_intelligence_integrated
+    msg := sprintf(
+        "IEC 62443 SR 6.2 RE 3 SL%v (TRE): Threat intelligence is not integrated into IACS monitoring. ICS-CERT/CISA advisories and sector-specific threat feeds must be operationalized at Security Level 3+.",
+        [input.target_sl]
+    )
+}
+
+violations contains msg if {
+    input.target_sl >= 4
+    not input.monitoring.anomaly_detection_enabled
+    msg := sprintf(
+        "IEC 62443 SR 6.2 RE 4 SL%v (TRE): No anomaly-based detection for IACS. Behavioral anomaly detection is required at Security Level 4 to detect sophisticated, previously unseen attacks.",
+        [input.target_sl]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Compliance Aggregation
+# ---------------------------------------------------------------------------
+
+compliant if { count(violations) == 0 }
+
+fr6_passing_srs := count([sr |
+    sr := [
+        count([v | some v in violations; contains(v, "SR 6.1")]) == 0,
+        count([v | some v in violations; contains(v, "SR 6.2")]) == 0,
+    ][_]
+    sr == true
+])
+
+compliance_report := {
+    "foundational_requirement": "FR 6",
+    "title":                    "Timely Response to Events (TRE)",
+    "standard":                 "IEC 62443-3-3",
+    "target_sl":                input.target_sl,
+    "total_srs":                2,
+    "passing_srs":              fr6_passing_srs,
+    "compliant":                compliant,
+    "violations":               violations,
+}

--- a/frameworks/critical_infrastructure/iec_62443/fr7_resource_availability.rego
+++ b/frameworks/critical_infrastructure/iec_62443/fr7_resource_availability.rego
@@ -1,0 +1,353 @@
+package iec_62443.fr7
+
+import rego.v1
+
+# =============================================================================
+# IEC 62443-3-3 FR 7 — Resource Availability (RA)
+#
+# Purpose: Ensure the availability of the IACS under all circumstances,
+# including the resilience of the IACS against denial-of-service attacks
+# and support for required capacity and performance.
+#
+# Security Requirements (SRs):
+#   SR 7.1 — Denial of service protection
+#   SR 7.2 — Resource management
+#   SR 7.3 — Control system backup
+#   SR 7.4 — Control system recovery and reconstitution
+#   SR 7.5 — Emergency power
+#   SR 7.6 — Network and security configuration settings
+#   SR 7.7 — Least functionality
+#   SR 7.8 — Control system component inventory
+#
+# Input shape:
+#   input.target_sl                              - int (1–4)
+#   input.ics_systems[]
+#     .name                                      - string
+#     .high_availability_configured              - bool
+#     .criticality                               - string ("high"/"medium"/"low")
+#     .unnecessary_services_disabled             - bool
+#     .os_version_current                        - bool
+#     .inventory_documented                      - bool
+#     .backup_configured                         - bool
+#     .resource_monitoring_enabled               - bool
+#     .rate_limiting_enabled                     - bool
+#     .emergency_power_backup                    - bool
+#     .recovery_time_objective_hours             - int
+#   input.monitoring
+#     .dos_protection                            - bool
+#   input.patch_management
+#     .process_documented                        - bool
+#     .tested_before_deployment                  - bool
+#     .rollback_capability                       - bool
+#   input.backups
+#     .backup_frequency_days                     - int
+#     .offsite_storage                           - bool
+#     .restoration_tested                        - bool
+#     .encryption_at_rest                        - bool
+#     .backup_rto_hours                          - int
+# =============================================================================
+
+default compliant := false
+
+# ---------------------------------------------------------------------------
+# SR 7.1 — Denial of service protection
+# Protect the IACS against DoS attacks.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.monitoring.dos_protection
+    msg := "IEC 62443 SR 7.1 (RA): No DoS protection for IACS network. Industrial control systems must be protected against denial-of-service attacks that could disrupt critical operations."
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.rate_limiting_enabled
+    msg := sprintf(
+        "IEC 62443 SR 7.1 (RA): ICS system '%v' has no rate limiting. Rate limiting on communication interfaces prevents resource exhaustion from DoS attacks.",
+        [system.name]
+    )
+}
+
+# SR 7.1 RE 1 (SL 2+): DoS protection with traffic management
+violations contains msg if {
+    input.target_sl >= 2
+    not input.network.dos_traffic_management
+    msg := sprintf(
+        "IEC 62443 SR 7.1 RE 1 SL%v (RA): No active DoS traffic management implemented. Intrusion prevention, traffic shaping, or equivalent controls are required at Security Level 2+.",
+        [input.target_sl]
+    )
+}
+
+# SR 7.1 RE 2 (SL 3+): Redundant network paths
+violations contains msg if {
+    input.target_sl >= 3
+    not input.network.redundant_paths
+    msg := sprintf(
+        "IEC 62443 SR 7.1 RE 2 SL%v (RA): No redundant network paths for critical IACS communications. Network redundancy is required at Security Level 3+ to maintain availability under partial failure.",
+        [input.target_sl]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 7.2 — Resource management
+# Manage IACS resources to prevent resource exhaustion.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.resource_monitoring_enabled
+    msg := sprintf(
+        "IEC 62443 SR 7.2 (RA): ICS system '%v' does not monitor resource usage. CPU, memory, disk, and network resource utilization must be monitored with alerts for degraded capacity.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    input.target_sl >= 2
+    some system in input.ics_systems
+    not system.resource_limits_configured
+    msg := sprintf(
+        "IEC 62443 SR 7.2 RE 1 SL%v (RA): ICS system '%v' has no resource limits configured. Resource quotas must be enforced to prevent a single process or user from exhausting system resources.",
+        [input.target_sl, system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 7.3 — Control system backup
+# Maintain backups of the IACS configuration and data.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.backup_configured
+    msg := sprintf(
+        "IEC 62443 SR 7.3 (RA): ICS system '%v' has no backup configured. Regular backups of IACS configuration, logic, and data are required for recovery.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    input.backups.backup_frequency_days > 7
+    msg := sprintf(
+        "IEC 62443 SR 7.3 (RA): IACS backups are performed every %v days. Backups must be performed at least weekly; daily backups are recommended for critical systems.",
+        [input.backups.backup_frequency_days]
+    )
+}
+
+violations contains msg if {
+    not input.backups.offsite_storage
+    msg := "IEC 62443 SR 7.3 (RA): IACS backups are not stored offsite. Offsite or geographically separated backup storage is required to survive a site-level disaster."
+}
+
+violations contains msg if {
+    not input.backups.restoration_tested
+    msg := "IEC 62443 SR 7.3 (RA): IACS backup restoration has not been tested. Backups must be periodically tested for recoverability — an untested backup is not a reliable backup."
+}
+
+violations contains msg if {
+    input.target_sl >= 2
+    not input.backups.encryption_at_rest
+    msg := sprintf(
+        "IEC 62443 SR 7.3 RE 1 SL%v (RA): IACS backups are not encrypted at rest. Backup media containing IACS configuration and data must be encrypted at Security Level 2+.",
+        [input.target_sl]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 7.4 — Control system recovery and reconstitution
+# Recover the IACS to a known secure state after an incident.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.recovery_procedure_documented
+    msg := sprintf(
+        "IEC 62443 SR 7.4 (RA): ICS system '%v' has no documented recovery procedure. A step-by-step recovery procedure enabling restoration to a known secure state is required.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.recovery_time_objective_hours > 24
+    system.criticality == "high"
+    msg := sprintf(
+        "IEC 62443 SR 7.4 (RA): High-criticality ICS system '%v' has an RTO of %v hours. Critical IACS systems must achieve recovery within 24 hours; 4 hours or less is recommended.",
+        [system.name, system.recovery_time_objective_hours]
+    )
+}
+
+violations contains msg if {
+    not input.patch_management.rollback_capability
+    msg := "IEC 62443 SR 7.4 (RA): No rollback capability for IACS updates/patches. The ability to revert to a previous known-good state is required for all IACS changes."
+}
+
+# SR 7.4 RE 1 (SL 2+): Tested recovery plan
+violations contains msg if {
+    input.target_sl >= 2
+    not input.security_management.recovery_plan_tested
+    msg := sprintf(
+        "IEC 62443 SR 7.4 RE 1 SL%v (RA): IACS recovery plan has not been tested. At Security Level 2+, recovery procedures must be exercised at least annually.",
+        [input.target_sl]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 7.5 — Emergency power
+# Maintain IACS availability during power disruptions.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.criticality == "high"
+    not system.emergency_power_backup
+    msg := sprintf(
+        "IEC 62443 SR 7.5 (RA): High-criticality ICS system '%v' has no emergency power backup (UPS/generator). Uninterrupted power is required for critical industrial control systems.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    input.target_sl >= 2
+    some system in input.ics_systems
+    not system.emergency_power_backup
+    msg := sprintf(
+        "IEC 62443 SR 7.5 SL%v (RA): ICS system '%v' has no emergency power backup. Emergency power capability is required at Security Level 2+ for all IACS components.",
+        [input.target_sl, system.name]
+    )
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.emergency_power_backup
+    not system.emergency_power_tested
+    msg := sprintf(
+        "IEC 62443 SR 7.5 (RA): ICS system '%v' emergency power backup has not been tested. UPS/generator systems must be tested at least semi-annually to verify runtime and automatic switchover.",
+        [system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 7.6 — Network and security configuration settings
+# Maintain security configurations to ensure continued protection.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.configuration_baseline_documented
+    msg := sprintf(
+        "IEC 62443 SR 7.6 (RA): ICS system '%v' has no documented configuration baseline. A hardened baseline configuration must be documented and enforced.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    input.target_sl >= 2
+    not input.security_management.configuration_change_management
+    msg := sprintf(
+        "IEC 62443 SR 7.6 RE 1 SL%v (RA): No configuration change management process. All changes to IACS network and security configurations must go through a formal change control process.",
+        [input.target_sl]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 7.7 — Least functionality
+# Configure IACS to provide only essential functionality.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.unnecessary_services_disabled
+    msg := sprintf(
+        "IEC 62443 SR 7.7 (RA): ICS system '%v' has unnecessary services enabled. Disable all services, protocols, and ports not required for IACS operation to reduce the attack surface.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.os_hardened
+    msg := sprintf(
+        "IEC 62443 SR 7.7 (RA): ICS system '%v' OS has not been hardened. Remove unnecessary OS components, disable unused features, and apply a hardening standard (CIS benchmark or equivalent).",
+        [system.name]
+    )
+}
+
+# SR 7.7 RE 1 (SL 2+): Periodic review of enabled functionality
+violations contains msg if {
+    input.target_sl >= 2
+    not input.security_management.functionality_review_schedule
+    msg := sprintf(
+        "IEC 62443 SR 7.7 RE 1 SL%v (RA): No periodic review of IACS enabled functionality. Enabled services, protocols, and functions must be reviewed at least annually at Security Level 2+.",
+        [input.target_sl]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# SR 7.8 — Control system component inventory
+# Maintain a current inventory of all IACS components.
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.inventory_documented
+    msg := sprintf(
+        "IEC 62443 SR 7.8 (RA): ICS system '%v' is not documented in the IACS component inventory. Every IACS component must be inventoried with hardware, software, firmware versions, and network information.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    not input.network.network_inventory_documented
+    msg := "IEC 62443 SR 7.8 (RA): Network inventory is not documented. A complete, up-to-date asset inventory of all IACS network components is required."
+}
+
+violations contains msg if {
+    input.target_sl >= 2
+    not input.security_management.inventory_auto_discovery
+    msg := sprintf(
+        "IEC 62443 SR 7.8 RE 1 SL%v (RA): No automated asset discovery for IACS. Automated inventory discovery or network scanning tools are required at Security Level 2+ to detect unauthorized devices.",
+        [input.target_sl]
+    )
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.inventory_documented
+    not system.os_version_current
+    msg := sprintf(
+        "IEC 62443 SR 7.8 (RA): ICS system '%v' is running an outdated OS version. Inventory data must be current and unsupported OS versions must be remediated or documented as accepted risk.",
+        [system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Compliance Aggregation
+# ---------------------------------------------------------------------------
+
+compliant if { count(violations) == 0 }
+
+fr7_passing_srs := count([sr |
+    sr := [
+        count([v | some v in violations; contains(v, "SR 7.1")]) == 0,
+        count([v | some v in violations; contains(v, "SR 7.2")]) == 0,
+        count([v | some v in violations; contains(v, "SR 7.3")]) == 0,
+        count([v | some v in violations; contains(v, "SR 7.4")]) == 0,
+        count([v | some v in violations; contains(v, "SR 7.5")]) == 0,
+        count([v | some v in violations; contains(v, "SR 7.6")]) == 0,
+        count([v | some v in violations; contains(v, "SR 7.7")]) == 0,
+        count([v | some v in violations; contains(v, "SR 7.8")]) == 0,
+    ][_]
+    sr == true
+])
+
+compliance_report := {
+    "foundational_requirement": "FR 7",
+    "title":                    "Resource Availability (RA)",
+    "standard":                 "IEC 62443-3-3",
+    "target_sl":                input.target_sl,
+    "total_srs":                8,
+    "passing_srs":              fr7_passing_srs,
+    "compliant":                compliant,
+    "violations":               violations,
+}

--- a/frameworks/critical_infrastructure/iec_62443/iec_62443_main.rego
+++ b/frameworks/critical_infrastructure/iec_62443/iec_62443_main.rego
@@ -1,380 +1,256 @@
-package iec_62443
+package iec_62443_main
 
 import rego.v1
 
 # =============================================================================
-# IEC 62443 — Industrial Automation and Control Systems Security
-# International standard for OT/ICS cybersecurity
+# IEC 62443 — Industrial Automation and Control Systems (IACS) Security
+# Main Orchestrator — Aggregates All Parts and Foundational Requirements
 #
-# Structure:
-#   Part 2-1: Security management system requirements
-#   Part 2-4: Security program requirements for IACS service providers
-#   Part 3-2: Security risk assessment for system design
-#   Part 3-3: System security requirements and security levels
+# Standard: IEC 62443 (series)
+# Full Title: Security for industrial automation and control systems
+# Publisher: International Electrotechnical Commission (IEC)
+# Scope: OT/ICS/SCADA cybersecurity for industrial environments
 #
-# Security Levels (SL):
+# Coverage:
+#   Part 2-1 — Security Management System (CSMS)          [part2_security_management.rego]
+#   Part 2-3 — Patch Management                           [part2_patch_management.rego]
+#   Part 2-4 — IACS Service Provider Requirements         [part2_service_provider.rego]
+#   Part 3-2 — Security Risk Assessment for System Design [part3_risk_assessment.rego]
+#   Part 3-3 FR 1 — Identification & Authentication       [fr1_identification_authentication.rego]
+#   Part 3-3 FR 2 — Use Control                           [fr2_use_control.rego]
+#   Part 3-3 FR 3 — System Integrity                      [fr3_system_integrity.rego]
+#   Part 3-3 FR 4 — Data Confidentiality                  [fr4_data_confidentiality.rego]
+#   Part 3-3 FR 5 — Restricted Data Flow                  [fr5_restricted_data_flow.rego]
+#   Part 3-3 FR 6 — Timely Response to Events             [fr6_timely_response.rego]
+#   Part 3-3 FR 7 — Resource Availability                 [fr7_resource_availability.rego]
+#
+# Security Levels:
 #   SL 1 — Protection against casual or coincidental violation
 #   SL 2 — Protection against intentional violation with simple means
-#   SL 3 — Protection against sophisticated attacks
-#   SL 4 — Protection against state-sponsored attacks
+#   SL 3 — Protection against sophisticated attacks (nation-state capable actors)
+#   SL 4 — Protection against state-sponsored, highly motivated, well-resourced attacks
 #
-# Foundational Requirements (FR):
-#   FR 1 — Identification & Authentication Control (IAC)
-#   FR 2 — Use Control (UC)
-#   FR 3 — System Integrity (SI)
-#   FR 4 — Data Confidentiality (DC)
-#   FR 5 — Restricted Data Flow (RDF)
-#   FR 6 — Timely Response to Events (TRE)
-#   FR 7 — Resource Availability (RA)
-#
-# Input shape:
-#   input.ics_systems[]         - industrial control systems
-#   input.zones[]               - network zones/cells
-#   input.conduits[]            - communication conduits between zones
-#   input.target_sl             - target security level (1-4)
-#   input.authentication        - authentication controls
-#   input.network               - network controls
-#   input.monitoring            - monitoring controls
-#   input.patch_management      - patch/update management
+# OPA Endpoint: POST http://192.168.4.62:8183/v1/data/iec_62443_main
 # =============================================================================
 
-# ---------------------------------------------------------------------------
-# FR 1 — Identification & Authentication Control (IAC)
-# ---------------------------------------------------------------------------
-
-violation_fr1 contains msg if {
-    some system in input.ics_systems
-    not system.unique_identification
-    msg := sprintf(
-        "IEC 62443 FR1 (IAC): ICS system '%v' does not enforce unique user identification. All users and devices must have unique identifiers.",
-        [system.name]
-    )
-}
-
-violation_fr1 contains msg if {
-    input.target_sl >= 2
-    some system in input.ics_systems
-    not system.mfa_enabled
-    msg := sprintf(
-        "IEC 62443 FR1 SL2 (IAC): ICS system '%v' does not enforce multi-factor authentication. MFA is required at Security Level 2+.",
-        [system.name]
-    )
-}
-
-violation_fr1 contains msg if {
-    input.target_sl >= 2
-    some system in input.ics_systems
-    system.default_credentials_unchanged
-    msg := sprintf(
-        "IEC 62443 FR1 SL2 (IAC): ICS system '%v' uses unchanged default credentials. Default credentials are a critical vulnerability in OT environments.",
-        [system.name]
-    )
-}
-
-violation_fr1 contains msg if {
-    input.target_sl >= 3
-    not input.authentication.pki_or_certificate_based
-    msg := "IEC 62443 FR1 SL3 (IAC): PKI or certificate-based authentication is not implemented. Required at Security Level 3+ for strong identity assurance."
-}
+import data.iec_62443.fr1
+import data.iec_62443.fr2
+import data.iec_62443.fr3
+import data.iec_62443.fr4
+import data.iec_62443.fr5
+import data.iec_62443.fr6
+import data.iec_62443.fr7
+import data.iec_62443.part2_1
+import data.iec_62443.part2_3
+import data.iec_62443.part2_4
+import data.iec_62443.part3_2
 
 # ---------------------------------------------------------------------------
-# FR 2 — Use Control (UC)
+# All violations aggregated across all parts and FRs
 # ---------------------------------------------------------------------------
 
-violation_fr2 contains msg if {
-    some system in input.ics_systems
-    not system.least_privilege_enforced
-    msg := sprintf(
-        "IEC 62443 FR2 (UC): ICS system '%v' does not enforce least privilege. Users must only have access required for their function.",
-        [system.name]
-    )
-}
-
-violation_fr2 contains msg if {
-    input.target_sl >= 2
-    not input.authentication.audit_trail_for_privileged_access
-    msg := "IEC 62443 FR2 SL2 (UC): Privileged access is not audited. All privileged operations on ICS must be logged."
-}
-
-violation_fr2 contains msg if {
-    some system in input.ics_systems
-    system.remote_access_enabled
-    not system.remote_access_controlled
-    msg := sprintf(
-        "IEC 62443 FR2 (UC): ICS system '%v' has uncontrolled remote access. Remote access to ICS must be explicitly authorized and controlled.",
-        [system.name]
-    )
-}
-
-# ---------------------------------------------------------------------------
-# FR 3 — System Integrity (SI)
-# ---------------------------------------------------------------------------
-
-violation_fr3 contains msg if {
-    some system in input.ics_systems
-    not system.communication_integrity
-    msg := sprintf(
-        "IEC 62443 FR3 (SI): ICS system '%v' does not enforce communication integrity. Messages must be protected against unauthorized modification.",
-        [system.name]
-    )
-}
-
-violation_fr3 contains msg if {
-    input.target_sl >= 2
-    some system in input.ics_systems
-    not system.malware_protection
-    not system.application_whitelisting
-    msg := sprintf(
-        "IEC 62443 FR3 SL2 (SI): ICS system '%v' has no malware protection or application whitelisting. One of these controls is required at SL2.",
-        [system.name]
-    )
-}
-
-violation_fr3 contains msg if {
-    input.target_sl >= 2
-    some system in input.ics_systems
-    system.firmware_integrity_checking == false
-    msg := sprintf(
-        "IEC 62443 FR3 SL2 (SI): ICS system '%v' does not verify firmware integrity. Firmware integrity checking is required at SL2.",
-        [system.name]
-    )
-}
-
-violation_fr3 contains msg if {
-    not input.patch_management.process_documented
-    msg := "IEC 62443 FR3 (SI): No patch management process for ICS. Security patches must be evaluated and applied in a timely manner."
-}
-
-violation_fr3 contains msg if {
-    input.patch_management.process_documented
-    input.patch_management.max_patch_delay_days > 90
-    msg := sprintf(
-        "IEC 62443 FR3 (SI): Critical ICS patches are delayed up to %v days. Evaluate and apply critical patches within 30 days.",
-        [input.patch_management.max_patch_delay_days]
-    )
-}
-
-# ---------------------------------------------------------------------------
-# FR 4 — Data Confidentiality (DC)
-# ---------------------------------------------------------------------------
-
-violation_fr4 contains msg if {
-    input.target_sl >= 2
-    some system in input.ics_systems
-    system.sensitive_data_transmitted
-    not system.data_encrypted_in_transit
-    msg := sprintf(
-        "IEC 62443 FR4 SL2 (DC): ICS system '%v' transmits sensitive data without encryption. Encrypt all sensitive ICS communications.",
-        [system.name]
-    )
-}
-
-violation_fr4 contains msg if {
-    input.target_sl >= 2
-    some system in input.ics_systems
-    not system.data_at_rest_protected
-    msg := sprintf(
-        "IEC 62443 FR4 SL2 (DC): ICS system '%v' does not protect data at rest. Configuration and operational data must be protected.",
-        [system.name]
-    )
-}
-
-# ---------------------------------------------------------------------------
-# FR 5 — Restricted Data Flow (RDF) — Zone and Conduit Model
-# ---------------------------------------------------------------------------
-
-violation_fr5 contains msg if {
-    count(input.zones) == 0
-    msg := "IEC 62443 FR5 (RDF): No network zones defined. IEC 62443 requires network segmentation using zones and conduits."
-}
-
-violation_fr5 contains msg if {
-    some zone in input.zones
-    not zone.security_level_defined
-    msg := sprintf(
-        "IEC 62443 FR5 (RDF): Zone '%v' does not have a defined security level. Each zone must have an assigned SL.",
-        [zone.name]
-    )
-}
-
-violation_fr5 contains msg if {
-    some conduit in input.conduits
-    not conduit.firewall_or_dmz
-    msg := sprintf(
-        "IEC 62443 FR5 (RDF): Conduit between zones '%v' and '%v' has no firewall or DMZ. All zone boundaries must be protected.",
-        [conduit.source_zone, conduit.dest_zone]
-    )
-}
-
-violation_fr5 contains msg if {
-    some conduit in input.conduits
-    conduit.source_zone == "corporate_it"
-    conduit.dest_zone == "ics_control"
-    not conduit.unidirectional_gateway
-    msg := "IEC 62443 FR5 (RDF): IT/OT boundary between corporate and ICS control zone lacks a unidirectional gateway (data diode). This is a critical segmentation requirement."
-}
-
-violation_fr5 contains msg if {
-    not input.network.it_ot_segmentation
-    msg := "IEC 62443 FR5 (RDF): IT and OT networks are not segmented. Industrial control systems must be isolated from corporate IT networks."
-}
-
-violation_fr5 contains msg if {
-    input.network.direct_internet_connectivity_to_ics
-    msg := "IEC 62443 FR5 (RDF): ICS systems have direct Internet connectivity. ICS must not be directly Internet-accessible."
-}
-
-# ---------------------------------------------------------------------------
-# FR 6 — Timely Response to Events (TRE)
-# ---------------------------------------------------------------------------
-
-violation_fr6 contains msg if {
-    some system in input.ics_systems
-    not system.audit_logging_enabled
-    msg := sprintf(
-        "IEC 62443 FR6 (TRE): ICS system '%v' does not have audit logging enabled. Security events must be logged for timely response.",
-        [system.name]
-    )
-}
-
-violation_fr6 contains msg if {
-    not input.monitoring.security_event_monitoring
-    msg := "IEC 62443 FR6 (TRE): No security event monitoring for ICS. Real-time monitoring is required to enable timely response to incidents."
-}
-
-violation_fr6 contains msg if {
-    not input.monitoring.incident_response_plan_for_ics
-    msg := "IEC 62443 FR6 (TRE): No ICS-specific incident response plan. OT/ICS incidents require specialized response procedures distinct from IT IR plans."
-}
-
-violation_fr6 contains msg if {
-    input.monitoring.ics_log_retention_days < 90
-    msg := sprintf(
-        "IEC 62443 FR6 (TRE): ICS audit logs are retained for only %v days. Retain ICS security logs for at least 90 days.",
-        [input.monitoring.ics_log_retention_days]
-    )
-}
-
-# ---------------------------------------------------------------------------
-# FR 7 — Resource Availability (RA)
-# ---------------------------------------------------------------------------
-
-violation_fr7 contains msg if {
-    some system in input.ics_systems
-    not system.high_availability_configured
-    system.criticality == "high"
-    msg := sprintf(
-        "IEC 62443 FR7 (RA): High-criticality ICS system '%v' does not have high availability configured. Redundancy is required for critical systems.",
-        [system.name]
-    )
-}
-
-violation_fr7 contains msg if {
-    not input.monitoring.dos_protection
-    msg := "IEC 62443 FR7 (RA): No DoS protection for ICS network. ICS systems must be protected against denial-of-service attacks."
-}
-
-violation_fr7 contains msg if {
-    not input.patch_management.tested_before_deployment
-    msg := "IEC 62443 FR7 (RA): ICS patches are not tested before deployment. Untested patches can cause availability failures in critical systems."
-}
-
-# ---------------------------------------------------------------------------
-# IACS Service Provider Requirements (Part 2-4)
-# ---------------------------------------------------------------------------
-
-violation_service_provider contains msg if {
-    input.is_iacs_service_provider == true
-    not input.service_provider.security_program_documented
-    msg := "IEC 62443-2-4: IACS service provider has no documented security program. Service providers must have a formal security management program."
-}
-
-violation_service_provider contains msg if {
-    input.is_iacs_service_provider == true
-    not input.service_provider.customer_security_requirements_reviewed
-    msg := "IEC 62443-2-4: IACS service provider has not reviewed customer security requirements. Provider must align with customer security requirements."
-}
-
-# ---------------------------------------------------------------------------
-# Aggregate
-# ---------------------------------------------------------------------------
-
-all_violations := array.concat(
+part2_violations := array.concat(
     array.concat(
-        [v | some v in violation_fr1],
-        [v | some v in violation_fr2]
+        [v | some v in part2_1.violations],
+        [v | some v in part2_3.violations]
     ),
-    array.concat(
-        array.concat(
-            [v | some v in violation_fr3],
-            [v | some v in violation_fr4]
-        ),
-        array.concat(
-            array.concat(
-                [v | some v in violation_fr5],
-                [v | some v in violation_fr6]
-            ),
-            array.concat(
-                [v | some v in violation_fr7],
-                [v | some v in violation_service_provider]
-            )
-        )
-    )
+    [v | some v in part2_4.violations]
 )
+
+part3_violations_fr1_fr2 := array.concat(
+    [v | some v in fr1.violations],
+    [v | some v in fr2.violations]
+)
+
+part3_violations_fr3_fr4 := array.concat(
+    [v | some v in fr3.violations],
+    [v | some v in fr4.violations]
+)
+
+part3_violations_fr5_fr6 := array.concat(
+    [v | some v in fr5.violations],
+    [v | some v in fr6.violations]
+)
+
+part3_violations_fr7_risk := array.concat(
+    [v | some v in fr7.violations],
+    [v | some v in part3_2.violations]
+)
+
+part3_violations_group1 := array.concat(
+    part3_violations_fr1_fr2,
+    part3_violations_fr3_fr4
+)
+
+part3_violations_group2 := array.concat(
+    part3_violations_fr5_fr6,
+    part3_violations_fr7_risk
+)
+
+part3_violations := array.concat(
+    part3_violations_group1,
+    part3_violations_group2
+)
+
+all_violations := array.concat(part2_violations, part3_violations)
+
+# ---------------------------------------------------------------------------
+# Top-level compliance
+# ---------------------------------------------------------------------------
+
+default iec_62443_compliant := false
 
 iec_62443_compliant if { count(all_violations) == 0 }
 
-passing_requirements := count([fr |
+# ---------------------------------------------------------------------------
+# FR-level compliance flags
+# ---------------------------------------------------------------------------
+
+default fr1_compliant := false
+default fr2_compliant := false
+default fr3_compliant := false
+default fr4_compliant := false
+default fr5_compliant := false
+default fr6_compliant := false
+default fr7_compliant := false
+
+fr1_compliant if { fr1.compliant }
+fr2_compliant if { fr2.compliant }
+fr3_compliant if { fr3.compliant }
+fr4_compliant if { fr4.compliant }
+fr5_compliant if { fr5.compliant }
+fr6_compliant if { fr6.compliant }
+fr7_compliant if { fr7.compliant }
+
+# ---------------------------------------------------------------------------
+# Part 2 compliance flags
+# ---------------------------------------------------------------------------
+
+default part2_1_compliant := false
+default part2_3_compliant := false
+default part2_4_compliant := false
+default part3_2_compliant := false
+
+part2_1_compliant if { part2_1.compliant }
+part2_3_compliant if { part2_3.compliant }
+part2_4_compliant if { part2_4.compliant }
+part3_2_compliant if { part3_2.compliant }
+
+# ---------------------------------------------------------------------------
+# Compliance scoring
+# ---------------------------------------------------------------------------
+
+passing_frs := count([fr |
     fr := [
-        count(violation_fr1) == 0,
-        count(violation_fr2) == 0,
-        count(violation_fr3) == 0,
-        count(violation_fr4) == 0,
-        count(violation_fr5) == 0,
-        count(violation_fr6) == 0,
-        count(violation_fr7) == 0,
+        fr1_compliant,
+        fr2_compliant,
+        fr3_compliant,
+        fr4_compliant,
+        fr5_compliant,
+        fr6_compliant,
+        fr7_compliant,
     ][_]
     fr == true
 ])
 
-compliance_score := round((passing_requirements / 7) * 100)
+# Total SRs across all FRs: FR1=13, FR2=12, FR3=9, FR4=3, FR5=4, FR6=2, FR7=8 = 51
+total_srs := 51
+
+passing_srs := (
+    fr1.compliance_report.passing_srs +
+    fr2.compliance_report.passing_srs +
+    fr3.compliance_report.passing_srs +
+    fr4.compliance_report.passing_srs +
+    fr5.compliance_report.passing_srs +
+    fr6.compliance_report.passing_srs +
+    fr7.compliance_report.passing_srs
+)
+
+sr_compliance_score := round((passing_srs / total_srs) * 100)
+
+fr_compliance_score := round((passing_frs / 7) * 100)
+
+# ---------------------------------------------------------------------------
+# Complete compliance report
+# ---------------------------------------------------------------------------
 
 iec_62443_compliance_report := {
-    "standard":         "IEC 62443",
-    "full_title":       "Industrial Automation and Control Systems Security",
-    "target_sl":        input.target_sl,
-    "compliant":        iec_62443_compliant,
-    "compliance_score": compliance_score,
-    "total_violations": count(all_violations),
-    "violations":       all_violations,
-    "foundational_requirements": {
+    "standard":             "IEC 62443",
+    "full_title":           "Security for Industrial Automation and Control Systems",
+    "target_sl":            input.target_sl,
+    "compliant":            iec_62443_compliant,
+    "total_violations":     count(all_violations),
+    "fr_compliance_score":  fr_compliance_score,
+    "sr_compliance_score":  sr_compliance_score,
+    "passing_frs":          passing_frs,
+    "total_frs":            7,
+    "passing_srs":          passing_srs,
+    "total_srs":            total_srs,
+
+    "part3_3_foundational_requirements": {
         "FR1_identification_authentication": {
-            "compliant": count(violation_fr1) == 0,
-            "violations": violation_fr1,
+            "compliant":   fr1_compliant,
+            "total_srs":   13,
+            "passing_srs": fr1.compliance_report.passing_srs,
+            "violations":  fr1.violations,
         },
         "FR2_use_control": {
-            "compliant": count(violation_fr2) == 0,
-            "violations": violation_fr2,
+            "compliant":   fr2_compliant,
+            "total_srs":   12,
+            "passing_srs": fr2.compliance_report.passing_srs,
+            "violations":  fr2.violations,
         },
         "FR3_system_integrity": {
-            "compliant": count(violation_fr3) == 0,
-            "violations": violation_fr3,
+            "compliant":   fr3_compliant,
+            "total_srs":   9,
+            "passing_srs": fr3.compliance_report.passing_srs,
+            "violations":  fr3.violations,
         },
         "FR4_data_confidentiality": {
-            "compliant": count(violation_fr4) == 0,
-            "violations": violation_fr4,
+            "compliant":   fr4_compliant,
+            "total_srs":   3,
+            "passing_srs": fr4.compliance_report.passing_srs,
+            "violations":  fr4.violations,
         },
         "FR5_restricted_data_flow": {
-            "compliant": count(violation_fr5) == 0,
-            "violations": violation_fr5,
+            "compliant":   fr5_compliant,
+            "total_srs":   4,
+            "passing_srs": fr5.compliance_report.passing_srs,
+            "violations":  fr5.violations,
         },
         "FR6_timely_response": {
-            "compliant": count(violation_fr6) == 0,
-            "violations": violation_fr6,
+            "compliant":   fr6_compliant,
+            "total_srs":   2,
+            "passing_srs": fr6.compliance_report.passing_srs,
+            "violations":  fr6.violations,
         },
         "FR7_resource_availability": {
-            "compliant": count(violation_fr7) == 0,
-            "violations": violation_fr7,
+            "compliant":   fr7_compliant,
+            "total_srs":   8,
+            "passing_srs": fr7.compliance_report.passing_srs,
+            "violations":  fr7.violations,
         },
     },
+
+    "part2_management_requirements": {
+        "part2_1_security_management": {
+            "compliant":   part2_1_compliant,
+            "violations":  part2_1.violations,
+        },
+        "part2_3_patch_management": {
+            "compliant":   part2_3_compliant,
+            "violations":  part2_3.violations,
+        },
+        "part2_4_service_provider": {
+            "compliant":   part2_4_compliant,
+            "violations":  part2_4.violations,
+        },
+    },
+
+    "part3_2_risk_assessment": {
+        "compliant":   part3_2_compliant,
+        "violations":  part3_2.violations,
+    },
+
+    "all_violations": all_violations,
 }

--- a/frameworks/critical_infrastructure/iec_62443/part2_patch_management.rego
+++ b/frameworks/critical_infrastructure/iec_62443/part2_patch_management.rego
@@ -1,0 +1,160 @@
+package iec_62443.part2_3
+
+import rego.v1
+
+# =============================================================================
+# IEC 62443-2-3 — Patch Management in the IACS Environment
+#
+# Purpose: Define requirements for managing security patches and updates for
+# IACS components. OT patch management differs significantly from IT — patches
+# must be tested in isolated environments before production deployment, and
+# rollback capability is essential to prevent operational disruption.
+#
+# Key Requirement Areas:
+#   - Patch identification and evaluation
+#   - Patch testing and qualification
+#   - Patch deployment and scheduling
+#   - Compensating controls for unpatched systems
+#   - Vendor coordination
+#
+# Input shape:
+#   input.patch_management
+#     .process_documented                      - bool
+#     .max_patch_delay_days                    - int
+#     .tested_before_deployment                - bool
+#     .rollback_capability                     - bool
+#     .patch_testing_environment               - bool
+#     .vendor_notification_subscriptions       - bool
+#     .compensating_controls_for_unpatched     - bool
+#     .patch_inventory_tracked                 - bool
+#     .emergency_patch_procedure               - bool
+#     .change_management_integrated            - bool
+#     .patch_deployment_schedule_documented    - bool
+#   input.ics_systems[]
+#     .name                                    - string
+#     .os_version_current                      - bool
+#     .firmware_version_current                - bool
+#     .patch_status_documented                 - bool
+# =============================================================================
+
+default compliant := false
+
+# ---------------------------------------------------------------------------
+# Patch Identification and Evaluation
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.patch_management.process_documented
+    msg := "IEC 62443-2-3: No patch management process documented for IACS. A formal process for identifying, evaluating, testing, and applying security patches is required."
+}
+
+violations contains msg if {
+    not input.patch_management.vendor_notification_subscriptions
+    msg := "IEC 62443-2-3: No vendor security notification subscriptions. Subscribe to ICS-CERT, vendor security advisories, and sector-specific vulnerability feeds to receive timely patch notifications."
+}
+
+violations contains msg if {
+    not input.patch_management.patch_inventory_tracked
+    msg := "IEC 62443-2-3: Patch status is not tracked for IACS components. Maintain a current patch inventory for all IACS hardware and software components."
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    not system.patch_status_documented
+    msg := sprintf(
+        "IEC 62443-2-3: Patch status for ICS system '%v' is not documented. Every IACS component must have a documented patch status, including exceptions and compensating controls for unpatched vulnerabilities.",
+        [system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Patch Testing and Qualification
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.patch_management.tested_before_deployment
+    msg := "IEC 62443-2-3: IACS patches are not tested before production deployment. Patches must be evaluated in an isolated test environment that mirrors the production IACS before deployment — untested patches can cause operational failures."
+}
+
+violations contains msg if {
+    not input.patch_management.patch_testing_environment
+    msg := "IEC 62443-2-3: No dedicated patch testing environment for IACS. A test environment replicating the production IACS is required for safe patch qualification."
+}
+
+# ---------------------------------------------------------------------------
+# Patch Deployment and Scheduling
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    input.patch_management.max_patch_delay_days > 90
+    msg := sprintf(
+        "IEC 62443-2-3: Critical IACS patches are delayed up to %v days. Critical security patches must be deployed within 90 days; within 30 days for actively exploited vulnerabilities.",
+        [input.patch_management.max_patch_delay_days]
+    )
+}
+
+violations contains msg if {
+    not input.patch_management.patch_deployment_schedule_documented
+    msg := "IEC 62443-2-3: No documented patch deployment schedule. A maintenance window schedule for IACS patches must be established that balances security and operational continuity."
+}
+
+violations contains msg if {
+    not input.patch_management.change_management_integrated
+    msg := "IEC 62443-2-3: Patch management is not integrated with change management. All IACS patches must go through the formal change management process to maintain configuration control."
+}
+
+violations contains msg if {
+    not input.patch_management.emergency_patch_procedure
+    msg := "IEC 62443-2-3: No emergency patch procedure defined. A documented emergency patch procedure for critical/zero-day vulnerabilities is required for timely response."
+}
+
+# ---------------------------------------------------------------------------
+# Rollback and Recovery
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.patch_management.rollback_capability
+    msg := "IEC 62443-2-3: No rollback capability for IACS patches. The ability to revert to a pre-patch state is required in case a patch causes operational issues."
+}
+
+# ---------------------------------------------------------------------------
+# Compensating Controls
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.patch_management.compensating_controls_for_unpatched
+    msg := "IEC 62443-2-3: No compensating controls defined for unpatched IACS vulnerabilities. When patching is not immediately feasible, compensating controls (network isolation, additional monitoring, vendor mitigations) must be documented and implemented."
+}
+
+# System-level checks
+violations contains msg if {
+    some system in input.ics_systems
+    not system.os_version_current
+    msg := sprintf(
+        "IEC 62443-2-3: ICS system '%v' is running an outdated OS version. Unsupported or unpatched operating systems represent unacceptable risk in an IACS environment.",
+        [system.name]
+    )
+}
+
+violations contains msg if {
+    some system in input.ics_systems
+    system.firmware_version_current == false
+    msg := sprintf(
+        "IEC 62443-2-3: ICS system '%v' firmware is not current. Outdated firmware may contain unmitigated vulnerabilities — apply vendor-recommended firmware updates following the patch testing process.",
+        [system.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Compliance Aggregation
+# ---------------------------------------------------------------------------
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "part":       "IEC 62443-2-3",
+    "title":      "Patch Management in the IACS Environment",
+    "standard":   "IEC 62443-2-3",
+    "compliant":  compliant,
+    "violations": violations,
+}

--- a/frameworks/critical_infrastructure/iec_62443/part2_security_management.rego
+++ b/frameworks/critical_infrastructure/iec_62443/part2_security_management.rego
@@ -1,0 +1,185 @@
+package iec_62443.part2_1
+
+import rego.v1
+
+# =============================================================================
+# IEC 62443-2-1 — Security Management System (CSMS)
+#
+# Purpose: Define requirements for establishing, implementing, operating,
+# monitoring, reviewing, maintaining, and improving an IACS Cyber Security
+# Management System (CSMS). Analogous to ISO 27001 but specific to OT/ICS.
+#
+# Key Requirement Areas:
+#   - Security policy and organization
+#   - Risk and asset management
+#   - Security implementation
+#   - Security monitoring and improvement
+#   - Business continuity and crisis management
+#
+# Input shape:
+#   input.security_management
+#     .csms_documented                         - bool
+#     .policy_approved                         - bool
+#     .policy_review_cycle_months              - int
+#     .roles_responsibilities_defined          - bool
+#     .security_awareness_training             - bool
+#     .training_frequency_months               - int
+#     .incident_response_capability            - bool
+#     .supply_chain_security                   - bool
+#     .risk_management_process                 - bool
+#     .security_testing_schedule_documented    - bool
+#     .recovery_plan_tested                    - bool
+#     .configuration_change_management         - bool
+#     .functionality_review_schedule           - bool
+#     .inventory_auto_discovery                - bool
+#     .third_party_security_requirements       - bool
+#     .security_metrics_tracked                - bool
+#     .csms_audit_conducted                    - bool
+#     .csms_audit_frequency_months             - int
+# =============================================================================
+
+default compliant := false
+
+# ---------------------------------------------------------------------------
+# Security Policy and Organization
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.security_management.csms_documented
+    msg := "IEC 62443-2-1 (CSMS): No documented Cyber Security Management System. A CSMS addressing people, process, and technology controls for the IACS is required."
+}
+
+violations contains msg if {
+    not input.security_management.policy_approved
+    msg := "IEC 62443-2-1 (CSMS): IACS cybersecurity policy has not been approved by senior management. Management authorization and ownership of the security policy is required."
+}
+
+violations contains msg if {
+    input.security_management.policy_approved
+    input.security_management.policy_review_cycle_months > 12
+    msg := sprintf(
+        "IEC 62443-2-1 (CSMS): IACS security policy is reviewed every %v months. Policy must be reviewed at least annually and after any significant incident or organizational change.",
+        [input.security_management.policy_review_cycle_months]
+    )
+}
+
+violations contains msg if {
+    not input.security_management.roles_responsibilities_defined
+    msg := "IEC 62443-2-1 (CSMS): Security roles and responsibilities are not defined. Ownership of each security control, including an IACS Security Manager role, must be assigned."
+}
+
+# ---------------------------------------------------------------------------
+# Risk Management
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.security_management.risk_management_process
+    msg := "IEC 62443-2-1 (CSMS): No IACS risk management process. A formal process for identifying, assessing, and treating cybersecurity risks to the IACS is required."
+}
+
+violations contains msg if {
+    not input.risk_assessment.conducted
+    msg := "IEC 62443-2-1 (CSMS): No IACS cybersecurity risk assessment has been conducted. A risk assessment is the foundation for all security decisions."
+}
+
+violations contains msg if {
+    input.risk_assessment.conducted
+    input.risk_assessment.review_frequency_months > 24
+    msg := sprintf(
+        "IEC 62443-2-1 (CSMS): IACS risk assessment is reviewed every %v months. Risk assessments must be reviewed at least every 24 months or after significant system changes.",
+        [input.risk_assessment.review_frequency_months]
+    )
+}
+
+violations contains msg if {
+    not input.risk_assessment.asset_inventory_complete
+    msg := "IEC 62443-2-1 (CSMS): IACS asset inventory is incomplete. A complete asset inventory is a prerequisite for risk assessment and security program effectiveness."
+}
+
+violations contains msg if {
+    not input.risk_assessment.threat_modeling_performed
+    msg := "IEC 62443-2-1 (CSMS): No threat modeling performed for IACS. Threat modeling (identifying realistic threat actors and attack vectors) must inform risk treatment decisions."
+}
+
+violations contains msg if {
+    not input.risk_assessment.consequence_analysis_performed
+    msg := "IEC 62443-2-1 (CSMS): No consequence analysis performed. Impact analysis of cyber incidents on safety, operations, environment, and business continuity is required."
+}
+
+# ---------------------------------------------------------------------------
+# Security Awareness and Training
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.security_management.security_awareness_training
+    msg := "IEC 62443-2-1 (CSMS): No security awareness training for IACS personnel. All employees with IACS access must receive role-appropriate cybersecurity training."
+}
+
+violations contains msg if {
+    input.security_management.security_awareness_training
+    input.security_management.training_frequency_months > 12
+    msg := sprintf(
+        "IEC 62443-2-1 (CSMS): IACS security training is conducted every %v months. Training must be conducted at least annually.",
+        [input.security_management.training_frequency_months]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Incident Response
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.security_management.incident_response_capability
+    msg := "IEC 62443-2-1 (CSMS): No IACS incident response capability. A documented ICS-specific incident response plan with trained personnel and clear escalation paths is required."
+}
+
+# ---------------------------------------------------------------------------
+# Supply Chain Security
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.security_management.supply_chain_security
+    msg := "IEC 62443-2-1 (CSMS): No supply chain security program for IACS. Security requirements must extend to OT vendors, integrators, and managed service providers with IACS access."
+}
+
+violations contains msg if {
+    not input.security_management.third_party_security_requirements
+    msg := "IEC 62443-2-1 (CSMS): Security requirements are not imposed on third parties. All vendors and contractors with IACS access must meet defined security requirements (ref: IEC 62443-2-4)."
+}
+
+# ---------------------------------------------------------------------------
+# Continuous Improvement
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.security_management.security_metrics_tracked
+    msg := "IEC 62443-2-1 (CSMS): No security metrics tracked. The CSMS must define and track key performance indicators (KPIs) for measuring security effectiveness."
+}
+
+violations contains msg if {
+    not input.security_management.csms_audit_conducted
+    msg := "IEC 62443-2-1 (CSMS): No CSMS audit conducted. The CSMS must be periodically audited against the defined objectives and requirements."
+}
+
+violations contains msg if {
+    input.security_management.csms_audit_conducted
+    input.security_management.csms_audit_frequency_months > 24
+    msg := sprintf(
+        "IEC 62443-2-1 (CSMS): CSMS audits are conducted every %v months. Audits must be conducted at least every 24 months.",
+        [input.security_management.csms_audit_frequency_months]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Compliance Aggregation
+# ---------------------------------------------------------------------------
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "part":       "IEC 62443-2-1",
+    "title":      "Security Management System (CSMS) Requirements",
+    "standard":   "IEC 62443-2-1",
+    "compliant":  compliant,
+    "violations": violations,
+}

--- a/frameworks/critical_infrastructure/iec_62443/part2_service_provider.rego
+++ b/frameworks/critical_infrastructure/iec_62443/part2_service_provider.rego
@@ -1,0 +1,191 @@
+package iec_62443.part2_4
+
+import rego.v1
+
+# =============================================================================
+# IEC 62443-2-4 — Security Program Requirements for IACS Service Providers
+#
+# Purpose: Define security requirements for IACS service providers (integrators,
+# maintenance contractors, OEMs, managed service providers) who design, install,
+# commission, maintain, or operate IACS on behalf of asset owners.
+#
+# Key Requirement Areas (SP requirements):
+#   SP.01 — Security management
+#   SP.02 — Physical security
+#   SP.03 — Personnel security
+#   SP.04 — Customer security requirements
+#   SP.05 — Remote access
+#   SP.06 — Temporary connections
+#   SP.07 — Security patching
+#   SP.08 — Malicious code protection
+#   SP.09 — Security event notification
+#   SP.10 — Security documentation
+#
+# Input shape:
+#   input.is_iacs_service_provider               - bool
+#   input.service_provider
+#     .security_program_documented               - bool
+#     .customer_security_requirements_reviewed   - bool
+#     .installation_protection_measures          - bool
+#     .remote_access_security_controlled         - bool
+#     .security_event_notification               - bool
+#     .personnel_background_checks               - bool
+#     .security_training_for_field_staff         - bool
+#     .portable_tool_security_policy             - bool
+#     .temporary_connection_policy               - bool
+#     .security_documentation_provided           - bool
+#     .vulnerability_disclosure_process          - bool
+#     .incident_notification_sla_hours           - int
+#     .remote_access_mfa_enforced                - bool
+#     .remote_session_audit_logged               - bool
+#     .malware_protection_on_tools               - bool
+#     .patch_qualification_for_supplied_systems  - bool
+# =============================================================================
+
+default compliant := false
+
+# Only evaluate if this is an IACS service provider context
+# (Asset owners may include this as a vendor assessment checklist)
+
+# ---------------------------------------------------------------------------
+# SP.01 — Security Management
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    input.is_iacs_service_provider == true
+    not input.service_provider.security_program_documented
+    msg := "IEC 62443-2-4 SP.01: IACS service provider has no documented security program. A formal security management program addressing all IEC 62443-2-4 requirements is required."
+}
+
+violations contains msg if {
+    input.is_iacs_service_provider == true
+    not input.service_provider.vulnerability_disclosure_process
+    msg := "IEC 62443-2-4 SP.01: No vulnerability disclosure process. The service provider must have a defined process for disclosing and responding to vulnerabilities in supplied IACS products or services."
+}
+
+# ---------------------------------------------------------------------------
+# SP.03 — Personnel Security
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    input.is_iacs_service_provider == true
+    not input.service_provider.personnel_background_checks
+    msg := "IEC 62443-2-4 SP.03: No background checks for IACS field personnel. Personnel with physical or logical access to customer IACS must undergo appropriate background screening."
+}
+
+violations contains msg if {
+    input.is_iacs_service_provider == true
+    not input.service_provider.security_training_for_field_staff
+    msg := "IEC 62443-2-4 SP.03: No security training for IACS field staff. Personnel performing IACS integration, installation, or maintenance must be trained on relevant cybersecurity practices."
+}
+
+# ---------------------------------------------------------------------------
+# SP.04 — Customer Security Requirements
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    input.is_iacs_service_provider == true
+    not input.service_provider.customer_security_requirements_reviewed
+    msg := "IEC 62443-2-4 SP.04: Customer IACS security requirements have not been reviewed. The service provider must formally review and acknowledge customer security requirements before commencing work."
+}
+
+violations contains msg if {
+    input.is_iacs_service_provider == true
+    not input.service_provider.security_documentation_provided
+    msg := "IEC 62443-2-4 SP.10: Security documentation has not been provided to the customer. Service providers must deliver security documentation (hardening guides, default credentials list, known vulnerabilities) for all supplied IACS components."
+}
+
+violations contains msg if {
+    input.is_iacs_service_provider == true
+    not input.service_provider.installation_protection_measures
+    msg := "IEC 62443-2-4 SP.04: No security measures during installation/commissioning. The service provider must implement appropriate security controls during IACS installation to prevent introduction of vulnerabilities."
+}
+
+# ---------------------------------------------------------------------------
+# SP.05 — Remote Access
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    input.is_iacs_service_provider == true
+    not input.service_provider.remote_access_security_controlled
+    msg := "IEC 62443-2-4 SP.05: Remote access to customer IACS is not security-controlled. All service provider remote access must go through customer-approved, auditable channels (VPN/jump host) with explicit session authorization."
+}
+
+violations contains msg if {
+    input.is_iacs_service_provider == true
+    not input.service_provider.remote_access_mfa_enforced
+    msg := "IEC 62443-2-4 SP.05: MFA is not enforced for service provider remote access. Multi-factor authentication is required for all remote IACS access by service providers."
+}
+
+violations contains msg if {
+    input.is_iacs_service_provider == true
+    not input.service_provider.remote_session_audit_logged
+    msg := "IEC 62443-2-4 SP.05: Remote service provider sessions are not audit logged. All remote access sessions must be logged and the logs made available to the asset owner."
+}
+
+# ---------------------------------------------------------------------------
+# SP.06 — Temporary Connections
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    input.is_iacs_service_provider == true
+    not input.service_provider.temporary_connection_policy
+    msg := "IEC 62443-2-4 SP.06: No policy for temporary connections to IACS. Laptops, diagnostic tools, and temporary devices connected to IACS must be controlled by a formal policy requiring malware scanning, configuration hardening, and session logging."
+}
+
+violations contains msg if {
+    input.is_iacs_service_provider == true
+    not input.service_provider.portable_tool_security_policy
+    msg := "IEC 62443-2-4 SP.06: No portable tool security policy. Service provider laptops and diagnostic tools used on IACS must be hardened, maintained, and free of unauthorized software."
+}
+
+violations contains msg if {
+    input.is_iacs_service_provider == true
+    not input.service_provider.malware_protection_on_tools
+    msg := "IEC 62443-2-4 SP.06/SP.08: Service provider portable tools lack malware protection. All tools connected to customer IACS must have current malware protection to prevent introduction of malicious code."
+}
+
+# ---------------------------------------------------------------------------
+# SP.07 — Security Patching for Supplied Systems
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    input.is_iacs_service_provider == true
+    not input.service_provider.patch_qualification_for_supplied_systems
+    msg := "IEC 62443-2-4 SP.07: No patch qualification process for supplied IACS systems. Service providers must qualify and communicate security patches for all IACS products they supply or maintain."
+}
+
+# ---------------------------------------------------------------------------
+# SP.09 — Security Event Notification
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    input.is_iacs_service_provider == true
+    not input.service_provider.security_event_notification
+    msg := "IEC 62443-2-4 SP.09: No security event notification capability. Service providers must notify asset owners of security events that may affect their IACS within defined timeframes."
+}
+
+violations contains msg if {
+    input.is_iacs_service_provider == true
+    input.service_provider.security_event_notification
+    input.service_provider.incident_notification_sla_hours > 24
+    msg := sprintf(
+        "IEC 62443-2-4 SP.09: Security event notification SLA is %v hours. Service providers must notify asset owners of critical security events within 24 hours; immediately for active incidents.",
+        [input.service_provider.incident_notification_sla_hours]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Compliance Aggregation
+# ---------------------------------------------------------------------------
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "part":                     "IEC 62443-2-4",
+    "title":                    "Security Program Requirements for IACS Service Providers",
+    "standard":                 "IEC 62443-2-4",
+    "is_iacs_service_provider": input.is_iacs_service_provider,
+    "compliant":                compliant,
+    "violations":               violations,
+}

--- a/frameworks/critical_infrastructure/iec_62443/part3_risk_assessment.rego
+++ b/frameworks/critical_infrastructure/iec_62443/part3_risk_assessment.rego
@@ -1,0 +1,188 @@
+package iec_62443.part3_2
+
+import rego.v1
+
+# =============================================================================
+# IEC 62443-3-2 — Security Risk Assessment for System Design
+#
+# Purpose: Define a methodology for conducting security risk assessments for
+# IACS systems. This standard bridges the gap between the high-level CSMS
+# requirements (Part 2-1) and the system-level security requirements (Part 3-3)
+# by providing a structured approach to identifying zones, conduits, target
+# security levels, and residual risk.
+#
+# Key Requirement Areas:
+#   - System partitioning (zone and conduit definition)
+#   - Target security level (SL-T) assignment
+#   - Risk assessment methodology
+#   - Residual risk evaluation
+#   - High-level security requirements derivation
+#
+# Input shape:
+#   input.risk_assessment
+#     .conducted                              - bool
+#     .cyber_risk_identified                  - bool
+#     .threat_modeling_performed              - bool
+#     .vulnerability_assessment_performed     - bool
+#     .residual_risk_accepted                 - bool
+#     .review_frequency_months                - int
+#     .asset_inventory_complete               - bool
+#     .consequence_analysis_performed         - bool
+#     .zones_and_conduits_defined             - bool
+#     .target_sl_assigned_per_zone            - bool
+#     .high_level_security_requirements       - bool
+#     .third_party_review                     - bool
+#   input.zones[]
+#     .name                                   - string
+#     .security_level_defined                 - bool
+#     .security_level                         - int
+#     .risk_assessment_documented             - bool
+#   input.target_sl                           - int (1–4)
+# =============================================================================
+
+default compliant := false
+
+# ---------------------------------------------------------------------------
+# Initial Cybersecurity Risk Assessment (ZCR 1)
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.risk_assessment.conducted
+    msg := "IEC 62443-3-2 ZCR 1: No cybersecurity risk assessment has been conducted. A formal risk assessment is the foundation for all IEC 62443 security decisions and must precede system design or security level assignment."
+}
+
+violations contains msg if {
+    not input.risk_assessment.asset_inventory_complete
+    msg := "IEC 62443-3-2 ZCR 1: Asset inventory is incomplete. A complete inventory of all IACS assets (hardware, software, firmware, communication paths) is a prerequisite for risk assessment."
+}
+
+violations contains msg if {
+    not input.risk_assessment.threat_modeling_performed
+    msg := "IEC 62443-3-2 ZCR 1: No threat modeling performed. Threat modeling (identifying threat actors, threat vectors, and attack scenarios) is required to understand the IACS threat landscape."
+}
+
+violations contains msg if {
+    not input.risk_assessment.consequence_analysis_performed
+    msg := "IEC 62443-3-2 ZCR 1: No consequence analysis performed. The impact of potential cyber incidents on safety, operations, environment, financial, and reputation must be analyzed."
+}
+
+violations contains msg if {
+    not input.risk_assessment.vulnerability_assessment_performed
+    msg := "IEC 62443-3-2 ZCR 1: No vulnerability assessment performed. Identify vulnerabilities in IACS components through analysis of known CVEs, configuration weaknesses, and architectural gaps."
+}
+
+violations contains msg if {
+    not input.risk_assessment.cyber_risk_identified
+    msg := "IEC 62443-3-2 ZCR 1: IACS cybersecurity risks have not been formally identified and documented. Risk register with likelihood, consequence, and risk rating is required."
+}
+
+# ---------------------------------------------------------------------------
+# System Partitioning — Zone and Conduit Definition (ZCR 2)
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.risk_assessment.zones_and_conduits_defined
+    msg := "IEC 62443-3-2 ZCR 2: Zones and conduits have not been formally defined. Partitioning the IACS into security zones and defining conduits between zones is a core IEC 62443 architectural requirement."
+}
+
+violations contains msg if {
+    count(input.zones) == 0
+    msg := "IEC 62443-3-2 ZCR 2: No security zones defined. The IACS must be divided into security zones based on criticality, function, and required security level."
+}
+
+violations contains msg if {
+    some zone in input.zones
+    not zone.risk_assessment_documented
+    msg := sprintf(
+        "IEC 62443-3-2 ZCR 2: Zone '%v' has no documented risk assessment. Each zone must have a zone-specific risk assessment driving its target security level assignment.",
+        [zone.name]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Target Security Level Assignment (ZCR 3)
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.risk_assessment.target_sl_assigned_per_zone
+    msg := "IEC 62443-3-2 ZCR 3: Target security levels (SL-T) have not been assigned per zone. Each zone must have a SL-T derived from the risk assessment results (SL 1–4)."
+}
+
+violations contains msg if {
+    some zone in input.zones
+    not zone.security_level_defined
+    msg := sprintf(
+        "IEC 62443-3-2 ZCR 3: Zone '%v' does not have a defined security level. All zones must have an explicit SL-T (1–4) based on the zone risk assessment.",
+        [zone.name]
+    )
+}
+
+# Validate that high-criticality zones have appropriate SL
+violations contains msg if {
+    some zone in input.zones
+    zone.criticality == "high"
+    zone.security_level < 2
+    msg := sprintf(
+        "IEC 62443-3-2 ZCR 3: High-criticality zone '%v' has Security Level %v. High-criticality IACS zones should have SL-T of at least 2 (SL 3 or 4 recommended for BES and safety-critical systems).",
+        [zone.name, zone.security_level]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# High-Level Security Requirements (ZCR 4)
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.risk_assessment.high_level_security_requirements
+    msg := "IEC 62443-3-2 ZCR 4: High-level security requirements (HLSRs) have not been derived from the risk assessment. HLSRs form the basis for selecting and implementing specific security controls (mapped to IEC 62443-3-3 SRs)."
+}
+
+# ---------------------------------------------------------------------------
+# Residual Risk Evaluation (ZCR 5)
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    not input.risk_assessment.residual_risk_accepted
+    msg := "IEC 62443-3-2 ZCR 5: Residual risk after security control implementation has not been formally evaluated and accepted. Senior management must accept documented residual risk."
+}
+
+# ---------------------------------------------------------------------------
+# Periodic Review
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    input.risk_assessment.conducted
+    input.risk_assessment.review_frequency_months > 24
+    msg := sprintf(
+        "IEC 62443-3-2: Risk assessment review cycle is %v months. IACS risk assessments must be reviewed at least every 24 months and after significant changes (new systems, topology changes, incident).",
+        [input.risk_assessment.review_frequency_months]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Third-Party Review (recommended for SL 3+)
+# ---------------------------------------------------------------------------
+
+violations contains msg if {
+    input.target_sl >= 3
+    not input.risk_assessment.third_party_review
+    msg := sprintf(
+        "IEC 62443-3-2 (SL%v): Risk assessment has not been reviewed by an independent third party. At Security Level 3+, an independent review by a qualified ICS security assessor is strongly recommended.",
+        [input.target_sl]
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Compliance Aggregation
+# ---------------------------------------------------------------------------
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "part":       "IEC 62443-3-2",
+    "title":      "Security Risk Assessment for System Design",
+    "standard":   "IEC 62443-3-2",
+    "target_sl":  input.target_sl,
+    "compliant":  compliant,
+    "violations": violations,
+}


### PR DESCRIPTION
## Summary

- Expands IEC 62443 from a single monolithic file to a **12-module library** covering all 51 System Requirements (SRs) from Part 3-3 and all Part 2 management requirements
- All 7 Foundational Requirements (FR 1–FR 7) in individual files with full SR coverage and Security Level (SL 1–4) tiered enforcement
- Part 2 management suite: CSMS (2-1), Patch Management (2-3), Service Provider (2-4)
- Part 3-2 Risk Assessment methodology (ZCR 1–5)
- Main orchestrator aggregates all modules; OPA endpoint: `POST /v1/data/iec_62443_main/iec_62443_compliance_report`
- README updated: policy count 332→343, new IEC 62443 coverage table and NERC-CIP section

## New files

| File | Coverage |
|------|----------|
| `fr1_identification_authentication.rego` | SR 1.1–1.13 (13 SRs) |
| `fr2_use_control.rego` | SR 2.1–2.12 (12 SRs) |
| `fr3_system_integrity.rego` | SR 3.1–3.9 (9 SRs) |
| `fr4_data_confidentiality.rego` | SR 4.1–4.3 (3 SRs) |
| `fr5_restricted_data_flow.rego` | SR 5.1–5.4 (4 SRs) — zone/conduit model |
| `fr6_timely_response.rego` | SR 6.1–6.2 (2 SRs) |
| `fr7_resource_availability.rego` | SR 7.1–7.8 (8 SRs) |
| `part2_security_management.rego` | IEC 62443-2-1 CSMS |
| `part2_patch_management.rego` | IEC 62443-2-3 OT patch mgmt |
| `part2_service_provider.rego` | IEC 62443-2-4 SP.01–SP.10 |
| `part3_risk_assessment.rego` | IEC 62443-3-2 ZCR 1–5 |
| `iec_62443_main.rego` | Orchestrator (replaces single-file implementation) |

## Test plan

- [x] All 12 files pass `opa check` (validated by pre-commit hook)
- [ ] Load into `opa-ot` container (`:8183`) and query `/v1/data/iec_62443_main/iec_62443_compliance_report` with sample input
- [ ] Verify SL-tiered violations fire correctly at SL 1, 2, 3, 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)