### PR TITLE
fix: add Sentinel demo template IDs 102-105 to MCP allowlist

### DIFF
--- a/governance/mcp/mcp_governance.rego
+++ b/governance/mcp/mcp_governance.rego
@@ -64,6 +64,7 @@ approved_template_ids := {
     115,                   # IEC 62443 Assessment
     116,                   # CIP-010 Baseline Capture/Check
     117,                   # CIP-008 Incident Response Evidence
+    102, 103, 104, 105,    # Sentinel: runtime block, audit sweep, AI governance, preflight
     121,                   # AAC - Seed Golden Image Workflow
     122, 123, 124,         # Golden Image: Check, Rollback, Notify Help Desk
     125,                   # AAC - Golden Image Enforcement (workflow)


### PR DESCRIPTION
## Summary
- Adds templates 102 (runtime block), 103 (audit sweep), 104 (AI governance), 105 (preflight) to `approved_template_ids`
- These IDs were reassigned on the 2026-03-28 fresh install; old IDs 34/35/36/38 are still present for backward compat

## Test plan
- [ ] Merge and reload OPA via Template 27
- [ ] Confirm `mcp__aap__api_job_templates_launch_create` with id=105 succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)