### PR TITLE
fix: Copilot must-fix — LICENSE, CI hardening, Makefile exit codes, SOX package collision, boolean defaults

### DIFF
--- a/.github/workflows/opa-test.yml
+++ b/.github/workflows/opa-test.yml
@@ -11,6 +11,9 @@ on:
     paths:
       - '**/*.rego'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Check and Test Rego Policies
@@ -18,13 +21,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Install OPA
         run: |
-          curl -L -o opa https://github.com/open-policy-agent/opa/releases/download/v0.68.0/opa_linux_amd64_static
+          OPA_VERSION=v0.68.0
+          curl -L -o opa \
+            "https://github.com/open-policy-agent/opa/releases/download/${OPA_VERSION}/opa_linux_amd64_static"
+          curl -L -o opa.sha256 \
+            "https://github.com/open-policy-agent/opa/releases/download/${OPA_VERSION}/opa_linux_amd64_static.sha256"
+          sha256sum -c opa.sha256
           chmod +x opa
           sudo mv opa /usr/local/bin/
+          rm -f opa.sha256
           opa version
 
       - name: Syntax check — benchmarks
@@ -70,12 +79,14 @@ jobs:
       - name: Run policy tests
         run: |
           echo "Running tests ..."
-          find . -name "*_test.rego" -not -path "./.git/*" | while read f; do
+          RC=0
+          for f in $(find . -name "*_test.rego" -not -path "./.git/*"); do
             dir=$(dirname "$f")
             echo "  Testing $dir ..."
-            opa test "$dir" -v || true
+            opa test "$dir" -v || RC=1
           done
           echo "Tests complete"
+          exit $RC
 
       - name: Count policies
         run: |

--- a/.github/workflows/opa-test.yml
+++ b/.github/workflows/opa-test.yml
@@ -26,13 +26,14 @@ jobs:
       - name: Install OPA
         run: |
           OPA_VERSION=v0.68.0
-          curl -L -o opa \
+          # Download under the original filename so sha256sum -c can find it
+          curl -L -o opa_linux_amd64_static \
             "https://github.com/open-policy-agent/opa/releases/download/${OPA_VERSION}/opa_linux_amd64_static"
           curl -L -o opa.sha256 \
             "https://github.com/open-policy-agent/opa/releases/download/${OPA_VERSION}/opa_linux_amd64_static.sha256"
           sha256sum -c opa.sha256
-          chmod +x opa
-          sudo mv opa /usr/local/bin/
+          chmod +x opa_linux_amd64_static
+          sudo mv opa_linux_amd64_static /usr/local/bin/opa
           rm -f opa.sha256
           opa version
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,185 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as submitted to the Licensor for inclusion
+      in the Work by the copyright owner or by an individual or Legal Entity
+      authorized to submit on behalf of the copyright owner. For the purposes
+      of this definition, "submitted" means any form of electronic, verbal,
+      or written communication sent to the Licensor or its representatives,
+      including but not limited to communication on electronic mailing lists,
+      source code control systems, and issue tracking systems that are managed
+      by, or on behalf of, the Licensor for the purpose of discussing and
+      improving the Work, but excluding communication that is conspicuously
+      marked or designated in writing by the copyright owner as "Not a
+      Contribution."
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and included
+      within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by the combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a cross-claim
+      or counterclaim in a lawsuit) alleging that the Work or any other
+      Contribution incorporated within the Work constitutes patent or
+      contributory patent infringement, then any patent licenses granted to
+      You under this License for that Work shall terminate as of the date
+      such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the
+          attribution notices contained within such NOTICE file, in
+          at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within
+          the Source form or documentation, if provided along with the
+          Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+          You may add Your own attribution notices within Derivative
+          Works that You distribute, alongside or in addition to the
+          NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the
+          License.
+
+      You may add Your own license statement for Your modifications and
+      may provide additional grant of rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of the
+      Contribution, either exclusively or together with the above rights
+      subject to these terms.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or reproducing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or all other
+      commercial damages or losses), even if such Contributor has been
+      advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may charge
+      only on Your behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2024 Red Hat, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -17,17 +17,25 @@ help:
 
 lint:
 	@echo "=== Checking syntax of all .rego files ==="
-	@find . -name "*.rego" -not -path "./.git/*" | sort | while read f; do \
-	  $(OPA) check "$$f" 2>&1 && echo "  OK: $$f" || echo "  FAIL: $$f"; \
-	done
-	@echo "Done."
+	@RC=0; \
+	for f in $$(find . -name "*.rego" -not -path "./.git/*" | sort); do \
+	  if $(OPA) check "$$f" 2>&1; then \
+	    echo "  OK: $$f"; \
+	  else \
+	    echo "  FAIL: $$f"; \
+	    RC=1; \
+	  fi; \
+	done; \
+	exit $$RC
 
 test:
 	@echo "=== Running OPA tests ==="
-	@find . -name "*_test.rego" -not -path "./.git/*" | while read f; do \
+	@RC=0; \
+	for f in $$(find . -name "*_test.rego" -not -path "./.git/*"); do \
 	  dir=$$(dirname $$f); \
-	  $(OPA) test $$dir -v 2>&1; \
-	done
+	  $(OPA) test $$dir -v 2>&1 || RC=1; \
+	done; \
+	exit $$RC
 
 check: lint test
 

--- a/frameworks/financial/sox/sox_main.rego
+++ b/frameworks/financial/sox/sox_main.rego
@@ -6,6 +6,8 @@ import rego.v1
 # Main aggregation policy for SOX compliance assessment
 
 # Overall SOX compliance evaluation
+default sox_compliant := false
+
 sox_compliant if {
     section_302_compliant
     section_404_compliant
@@ -14,6 +16,8 @@ sox_compliant if {
 }
 
 # Section 302: Corporate Responsibility for Financial Reports
+default section_302_compliant := false
+
 section_302_compliant if {
     data.sox.section_302.ceo_certification.provided
     data.sox.section_302.cfo_certification.provided
@@ -22,6 +26,8 @@ section_302_compliant if {
 }
 
 # Section 404: Management Assessment of Internal Controls
+default section_404_compliant := false
+
 section_404_compliant if {
     data.sox.section_404.management_assessment.completed
     data.sox.section_404.internal_controls.designed_effectively
@@ -30,6 +36,8 @@ section_404_compliant if {
 }
 
 # Section 409: Real-time Issuer Disclosures
+default section_409_compliant := false
+
 section_409_compliant if {
     data.sox.section_409.material_events.disclosed_timely
     data.sox.section_409.disclosure_process.automated
@@ -37,6 +45,8 @@ section_409_compliant if {
 }
 
 # Management Assessment Framework
+default management_assessment_compliant := false
+
 management_assessment_compliant if {
     data.sox.management.assessment_framework.documented
     data.sox.management.testing_procedures.comprehensive

--- a/frameworks/financial/sox/sox_simplified.rego
+++ b/frameworks/financial/sox/sox_simplified.rego
@@ -1,4 +1,4 @@
-package sox.main
+package sox.simplified
 
 import rego.v1
 
@@ -6,6 +6,8 @@ import rego.v1
 # Main policy for SOX compliance assessment
 
 # Overall SOX compliance evaluation
+default sox_compliant := false
+
 sox_compliant if {
     section_302_compliant
     section_404_compliant
@@ -14,6 +16,8 @@ sox_compliant if {
 }
 
 # Section 302: Corporate Responsibility for Financial Reports
+default section_302_compliant := false
+
 section_302_compliant if {
     input.sox.section_302.ceo_certification.provided
     input.sox.section_302.cfo_certification.provided
@@ -22,6 +26,8 @@ section_302_compliant if {
 }
 
 # Section 404: Management Assessment of Internal Controls
+default section_404_compliant := false
+
 section_404_compliant if {
     input.sox.section_404.management_assessment.completed
     input.sox.section_404.internal_controls.designed_effectively
@@ -30,6 +36,8 @@ section_404_compliant if {
 }
 
 # Section 409: Real-time Issuer Disclosures
+default section_409_compliant := false
+
 section_409_compliant if {
     input.sox.section_409.material_events.disclosed_timely
     input.sox.section_409.disclosure_process.automated
@@ -37,6 +45,8 @@ section_409_compliant if {
 }
 
 # IT General Controls (ITGC) Compliance
+default itgc_compliant := false
+
 itgc_compliant if {
     input.sox.itgc.access_controls.implemented
     input.sox.itgc.change_management.controlled


### PR DESCRIPTION
## Summary

Addresses all Copilot must-fix items from the latest code review:

- **LICENSE**: Add Apache-2.0 full text to match README claims
- **CI test enforcement**: Remove `|| true` from `Run policy tests` step — test failures now block merge; use `for` loop to preserve exit code from the pipeline subshell
- **Makefile**: `lint` and `test` targets now exit non-zero when any file fails (switch from `while read` pipeline to `for` loop so `RC` variable persists)
- **Workflow hardening**: Pin `actions/checkout` to commit SHA (`11bd719` = v4.2.2), add `permissions: contents: read`, verify OPA binary with official `.sha256` checksum file
- **SOX package collision**: Rename `sox_simplified.rego` package from `sox.main` to `sox.simplified` — eliminates OPA `eval_conflict_error` when both files are loaded
- **Boolean defaults**: Add `default := false` to all boolean helper predicates in `sox_main.rego` and `sox_simplified.rego` (`sox_compliant`, `section_302_compliant`, `section_404_compliant`, `section_409_compliant`, `itgc_compliant`, `management_assessment_compliant`) — prevents `undefined` report objects

## Test plan
- [ ] `make lint` exits 0 on valid policies, non-zero on syntax errors
- [ ] `make test` exits non-zero if any `*_test.rego` fails
- [ ] `opa check frameworks/financial/sox/` returns no errors (no package collision)
- [ ] CI workflow passes on push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)