### PR TITLE
feat: add debt scoring for 10 new compliance frameworks

### DIFF
--- a/benchmarks/cis/cloud/gcp/cis_gcp_main.rego
+++ b/benchmarks/cis/cloud/gcp/cis_gcp_main.rego
@@ -1,0 +1,407 @@
+package cis_gcp.main
+
+import rego.v1
+
+# CIS Google Cloud Platform Foundation Benchmark v2.0.0
+# Published: March 2023
+#
+# Covers GCP services and configurations across:
+#   1. IAM                     — Identity and Access Management
+#   2. Logging                 — Audit logging and monitoring
+#   3. Networking              — VPC, firewall, and network controls
+#   4. Virtual Machines        — Compute Engine security
+#   5. Storage                 — Cloud Storage bucket controls
+#   6. Cloud SQL               — Database security
+#   7. BigQuery                — Analytics data protection
+#   8. GKE                     — Google Kubernetes Engine
+#
+# OPA endpoint: POST http://<host>:8181/v1/data/cis_gcp/main/compliance_report
+
+default compliant := false
+
+compliant if {
+    count(violations) == 0
+}
+
+# ── Section 1 — Identity and Access Management ────────────────────────────────
+
+# 1.1 — Ensure that Corporate Login Credentials are used
+violations contains msg if {
+    not input.iam.corporate_login.enforced
+    msg := "CIS GCP 1.1: Corporate login credentials not enforced — personal Gmail accounts should not have project access"
+}
+
+# 1.2 — Ensure that multi-factor authentication is enabled for all non-service accounts
+violations contains msg if {
+    not input.iam.mfa.enforced_for_users
+    msg := "CIS GCP 1.2: MFA not enforced for all non-service account users"
+}
+
+# 1.3 — Ensure that Security Key Enforcement is enabled for all admin accounts
+violations contains msg if {
+    not input.iam.security_key.admin_accounts
+    msg := "CIS GCP 1.3: Security key (phishing-resistant MFA) not enforced for admin accounts"
+}
+
+# 1.4 — Ensure that Service Account does not have Admin privileges
+violations contains msg if {
+    not input.iam.service_accounts.no_admin_roles
+    msg := "CIS GCP 1.4: One or more service accounts have admin/owner roles — violates least privilege"
+}
+
+# 1.5 — Ensure that Service Account Keys are not created for users
+violations contains msg if {
+    not input.iam.service_account_keys.user_managed_restricted
+    msg := "CIS GCP 1.5: User-managed service account keys exist — prefer Google-managed keys"
+}
+
+# 1.6 — Ensure that Service Account Keys are rotated within 90 days
+violations contains msg if {
+    not input.iam.service_account_keys.rotation_90_days
+    msg := "CIS GCP 1.6: Service account keys not rotated within 90 days"
+}
+
+# 1.7 — Ensure that Separation of duties is enforced while assigning Service Account related roles to users
+violations contains msg if {
+    not input.iam.service_accounts.separation_of_duties
+    msg := "CIS GCP 1.7: Same user can create and use service accounts — separation of duties not enforced"
+}
+
+# 1.8 — Ensure that Cloud KMS cryptokeys are not anonymously or publicly accessible
+violations contains msg if {
+    not input.iam.kms_keys.no_public_access
+    msg := "CIS GCP 1.8: Cloud KMS cryptokeys accessible by allUsers or allAuthenticatedUsers"
+}
+
+# 1.9 — Ensure that Cloud KMS keys are rotated within 90 days
+violations contains msg if {
+    not input.iam.kms_keys.rotation_90_days
+    msg := "CIS GCP 1.9: Cloud KMS keys not configured for automatic rotation within 90 days"
+}
+
+# 1.10 — Ensure KMS encryption keys are protected from deletion
+violations contains msg if {
+    not input.iam.kms_keys.deletion_protection
+    msg := "CIS GCP 1.10: KMS encryption keys not protected against accidental deletion"
+}
+
+# 1.11 — Ensure that Workload Identity is used for GKE and other workloads
+violations contains msg if {
+    not input.iam.workload_identity.enabled
+    msg := "CIS GCP 1.11: Workload Identity not used — service account key files in workloads is insecure"
+}
+
+# ── Section 2 — Logging ────────────────────────────────────────────────────────
+
+# 2.1 — Ensure that Cloud Audit Logs are configured properly
+violations contains msg if {
+    not input.logging.audit_logs.data_access_enabled
+    msg := "CIS GCP 2.1: Cloud Audit Logs Data Access logging not enabled for all services"
+}
+
+# 2.2 — Ensure that sinks are configured for all log entries
+violations contains msg if {
+    not input.logging.sinks.configured
+    msg := "CIS GCP 2.2: Log sink not configured to export all log entries to a long-term storage destination"
+}
+
+# 2.3 — Ensure that retention policies on log buckets are configured using Bucket Lock
+violations contains msg if {
+    not input.logging.retention.bucket_lock_enabled
+    msg := "CIS GCP 2.3: Log bucket lock (retention policy) not enabled to prevent log tampering"
+}
+
+# 2.4 — Ensure log metric filters and alerts exist for project ownership changes
+violations contains msg if {
+    not input.logging.alerts.project_ownership_changes
+    msg := "CIS GCP 2.4: No metric filter/alert for project ownership assignment or changes"
+}
+
+# 2.5 — Ensure log metric filters and alerts exist for audit configuration changes
+violations contains msg if {
+    not input.logging.alerts.audit_config_changes
+    msg := "CIS GCP 2.5: No metric filter/alert for audit configuration changes"
+}
+
+# 2.6 — Ensure log metric filters and alerts exist for custom role changes
+violations contains msg if {
+    not input.logging.alerts.custom_role_changes
+    msg := "CIS GCP 2.6: No metric filter/alert for custom IAM role creation, modification, or deletion"
+}
+
+# 2.7 — Ensure log metric filters and alerts exist for VPC network changes
+violations contains msg if {
+    not input.logging.alerts.vpc_network_changes
+    msg := "CIS GCP 2.7: No metric filter/alert for VPC network changes"
+}
+
+# 2.8 — Ensure log metric filters and alerts exist for VPC network route changes
+violations contains msg if {
+    not input.logging.alerts.vpc_route_changes
+    msg := "CIS GCP 2.8: No metric filter/alert for VPC network route changes"
+}
+
+# 2.9 — Ensure log metric filters and alerts exist for VPC network firewall rule changes
+violations contains msg if {
+    not input.logging.alerts.firewall_rule_changes
+    msg := "CIS GCP 2.9: No metric filter/alert for VPC firewall rule changes"
+}
+
+# 2.10 — Ensure log metric filters and alerts exist for Cloud Storage IAM permission changes
+violations contains msg if {
+    not input.logging.alerts.storage_iam_changes
+    msg := "CIS GCP 2.10: No metric filter/alert for Cloud Storage bucket IAM permission changes"
+}
+
+# 2.11 — Ensure log metric filters and alerts exist for SQL instance configuration changes
+violations contains msg if {
+    not input.logging.alerts.sql_config_changes
+    msg := "CIS GCP 2.11: No metric filter/alert for Cloud SQL instance configuration changes"
+}
+
+# ── Section 3 — Networking ─────────────────────────────────────────────────────
+
+# 3.1 — Ensure that the default network does not exist in a project
+violations contains msg if {
+    not input.networking.default_network.deleted
+    msg := "CIS GCP 3.1: Default network exists in the project — delete default network and use custom VPCs"
+}
+
+# 3.2 — Ensure that Legacy Networks do not exist in a project
+violations contains msg if {
+    not input.networking.legacy_networks.none_exist
+    msg := "CIS GCP 3.2: Legacy network exists in project — migrate to VPC networks"
+}
+
+# 3.3 — Ensure that DNSSEC is enabled for Cloud DNS
+violations contains msg if {
+    not input.networking.dns.dnssec_enabled
+    msg := "CIS GCP 3.3: DNSSEC not enabled for Cloud DNS managed zones"
+}
+
+# 3.4 — Ensure that RSASHA1 is not used for the key-signing key in Cloud DNS
+violations contains msg if {
+    not input.networking.dns.no_rsasha1_key_signing
+    msg := "CIS GCP 3.4: RSASHA1 algorithm used for DNSSEC key-signing key — use stronger algorithm"
+}
+
+# 3.5 — Ensure that RSASHA1 is not used for the zone-signing key in Cloud DNS
+violations contains msg if {
+    not input.networking.dns.no_rsasha1_zone_signing
+    msg := "CIS GCP 3.5: RSASHA1 algorithm used for DNSSEC zone-signing key — use stronger algorithm"
+}
+
+# 3.6 — Ensure that SSH access is restricted from the internet
+violations contains msg if {
+    not input.networking.firewall.ssh_not_from_internet
+    msg := "CIS GCP 3.6: Firewall rule allows SSH (port 22) from 0.0.0.0/0 or ::/0"
+}
+
+# 3.7 — Ensure that RDP access is restricted from the internet
+violations contains msg if {
+    not input.networking.firewall.rdp_not_from_internet
+    msg := "CIS GCP 3.7: Firewall rule allows RDP (port 3389) from 0.0.0.0/0 or ::/0"
+}
+
+# 3.8 — Ensure that VPC Flow Logs is enabled for every subnet in a VPC Network
+violations contains msg if {
+    not input.networking.vpc.flow_logs_enabled
+    msg := "CIS GCP 3.8: VPC Flow Logs not enabled on all subnets"
+}
+
+# 3.9 — Ensure no HTTPS or SSL proxy load balancers permit SSL policies with weak cipher suites
+violations contains msg if {
+    not input.networking.load_balancer.no_weak_ssl_policies
+    msg := "CIS GCP 3.9: Load balancer SSL policy permits weak cipher suites or deprecated TLS versions"
+}
+
+# ── Section 4 — Virtual Machines ──────────────────────────────────────────────
+
+# 4.1 — Ensure that instances are not configured to use the default service account with full access to Cloud APIs
+violations contains msg if {
+    not input.compute.instances.no_default_sa_full_access
+    msg := "CIS GCP 4.1: VM instances use default service account with full API access scope"
+}
+
+# 4.2 — Ensure that instances are not configured to use the default service account
+violations contains msg if {
+    not input.compute.instances.no_default_service_account
+    msg := "CIS GCP 4.2: VM instances using default service account — create dedicated per-workload service accounts"
+}
+
+# 4.3 — Ensure 'Enable connecting to serial ports' is not enabled on VM instance
+violations contains msg if {
+    not input.compute.instances.serial_port_disabled
+    msg := "CIS GCP 4.3: Serial port access enabled on one or more VM instances — disable except for debugging"
+}
+
+# 4.4 — Ensure that Compute instances do not have public IP addresses
+violations contains msg if {
+    not input.compute.instances.no_public_ip
+    msg := "CIS GCP 4.4: Compute instances have public IP addresses — use Cloud NAT or IAP for external connectivity"
+}
+
+# 4.5 — Ensure that Compute instances have Confidential Computing enabled
+violations contains msg if {
+    not input.compute.instances.confidential_computing
+    msg := "CIS GCP 4.5: Confidential Computing (memory encryption) not enabled on sensitive workload VMs"
+}
+
+# 4.6 — Ensure that Compute instances are launched with Shielded VM enabled
+violations contains msg if {
+    not input.compute.instances.shielded_vm.enabled
+    msg := "CIS GCP 4.6: Shielded VM (Secure Boot, vTPM, Integrity Monitoring) not enabled on instances"
+}
+
+# 4.7 — Ensure OS login is enabled for a project
+violations contains msg if {
+    not input.compute.os_login.enabled
+    msg := "CIS GCP 4.7: OS Login not enabled — centralized SSH key management via IAM not enforced"
+}
+
+# ── Section 5 — Storage ────────────────────────────────────────────────────────
+
+# 5.1 — Ensure that Cloud Storage bucket is not anonymously or publicly accessible
+violations contains msg if {
+    not input.storage.buckets.no_public_access
+    msg := "CIS GCP 5.1: Cloud Storage bucket accessible by allUsers or allAuthenticatedUsers"
+}
+
+# 5.2 — Ensure that Cloud Storage buckets have uniform bucket-level access enabled
+violations contains msg if {
+    not input.storage.buckets.uniform_access
+    msg := "CIS GCP 5.2: Uniform bucket-level access not enabled — object-level ACLs create inconsistent controls"
+}
+
+# 5.3 — Ensure that logging is enabled for Cloud Storage buckets with sensitive data
+violations contains msg if {
+    not input.storage.buckets.access_logging
+    msg := "CIS GCP 5.3: Access logging not enabled on Cloud Storage buckets containing sensitive data"
+}
+
+# ── Section 6 — Cloud SQL ──────────────────────────────────────────────────────
+
+# 6.1 — Ensure that Cloud SQL database instance requires all incoming connections to use SSL
+violations contains msg if {
+    not input.cloud_sql.ssl.require_ssl
+    msg := "CIS GCP 6.1: Cloud SQL database instance does not require SSL for all connections"
+}
+
+# 6.2 — Ensure that Cloud SQL database instances are not open to the world
+violations contains msg if {
+    not input.cloud_sql.authorized_networks.no_public_access
+    msg := "CIS GCP 6.2: Cloud SQL authorized network allows 0.0.0.0/0 — restrict to known IPs"
+}
+
+# 6.3 — Ensure that Cloud SQL database instances do not have public IPs
+violations contains msg if {
+    not input.cloud_sql.private_ip.enabled
+    msg := "CIS GCP 6.3: Cloud SQL instances use public IP — configure private IP connectivity"
+}
+
+# 6.4 — Ensure that Cloud SQL database instances are configured with automated backups
+violations contains msg if {
+    not input.cloud_sql.backups.automated
+    msg := "CIS GCP 6.4: Automated backups not enabled on Cloud SQL instances"
+}
+
+# 6.5 — Ensure that Cloud SQL database instances are not using publicly accessible IP addresses
+violations contains msg if {
+    not input.cloud_sql.flags.no_dangerous_flags
+    msg := "CIS GCP 6.5: Cloud SQL database flags set to insecure values (e.g., local_infile=on, log_checkpoints=off)"
+}
+
+# ── Section 7 — BigQuery ────────────────────────────────────────────────────────
+
+# 7.1 — Ensure that BigQuery datasets are not anonymously or publicly accessible
+violations contains msg if {
+    not input.bigquery.datasets.no_public_access
+    msg := "CIS GCP 7.1: BigQuery dataset accessible by allUsers or allAuthenticatedUsers"
+}
+
+# 7.2 — Ensure that all BigQuery tables are encrypted with Customer Managed Encryption Keys (CMEK)
+violations contains msg if {
+    not input.bigquery.encryption.cmek_enabled
+    msg := "CIS GCP 7.2: BigQuery tables with sensitive data not encrypted with Customer Managed Encryption Keys"
+}
+
+# ── Section 8 — Google Kubernetes Engine ──────────────────────────────────────
+
+# 8.1 — Ensure Stackdriver Logging is set to Enabled on Kubernetes Engine Clusters
+violations contains msg if {
+    not input.gke.logging.enabled
+    msg := "CIS GCP 8.1: Cloud Logging (Stackdriver) not enabled on GKE clusters"
+}
+
+# 8.2 — Ensure Stackdriver Monitoring is set to Enabled on Kubernetes Engine Clusters
+violations contains msg if {
+    not input.gke.monitoring.enabled
+    msg := "CIS GCP 8.2: Cloud Monitoring (Stackdriver) not enabled on GKE clusters"
+}
+
+# 8.3 — Ensure Legacy Authorization is set to Disabled on Kubernetes Engine Clusters
+violations contains msg if {
+    not input.gke.legacy_abac.disabled
+    msg := "CIS GCP 8.3: Legacy Authorization (ABAC) not disabled on GKE cluster — use RBAC"
+}
+
+# 8.4 — Ensure Master Authorized Networks is enabled
+violations contains msg if {
+    not input.gke.master_authorized_networks.enabled
+    msg := "CIS GCP 8.4: Master Authorized Networks not enabled — GKE control plane accessible from any IP"
+}
+
+# 8.5 — Ensure Kubernetes Clusters are configured with Labels
+violations contains msg if {
+    not input.gke.cluster.labels_configured
+    msg := "CIS GCP 8.5: GKE cluster resource labels not configured for cost attribution and governance"
+}
+
+# 8.6 — Ensure Automatic Node Repair is enabled on all node pools
+violations contains msg if {
+    not input.gke.node_pools.auto_repair
+    msg := "CIS GCP 8.6: Automatic node repair not enabled on GKE node pools"
+}
+
+# 8.7 — Ensure Automatic Node Upgrades is enabled on node pools
+violations contains msg if {
+    not input.gke.node_pools.auto_upgrade
+    msg := "CIS GCP 8.7: Automatic node upgrades not enabled on GKE node pools"
+}
+
+# 8.8 — Ensure Container-Optimized OS is used for Kubernetes Engine Cluster Node image
+violations contains msg if {
+    not input.gke.node_pools.cos_image
+    msg := "CIS GCP 8.8: GKE node pools not using Container-Optimized OS (COS) image"
+}
+
+# 8.9 — Ensure Workload Identity is enabled on GKE clusters
+violations contains msg if {
+    not input.gke.workload_identity.enabled
+    msg := "CIS GCP 8.9: Workload Identity not enabled on GKE cluster — pods using node service account instead"
+}
+
+# ── Compliance Report ────────────────────────────────────────────────────────
+
+compliance_report := {
+    "framework":      "CIS Google Cloud Platform Foundation Benchmark",
+    "version":        "v2.0.0",
+    "published":      "March 2023",
+    "entity_name":    input.entity_name,
+    "project_id":     input.gcp_project_id,
+    "assessed_at":    input.assessment_date,
+    "compliant":      compliant,
+    "total_controls": 55,
+    "violations":     violations,
+    "violation_count": count(violations),
+    "section_summary": {
+        "iam":              [v | some v in violations; contains(v, "CIS GCP 1.")],
+        "logging":          [v | some v in violations; contains(v, "CIS GCP 2.")],
+        "networking":       [v | some v in violations; contains(v, "CIS GCP 3.")],
+        "virtual_machines": [v | some v in violations; contains(v, "CIS GCP 4.")],
+        "storage":          [v | some v in violations; contains(v, "CIS GCP 5.")],
+        "cloud_sql":        [v | some v in violations; contains(v, "CIS GCP 6.")],
+        "bigquery":         [v | some v in violations; contains(v, "CIS GCP 7.")],
+        "gke":              [v | some v in violations; contains(v, "CIS GCP 8.")],
+    },
+}

--- a/frameworks/compliance/nis2/nis2_main.rego
+++ b/frameworks/compliance/nis2/nis2_main.rego
@@ -1,0 +1,260 @@
+package nis2.main
+
+import rego.v1
+
+# EU Network and Information Security Directive 2 (NIS2) — Directive (EU) 2022/2555
+# Transposed into national law by October 2024. Covers 18 sectors:
+#   Essential entities:  energy, transport, banking, financial market infrastructure,
+#                        health, drinking water, wastewater, digital infrastructure,
+#                        ICT service management, public administration, space
+#   Important entities:  postal/courier, waste management, chemicals, food,
+#                        manufacturing (medical devices, computers, machinery, vehicles),
+#                        digital providers, research
+#
+# 10 minimum security measures (Article 21):
+#   1. Risk analysis and information system security policies
+#   2. Incident handling
+#   3. Business continuity and crisis management
+#   4. Supply chain security
+#   5. Security in network and information systems acquisition/development/maintenance
+#   6. Effectiveness assessment of cybersecurity risk management measures
+#   7. Cyber hygiene and cybersecurity training
+#   8. Cryptography and encryption policies
+#   9. HR security, access control, and asset management
+#  10. Multi-factor authentication
+#
+# OPA endpoint: POST http://<host>:8182/v1/data/nis2/main/compliance_report
+
+default compliant := false
+
+compliant if {
+    count(violations) == 0
+}
+
+# ── Article 21(2)(a) — Risk Analysis & Security Policies ────────────────────
+
+violations contains msg if {
+    not input.risk_management.risk_analysis.documented
+    msg := "NIS2 Art.21(2)(a): Risk analysis for network and information systems not documented"
+}
+
+violations contains msg if {
+    not input.risk_management.security_policies.approved_by_management
+    msg := "NIS2 Art.21(2)(a): Information security policies not approved by management body"
+}
+
+violations contains msg if {
+    not input.risk_management.risk_review.frequency_annual
+    msg := "NIS2 Art.21(2)(a): Risk analysis not reviewed at least annually or after significant changes"
+}
+
+# ── Article 21(2)(b) — Incident Handling ────────────────────────────────────
+
+violations contains msg if {
+    not input.incident_handling.plan.documented
+    msg := "NIS2 Art.21(2)(b): Incident handling plan not documented and tested"
+}
+
+violations contains msg if {
+    not input.incident_handling.significant_incident.early_warning_24h
+    msg := "NIS2 Art.23(4)(a): Early warning to CSIRT/authority not issued within 24 hours of significant incident"
+}
+
+violations contains msg if {
+    not input.incident_handling.significant_incident.notification_72h
+    msg := "NIS2 Art.23(4)(b): Incident notification to authority not issued within 72 hours"
+}
+
+violations contains msg if {
+    not input.incident_handling.significant_incident.final_report_1month
+    msg := "NIS2 Art.23(4)(d): Final incident report not submitted within 1 month"
+}
+
+violations contains msg if {
+    not input.incident_handling.log_retention.minimum_1_year
+    msg := "NIS2 Art.21(2)(b): Security logs not retained for minimum 1 year"
+}
+
+# ── Article 21(2)(c) — Business Continuity ──────────────────────────────────
+
+violations contains msg if {
+    not input.business_continuity.bcp.documented
+    msg := "NIS2 Art.21(2)(c): Business continuity plan not documented"
+}
+
+violations contains msg if {
+    not input.business_continuity.bcp.tested_annually
+    msg := "NIS2 Art.21(2)(c): Business continuity plan not tested at least annually"
+}
+
+violations contains msg if {
+    not input.business_continuity.drp.documented
+    msg := "NIS2 Art.21(2)(c): Disaster recovery plan not documented"
+}
+
+violations contains msg if {
+    not input.business_continuity.crisis_management.plan_exists
+    msg := "NIS2 Art.21(2)(c): Crisis management plan not established"
+}
+
+# ── Article 21(2)(d) — Supply Chain Security ────────────────────────────────
+
+violations contains msg if {
+    not input.supply_chain.vendor_assessment.process_exists
+    msg := "NIS2 Art.21(2)(d): Supplier and third-party security assessment process not established"
+}
+
+violations contains msg if {
+    not input.supply_chain.critical_suppliers.identified
+    msg := "NIS2 Art.21(2)(d): Critical ICT suppliers not identified and risk-assessed"
+}
+
+violations contains msg if {
+    not input.supply_chain.contractual_requirements.security_clauses
+    msg := "NIS2 Art.21(2)(d): Security requirements not included in supplier contracts"
+}
+
+# ── Article 21(2)(e) — Secure Acquisition / Development ─────────────────────
+
+violations contains msg if {
+    not input.secure_development.sdlc_policy.documented
+    msg := "NIS2 Art.21(2)(e): Secure software development lifecycle policy not documented"
+}
+
+violations contains msg if {
+    not input.secure_development.vulnerability_management.process_exists
+    msg := "NIS2 Art.21(2)(e): Vulnerability management process not established"
+}
+
+violations contains msg if {
+    not input.secure_development.patch_management.timely
+    msg := "NIS2 Art.21(2)(e): Timely patch management process not in place"
+}
+
+# ── Article 21(2)(f) — Effectiveness Assessment ─────────────────────────────
+
+violations contains msg if {
+    not input.effectiveness_assessment.penetration_testing.annual
+    msg := "NIS2 Art.21(2)(f): Penetration testing not conducted at least annually"
+}
+
+violations contains msg if {
+    not input.effectiveness_assessment.audit.regular
+    msg := "NIS2 Art.21(2)(f): Regular security audits of cybersecurity measures not performed"
+}
+
+# ── Article 21(2)(g) — Cyber Hygiene & Training ─────────────────────────────
+
+violations contains msg if {
+    not input.training.cybersecurity_awareness.conducted_annually
+    msg := "NIS2 Art.21(2)(g): Cybersecurity awareness training not conducted annually for all staff"
+}
+
+violations contains msg if {
+    not input.training.management_body.cybersecurity_training
+    msg := "NIS2 Art.21(2)(g): Management body members have not received cybersecurity training"
+}
+
+violations contains msg if {
+    not input.cyber_hygiene.patch_policy.exists
+    msg := "NIS2 Art.21(2)(g): Cyber hygiene policy (patching, updates, configurations) not established"
+}
+
+# ── Article 21(2)(h) — Cryptography ─────────────────────────────────────────
+
+violations contains msg if {
+    not input.cryptography.policy.documented
+    msg := "NIS2 Art.21(2)(h): Cryptography and encryption policy not documented"
+}
+
+violations contains msg if {
+    not input.cryptography.encryption.sensitive_data_at_rest
+    msg := "NIS2 Art.21(2)(h): Sensitive data at rest not encrypted"
+}
+
+violations contains msg if {
+    not input.cryptography.encryption.data_in_transit
+    msg := "NIS2 Art.21(2)(h): Data in transit not encrypted with strong protocols"
+}
+
+# ── Article 21(2)(i) — HR Security, Access Control & Asset Management ────────
+
+violations contains msg if {
+    not input.access_control.principle_of_least_privilege.enforced
+    msg := "NIS2 Art.21(2)(i): Principle of least privilege not enforced for system access"
+}
+
+violations contains msg if {
+    not input.access_control.privileged_accounts.managed
+    msg := "NIS2 Art.21(2)(i): Privileged accounts not managed through formal process"
+}
+
+violations contains msg if {
+    not input.asset_management.inventory.maintained
+    msg := "NIS2 Art.21(2)(i): Asset inventory not maintained for network and information systems"
+}
+
+violations contains msg if {
+    not input.hr_security.joiners_movers_leavers.process_exists
+    msg := "NIS2 Art.21(2)(i): HR security process for joiners/movers/leavers not established"
+}
+
+# ── Article 21(2)(j) — Multi-Factor Authentication ──────────────────────────
+
+violations contains msg if {
+    not input.mfa.remote_access.enforced
+    msg := "NIS2 Art.21(2)(j): MFA not enforced for remote access to network and information systems"
+}
+
+violations contains msg if {
+    not input.mfa.privileged_accounts.enforced
+    msg := "NIS2 Art.21(2)(j): MFA not enforced for privileged account access"
+}
+
+violations contains msg if {
+    not input.mfa.critical_systems.enforced
+    msg := "NIS2 Art.21(2)(j): MFA not enforced for access to critical systems"
+}
+
+# ── Management Accountability (Article 20) ───────────────────────────────────
+
+violations contains msg if {
+    not input.governance.management_body.approved_measures
+    msg := "NIS2 Art.20: Management body has not approved cybersecurity risk management measures"
+}
+
+violations contains msg if {
+    not input.governance.management_body.oversight_accountability
+    msg := "NIS2 Art.20: Management body not accountable for implementation of cybersecurity measures"
+}
+
+# ── Compliance Report ────────────────────────────────────────────────────────
+
+compliance_report := {
+    "framework":       "EU Network and Information Security Directive 2 (NIS2)",
+    "directive":       "Directive (EU) 2022/2555",
+    "transposition":   "October 2024",
+    "entity_name":     input.entity_name,
+    "entity_type":     input.entity_type,
+    "sector":          input.sector,
+    "entity_category": input.entity_category,
+    "assessed_at":     input.assessment_date,
+    "compliant":       compliant,
+    "total_controls":  34,
+    "violations":      violations,
+    "violation_count": count(violations),
+    "article_summary": {
+        "art_20_governance":          [v | some v in violations; contains(v, "Art.20")],
+        "art_21a_risk_policies":      [v | some v in violations; contains(v, "Art.21(2)(a)")],
+        "art_21b_incident_handling":  [v | some v in violations; contains(v, "Art.21(2)(b)")],
+        "art_21c_continuity":         [v | some v in violations; contains(v, "Art.21(2)(c)")],
+        "art_21d_supply_chain":       [v | some v in violations; contains(v, "Art.21(2)(d)")],
+        "art_21e_secure_dev":         [v | some v in violations; contains(v, "Art.21(2)(e)")],
+        "art_21f_effectiveness":      [v | some v in violations; contains(v, "Art.21(2)(f)")],
+        "art_21g_hygiene_training":   [v | some v in violations; contains(v, "Art.21(2)(g)")],
+        "art_21h_cryptography":       [v | some v in violations; contains(v, "Art.21(2)(h)")],
+        "art_21i_access_assets":      [v | some v in violations; contains(v, "Art.21(2)(i)")],
+        "art_21j_mfa":                [v | some v in violations; contains(v, "Art.21(2)(j)")],
+        "art_23_reporting":           [v | some v in violations; contains(v, "Art.23")],
+    },
+}

--- a/frameworks/critical_infrastructure/nist_800_82/nist_800_82_main.rego
+++ b/frameworks/critical_infrastructure/nist_800_82/nist_800_82_main.rego
@@ -1,0 +1,259 @@
+package nist_800_82.main
+
+import rego.v1
+
+# NIST Special Publication 800-82 Revision 3
+# "Guide to Operational Technology (OT) Security"
+# Published: September 2023
+#
+# Covers: ICS, SCADA, DCS, PLC, RTU, HMI, and other OT systems
+# Natural companion to NERC-CIP for utility and critical infrastructure operators
+#
+# Mapped to NIST SP 800-53 Rev 5 control families with OT-specific overlays:
+#   AC  — Access Control
+#   AU  — Audit and Accountability
+#   CA  — Assessment, Authorization, Monitoring
+#   CM  — Configuration Management
+#   CP  — Contingency Planning
+#   IA  — Identification and Authentication
+#   IR  — Incident Response
+#   MA  — Maintenance
+#   MP  — Media Protection
+#   PE  — Physical and Environmental Protection
+#   PL  — Planning
+#   PM  — Program Management
+#   RA  — Risk Assessment
+#   SA  — System and Services Acquisition
+#   SC  — System and Communications Protection
+#   SI  — System and Information Integrity
+#
+# OPA endpoint: POST http://<host>:8183/v1/data/nist_800_82/main/compliance_report
+
+default compliant := false
+
+compliant if {
+    count(violations) == 0
+}
+
+# ── OT-Specific Risk Assessment ───────────────────────────────────────────────
+
+violations contains msg if {
+    not input.risk_assessment.ot_specific.conducted
+    msg := "NIST 800-82 RA-3(OT): OT-specific risk assessment not conducted — must account for safety, availability, and process integrity impacts"
+}
+
+violations contains msg if {
+    not input.risk_assessment.consequence_analysis.life_safety
+    msg := "NIST 800-82 RA-3(OT): Risk assessment does not evaluate life-safety consequences of cyber events"
+}
+
+violations contains msg if {
+    not input.risk_assessment.consequence_analysis.environmental
+    msg := "NIST 800-82 RA-3(OT): Risk assessment does not evaluate environmental impact consequences of cyber events"
+}
+
+violations contains msg if {
+    not input.risk_assessment.asset_inventory.ot_systems
+    msg := "NIST 800-82 CM-8(OT): OT asset inventory not maintained (PLCs, RTUs, HMIs, historians, engineering workstations)"
+}
+
+# ── Network Architecture and Segmentation ────────────────────────────────────
+
+violations contains msg if {
+    not input.network.ot_it_segmentation.implemented
+    msg := "NIST 800-82 SC-7(OT): OT network not segmented from IT/corporate network using firewall or DMZ"
+}
+
+violations contains msg if {
+    not input.network.demilitarized_zone.exists
+    msg := "NIST 800-82 SC-7(OT): DMZ not established between OT and IT networks for data exchange"
+}
+
+violations contains msg if {
+    not input.network.wireless.ot_wireless_restricted
+    msg := "NIST 800-82 SC-8(OT): Wireless access to OT networks not restricted and controlled"
+}
+
+violations contains msg if {
+    not input.network.remote_access.ot_specific_controls
+    msg := "NIST 800-82 AC-17(OT): Remote access to OT systems not controlled with OT-specific security controls"
+}
+
+violations contains msg if {
+    not input.network.dial_up.disabled_or_controlled
+    msg := "NIST 800-82 SC-7(OT): Dial-up modems connected to OT systems not disabled or controlled"
+}
+
+violations contains msg if {
+    not input.network.data_flows.documented
+    msg := "NIST 800-82 SC-7(OT): Data flows between OT zones and to IT/internet not documented"
+}
+
+# ── Access Control ────────────────────────────────────────────────────────────
+
+violations contains msg if {
+    not input.access_control.ot_accounts.managed
+    msg := "NIST 800-82 AC-2(OT): OT system accounts not formally managed — shared accounts common but must be documented"
+}
+
+violations contains msg if {
+    not input.access_control.privileged_access.ot.controlled
+    msg := "NIST 800-82 AC-6(OT): Privileged access to OT engineering workstations and HMIs not controlled"
+}
+
+violations contains msg if {
+    not input.access_control.vendor_remote.managed
+    msg := "NIST 800-82 AC-17(OT): Vendor and third-party remote access to OT systems not controlled and monitored"
+}
+
+violations contains msg if {
+    not input.access_control.physical_ot_access.controlled
+    msg := "NIST 800-82 PE-3(OT): Physical access to OT components (field devices, control panels) not controlled"
+}
+
+# ── Configuration Management ──────────────────────────────────────────────────
+
+violations contains msg if {
+    not input.configuration.ot_baseline.established
+    msg := "NIST 800-82 CM-2(OT): Secure baseline configuration not established for OT systems"
+}
+
+violations contains msg if {
+    not input.configuration.change_management.ot_process
+    msg := "NIST 800-82 CM-3(OT): Change management process not established for OT system changes — must consider safety impacts"
+}
+
+violations contains msg if {
+    not input.configuration.removable_media.controlled
+    msg := "NIST 800-82 MP-7(OT): Removable media (USB drives, laptops) not controlled when connecting to OT systems"
+}
+
+violations contains msg if {
+    not input.configuration.software.authorized_only
+    msg := "NIST 800-82 CM-7(OT): Only authorized software permitted to execute on OT systems — whitelisting required"
+}
+
+# ── Patch Management (OT-Specific Challenges) ────────────────────────────────
+
+violations contains msg if {
+    not input.patch_management.ot.policy_exists
+    msg := "NIST 800-82 SI-2(OT): OT-specific patch management policy not established — must account for vendor approval requirements"
+}
+
+violations contains msg if {
+    not input.patch_management.ot.compensating_controls
+    msg := "NIST 800-82 SI-2(OT): Compensating controls not in place for OT systems that cannot be immediately patched"
+}
+
+violations contains msg if {
+    not input.patch_management.ot.vendor_coordination
+    msg := "NIST 800-82 SI-2(OT): Vendor coordination process not established for OT software updates"
+}
+
+# ── Incident Response ─────────────────────────────────────────────────────────
+
+violations contains msg if {
+    not input.incident_response.ot_specific.plan_exists
+    msg := "NIST 800-82 IR-4(OT): OT-specific incident response plan not established — must include safety system recovery"
+}
+
+violations contains msg if {
+    not input.incident_response.ot_specific.coordination_with_safety
+    msg := "NIST 800-82 IR-4(OT): Incident response plan does not coordinate with safety and engineering teams"
+}
+
+violations contains msg if {
+    not input.incident_response.ot_specific.forensics_consideration
+    msg := "NIST 800-82 IR-4(OT): OT incident response does not address forensic evidence collection without disrupting operations"
+}
+
+violations contains msg if {
+    not input.incident_response.reporting.ics_cert
+    msg := "NIST 800-82 IR-6(OT): Process not established to report OT incidents to ICS-CERT / CISA"
+}
+
+# ── Audit and Monitoring ──────────────────────────────────────────────────────
+
+violations contains msg if {
+    not input.monitoring.ot_network.continuous
+    msg := "NIST 800-82 AU-2(OT): Continuous monitoring not implemented for OT network traffic"
+}
+
+violations contains msg if {
+    not input.monitoring.ot_network.protocol_aware
+    msg := "NIST 800-82 AU-2(OT): OT network monitoring not protocol-aware (Modbus, DNP3, IEC 61850, etc.)"
+}
+
+violations contains msg if {
+    not input.monitoring.historian.log_integrity
+    msg := "NIST 800-82 AU-9(OT): Process historian logs not protected from tampering"
+}
+
+# ── System Integrity ──────────────────────────────────────────────────────────
+
+violations contains msg if {
+    not input.system_integrity.malware_protection.ot_appropriate
+    msg := "NIST 800-82 SI-3(OT): OT-appropriate malware protection not deployed — must not impact real-time operations"
+}
+
+violations contains msg if {
+    not input.system_integrity.firmware.integrity_verified
+    msg := "NIST 800-82 SI-7(OT): Firmware integrity verification not performed for critical OT devices"
+}
+
+# ── Contingency Planning ──────────────────────────────────────────────────────
+
+violations contains msg if {
+    not input.contingency.backup.ot_configurations
+    msg := "NIST 800-82 CP-9(OT): OT system configurations (PLC programs, HMI screens, historian data) not backed up"
+}
+
+violations contains msg if {
+    not input.contingency.recovery.ot_rto_defined
+    msg := "NIST 800-82 CP-2(OT): Recovery Time Objectives not defined for OT systems — must balance safety with cyber recovery"
+}
+
+violations contains msg if {
+    not input.contingency.manual_operations.procedures_documented
+    msg := "NIST 800-82 CP-2(OT): Manual/degraded operations procedures not documented for OT systems"
+}
+
+# ── Supply Chain (OT Equipment) ───────────────────────────────────────────────
+
+violations contains msg if {
+    not input.supply_chain.ot_equipment.vendor_assessment
+    msg := "NIST 800-82 SR-3(OT): OT equipment vendor security assessment not performed"
+}
+
+violations contains msg if {
+    not input.supply_chain.ot_equipment.counterfeit_protection
+    msg := "NIST 800-82 SR-4(OT): Process not established to detect counterfeit OT hardware components"
+}
+
+# ── Compliance Report ────────────────────────────────────────────────────────
+
+compliance_report := {
+    "framework":       "NIST Special Publication 800-82 Rev 3",
+    "title":           "Guide to Operational Technology (OT) Security",
+    "published":       "September 2023",
+    "entity_name":     input.entity_name,
+    "ot_system_type":  input.ot_system_type,
+    "sector":          input.sector,
+    "assessed_at":     input.assessment_date,
+    "compliant":       compliant,
+    "total_controls":  32,
+    "violations":      violations,
+    "violation_count": count(violations),
+    "control_family_summary": {
+        "risk_assessment":      [v | some v in violations; contains(v, "RA-")],
+        "network_architecture": array.concat([v | some v in violations; contains(v, "SC-7")], [v | some v in violations; contains(v, "SC-8")]),
+        "access_control":       array.concat([v | some v in violations; contains(v, "AC-")], [v | some v in violations; contains(v, "PE-")]),
+        "configuration_mgmt":   array.concat([v | some v in violations; contains(v, "CM-")], [v | some v in violations; contains(v, "MP-")]),
+        "patch_management":     [v | some v in violations; contains(v, "SI-2")],
+        "incident_response":    [v | some v in violations; contains(v, "IR-")],
+        "monitoring":           [v | some v in violations; contains(v, "AU-")],
+        "system_integrity":     array.concat([v | some v in violations; contains(v, "SI-3")], [v | some v in violations; contains(v, "SI-7")]),
+        "contingency_planning": [v | some v in violations; contains(v, "CP-")],
+        "supply_chain":         [v | some v in violations; contains(v, "SR-")],
+    },
+}

--- a/frameworks/financial/dora/dora_main.rego
+++ b/frameworks/financial/dora/dora_main.rego
@@ -1,0 +1,230 @@
+package dora.main
+
+import rego.v1
+
+# EU Digital Operational Resilience Act (DORA) — Regulation (EU) 2022/2554
+# Mandatory for all EU financial entities from 17 January 2025.
+#
+# Five pillars:
+#   Pillar 1 — ICT Risk Management (Articles 5–16)
+#   Pillar 2 — ICT-Related Incident Reporting (Articles 17–23)
+#   Pillar 3 — Digital Operational Resilience Testing (Articles 24–27)
+#   Pillar 4 — ICT Third-Party Risk Management (Articles 28–44)
+#   Pillar 5 — Information Sharing (Article 45)
+#
+# OPA endpoint: POST http://<host>:8182/v1/data/dora/main/compliance_report
+
+default compliant := false
+
+compliant if {
+    count(violations) == 0
+}
+
+# ── Pillar 1 — ICT Risk Management ──────────────────────────────────────────
+
+violations contains msg if {
+    not input.ict_risk_management.governance_framework.documented
+    msg := "DORA Art.5: ICT risk management governance framework not documented"
+}
+
+violations contains msg if {
+    not input.ict_risk_management.risk_appetite.defined
+    msg := "DORA Art.6: ICT risk appetite and tolerance levels not formally defined"
+}
+
+violations contains msg if {
+    not input.ict_risk_management.asset_inventory.maintained
+    msg := "DORA Art.8: ICT asset inventory not maintained (hardware, software, data assets)"
+}
+
+violations contains msg if {
+    not input.ict_risk_management.threat_intelligence.process_exists
+    msg := "DORA Art.13: Threat intelligence gathering and monitoring process absent"
+}
+
+violations contains msg if {
+    not input.ict_risk_management.recovery_objectives.rto_defined
+    msg := "DORA Art.12: Recovery Time Objectives (RTO) not defined for critical ICT systems"
+}
+
+violations contains msg if {
+    not input.ict_risk_management.recovery_objectives.rpo_defined
+    msg := "DORA Art.12: Recovery Point Objectives (RPO) not defined for critical ICT systems"
+}
+
+violations contains msg if {
+    not input.ict_risk_management.backup_policy.documented
+    msg := "DORA Art.12: ICT backup policy not documented or tested"
+}
+
+violations contains msg if {
+    not input.ict_risk_management.patch_management.process_exists
+    msg := "DORA Art.10: Patch and vulnerability management process not established"
+}
+
+violations contains msg if {
+    not input.ict_risk_management.encryption.in_transit
+    msg := "DORA Art.9: Data in transit not encrypted — encryption of sensitive data required"
+}
+
+violations contains msg if {
+    not input.ict_risk_management.encryption.at_rest
+    msg := "DORA Art.9: Data at rest not encrypted — encryption of sensitive data required"
+}
+
+violations contains msg if {
+    not input.ict_risk_management.mfa.enabled
+    msg := "DORA Art.9: Multi-factor authentication not enforced for ICT system access"
+}
+
+violations contains msg if {
+    not input.ict_risk_management.privileged_access.managed
+    msg := "DORA Art.9: Privileged access not managed — PAM controls required"
+}
+
+violations contains msg if {
+    not input.ict_risk_management.annual_review.completed
+    msg := "DORA Art.6: ICT risk management framework annual review not completed"
+}
+
+# ── Pillar 2 — ICT Incident Reporting ───────────────────────────────────────
+
+violations contains msg if {
+    not input.incident_reporting.classification_process.documented
+    msg := "DORA Art.18: ICT incident classification and impact assessment process not documented"
+}
+
+violations contains msg if {
+    not input.incident_reporting.initial_notification.within_4_hours
+    msg := "DORA Art.19: Major incident initial notification to authority not within 4 hours"
+}
+
+violations contains msg if {
+    not input.incident_reporting.intermediate_report.within_72_hours
+    msg := "DORA Art.19: Intermediate incident report to authority not within 72 hours"
+}
+
+violations contains msg if {
+    not input.incident_reporting.final_report.within_1_month
+    msg := "DORA Art.19: Final incident report to authority not within 1 month of resolution"
+}
+
+violations contains msg if {
+    not input.incident_reporting.incident_register.maintained
+    msg := "DORA Art.17: ICT incident register not maintained with required details"
+}
+
+violations contains msg if {
+    not input.incident_reporting.root_cause_analysis.performed
+    msg := "DORA Art.17: Root cause analysis not performed for major ICT incidents"
+}
+
+# ── Pillar 3 — Digital Operational Resilience Testing ───────────────────────
+
+violations contains msg if {
+    not input.resilience_testing.basic_testing.annual
+    msg := "DORA Art.25: Basic resilience testing (vulnerability scans, pen tests) not conducted annually"
+}
+
+violations contains msg if {
+    not input.resilience_testing.tlpt.conducted
+    msg := "DORA Art.26: Threat-Led Penetration Testing (TLPT) not conducted (significant entities: every 3 years)"
+}
+
+violations contains msg if {
+    not input.resilience_testing.test_results.remediated
+    msg := "DORA Art.25: Critical findings from resilience testing not remediated in defined timeframe"
+}
+
+violations contains msg if {
+    not input.resilience_testing.continuity_drills.conducted
+    msg := "DORA Art.25: Business continuity and crisis communication drills not conducted"
+}
+
+# ── Pillar 4 — ICT Third-Party Risk Management ──────────────────────────────
+
+violations contains msg if {
+    not input.third_party_risk.register.maintained
+    msg := "DORA Art.28: ICT third-party service provider register not maintained"
+}
+
+violations contains msg if {
+    not input.third_party_risk.contracts.exit_strategy
+    msg := "DORA Art.30: ICT service contracts do not include exit strategy and transition plan"
+}
+
+violations contains msg if {
+    not input.third_party_risk.contracts.audit_rights
+    msg := "DORA Art.30: ICT service contracts do not include audit and access rights"
+}
+
+violations contains msg if {
+    not input.third_party_risk.contracts.sla_defined
+    msg := "DORA Art.30: ICT service contracts lack SLA definitions for availability and performance"
+}
+
+violations contains msg if {
+    not input.third_party_risk.concentration_risk.assessed
+    msg := "DORA Art.29: ICT concentration risk not assessed (over-reliance on single provider)"
+}
+
+violations contains msg if {
+    not input.third_party_risk.critical_providers.identified
+    msg := "DORA Art.28: Critical ICT third-party providers not identified and assessed"
+}
+
+violations contains msg if {
+    not input.third_party_risk.due_diligence.performed
+    msg := "DORA Art.28: Due diligence not performed for ICT third-party providers"
+}
+
+# ── Pillar 5 — Information Sharing ──────────────────────────────────────────
+
+violations contains msg if {
+    not input.information_sharing.arrangements.in_place
+    msg := "DORA Art.45: Cyber threat information sharing arrangements not established"
+}
+
+# ── Compliance Report ────────────────────────────────────────────────────────
+
+compliance_report := {
+    "framework":      "EU Digital Operational Resilience Act (DORA)",
+    "regulation":     "Regulation (EU) 2022/2554",
+    "effective_date": "2025-01-17",
+    "entity":         input.entity_name,
+    "entity_type":    input.entity_type,
+    "assessed_at":    input.assessment_date,
+    "compliant":      compliant,
+    "total_controls": 30,
+    "violations":     violations,
+    "violation_count": count(violations),
+    "pillar_summary": {
+        "ict_risk_management":  pillar1_violations,
+        "incident_reporting":   pillar2_violations,
+        "resilience_testing":   pillar3_violations,
+        "third_party_risk":     pillar4_violations,
+        "information_sharing":  pillar5_violations,
+    },
+}
+
+# Pillar helper sets (partial set rules — OPA serializes as sorted arrays in JSON output)
+pillar1_violations contains v if { some v in violations; contains(v, "Art.5") }
+pillar1_violations contains v if { some v in violations; contains(v, "Art.6") }
+pillar1_violations contains v if { some v in violations; contains(v, "Art.8") }
+pillar1_violations contains v if { some v in violations; contains(v, "Art.9") }
+pillar1_violations contains v if { some v in violations; contains(v, "Art.10") }
+pillar1_violations contains v if { some v in violations; contains(v, "Art.12") }
+pillar1_violations contains v if { some v in violations; contains(v, "Art.13") }
+
+pillar2_violations contains v if { some v in violations; contains(v, "Art.17") }
+pillar2_violations contains v if { some v in violations; contains(v, "Art.18") }
+pillar2_violations contains v if { some v in violations; contains(v, "Art.19") }
+
+pillar3_violations contains v if { some v in violations; contains(v, "Art.25") }
+pillar3_violations contains v if { some v in violations; contains(v, "Art.26") }
+
+pillar4_violations contains v if { some v in violations; contains(v, "Art.28") }
+pillar4_violations contains v if { some v in violations; contains(v, "Art.29") }
+pillar4_violations contains v if { some v in violations; contains(v, "Art.30") }
+
+pillar5_violations contains v if { some v in violations; contains(v, "Art.45") }

--- a/frameworks/financial/ny_dfs/ny_dfs_main.rego
+++ b/frameworks/financial/ny_dfs/ny_dfs_main.rego
@@ -1,0 +1,295 @@
+package ny_dfs.main
+
+import rego.v1
+
+# New York Department of Financial Services — 23 NYCRR Part 500
+# Cybersecurity Requirements for Financial Services Companies
+# Version 2 (November 2023) — significant updates from original 2017 rule
+#
+# Applies to: all DFS-licensed/registered entities including banks, insurance companies,
+#             money transmitters, mortgage servicers, and virtual currency businesses
+#
+# Key sections:
+#   500.2   Cybersecurity Program
+#   500.3   Cybersecurity Policy
+#   500.4   Chief Information Security Officer (CISO)
+#   500.5   Penetration Testing and Vulnerability Assessments
+#   500.6   Audit Trail
+#   500.7   Access Privileges and Management
+#   500.9   Risk Assessment
+#   500.10  Cybersecurity Personnel and Intelligence
+#   500.11  Third-Party Service Provider Security Policy
+#   500.12  Multi-Factor Authentication
+#   500.13  Data Retention Limitations
+#   500.14  Training and Monitoring
+#   500.15  Encryption of Non-Public Information
+#   500.16  Incident Response and Business Continuity Plan
+#   500.17  Notices to Superintendent
+#
+# OPA endpoint: POST http://<host>:8182/v1/data/ny_dfs/main/compliance_report
+
+default compliant := false
+
+compliant if {
+    count(violations) == 0
+}
+
+# ── 500.2 — Cybersecurity Program ────────────────────────────────────────────
+
+violations contains msg if {
+    not input.cybersecurity_program.exists
+    msg := "23 NYCRR 500.2: Cybersecurity program not established to protect information systems and nonpublic information"
+}
+
+violations contains msg if {
+    not input.cybersecurity_program.risk_based.design
+    msg := "23 NYCRR 500.2(b): Cybersecurity program not designed based on covered entity's risk assessment"
+}
+
+# ── 500.3 — Cybersecurity Policy ─────────────────────────────────────────────
+
+violations contains msg if {
+    not input.cybersecurity_policy.documented
+    msg := "23 NYCRR 500.3: Written cybersecurity policy not implemented and maintained"
+}
+
+violations contains msg if {
+    not input.cybersecurity_policy.board_approved
+    msg := "23 NYCRR 500.3: Cybersecurity policy not approved by senior officer or board"
+}
+
+violations contains msg if {
+    not input.cybersecurity_policy.annual_review
+    msg := "23 NYCRR 500.3: Cybersecurity policy not reviewed at least annually"
+}
+
+# ── 500.4 — CISO ─────────────────────────────────────────────────────────────
+
+violations contains msg if {
+    not input.ciso.designated
+    msg := "23 NYCRR 500.4(a): Qualified CISO not designated to oversee cybersecurity program"
+}
+
+violations contains msg if {
+    not input.ciso.annual_report.to_board
+    msg := "23 NYCRR 500.4(b): CISO has not provided annual report to board on cybersecurity program"
+}
+
+violations contains msg if {
+    not input.ciso.annual_report.includes_material_issues
+    msg := "23 NYCRR 500.4(b): CISO annual report does not address material cybersecurity issues"
+}
+
+# ── 500.5 — Penetration Testing & Vulnerability Assessments ──────────────────
+
+violations contains msg if {
+    not input.testing.penetration_test.annual
+    msg := "23 NYCRR 500.5(a)(1): Annual penetration testing of information systems not performed"
+}
+
+violations contains msg if {
+    not input.testing.vulnerability_assessment.semi_annual
+    msg := "23 NYCRR 500.5(a)(2): Bi-annual automated vulnerability scans not conducted"
+}
+
+violations contains msg if {
+    not input.testing.findings.remediation_tracked
+    msg := "23 NYCRR 500.5: Penetration test and vulnerability assessment findings not tracked to remediation"
+}
+
+# ── 500.6 — Audit Trail ──────────────────────────────────────────────────────
+
+violations contains msg if {
+    not input.audit_trail.systems.tamper_resistant
+    msg := "23 NYCRR 500.6(a): Audit trail systems not designed to protect against tampering and alteration"
+}
+
+violations contains msg if {
+    not input.audit_trail.retention.minimum_3_years_financial
+    msg := "23 NYCRR 500.6(b): Financial records audit trail not retained for minimum 3 years"
+}
+
+violations contains msg if {
+    not input.audit_trail.retention.minimum_5_years_security
+    msg := "23 NYCRR 500.6(b): Cybersecurity event audit trail not retained for minimum 5 years"
+}
+
+# ── 500.7 — Access Privileges ────────────────────────────────────────────────
+
+violations contains msg if {
+    not input.access_control.least_privilege.enforced
+    msg := "23 NYCRR 500.7: Least privilege not enforced — access limited to what is necessary for job function"
+}
+
+violations contains msg if {
+    not input.access_control.privileged_accounts.regular_review
+    msg := "23 NYCRR 500.7(b): Privileged account access not reviewed at least annually"
+}
+
+violations contains msg if {
+    not input.access_control.terminated_users.prompt_revocation
+    msg := "23 NYCRR 500.7(c): Access not promptly revoked for terminated employees"
+}
+
+violations contains msg if {
+    not input.access_control.password_policy.strong
+    msg := "23 NYCRR 500.7(d): Strong password policy not enforced for system access"
+}
+
+# ── 500.9 — Risk Assessment ───────────────────────────────────────────────────
+
+violations contains msg if {
+    not input.risk_assessment.conducted
+    msg := "23 NYCRR 500.9: Cybersecurity risk assessment not conducted"
+}
+
+violations contains msg if {
+    not input.risk_assessment.periodic_review
+    msg := "23 NYCRR 500.9(a): Risk assessment not reviewed and updated periodically"
+}
+
+violations contains msg if {
+    not input.risk_assessment.covers_nonpublic_information
+    msg := "23 NYCRR 500.9(a)(2): Risk assessment does not address risks to nonpublic information"
+}
+
+# ── 500.10 — Cybersecurity Personnel ─────────────────────────────────────────
+
+violations contains msg if {
+    not input.personnel.qualified_staff.available
+    msg := "23 NYCRR 500.10(a): Qualified cybersecurity personnel not employed or engaged"
+}
+
+violations contains msg if {
+    not input.personnel.training.cybersecurity.annual
+    msg := "23 NYCRR 500.10(b): Annual cybersecurity training not provided to all relevant personnel"
+}
+
+# ── 500.11 — Third-Party Service Provider Security ────────────────────────────
+
+violations contains msg if {
+    not input.third_party.policy.documented
+    msg := "23 NYCRR 500.11: Written third-party service provider security policy not implemented"
+}
+
+violations contains msg if {
+    not input.third_party.contracts.security_controls_required
+    msg := "23 NYCRR 500.11(a)(1): Third-party contracts do not require implementation of security controls"
+}
+
+violations contains msg if {
+    not input.third_party.contracts.prompt_notification_required
+    msg := "23 NYCRR 500.11(a)(2): Third-party contracts do not require prompt notification of cybersecurity events"
+}
+
+violations contains msg if {
+    not input.third_party.assessment.periodic_due_diligence
+    msg := "23 NYCRR 500.11(a)(3): Periodic due diligence of third-party service providers not conducted"
+}
+
+# ── 500.12 — Multi-Factor Authentication ─────────────────────────────────────
+
+violations contains msg if {
+    not input.mfa.remote_access.enforced
+    msg := "23 NYCRR 500.12: MFA not implemented for remote access to information systems"
+}
+
+violations contains msg if {
+    not input.mfa.third_party_access.enforced
+    msg := "23 NYCRR 500.12: MFA not implemented for third-party access to internal networks"
+}
+
+violations contains msg if {
+    not input.mfa.privileged_accounts.enforced
+    msg := "23 NYCRR 500.12: MFA not implemented for privileged account access"
+}
+
+# ── 500.13 — Data Retention Limitations ──────────────────────────────────────
+
+violations contains msg if {
+    not input.data_retention.policy.documented
+    msg := "23 NYCRR 500.13: Data retention and disposal policy not documented"
+}
+
+violations contains msg if {
+    not input.data_retention.nonpublic_info.disposed_when_no_longer_needed
+    msg := "23 NYCRR 500.13: Nonpublic information not securely disposed when no longer needed"
+}
+
+# ── 500.14 — Training and Monitoring ─────────────────────────────────────────
+
+violations contains msg if {
+    not input.training.security_awareness.annual
+    msg := "23 NYCRR 500.14(a): Annual cybersecurity awareness training not provided to all personnel"
+}
+
+violations contains msg if {
+    not input.monitoring.anomalous_activity.systems_in_place
+    msg := "23 NYCRR 500.14(b): Monitoring systems not in place to detect anomalous activity"
+}
+
+violations contains msg if {
+    not input.monitoring.user_activity.privileged_users_monitored
+    msg := "23 NYCRR 500.14(b): Authorized user activity not monitored to detect unauthorized access"
+}
+
+# ── 500.15 — Encryption ───────────────────────────────────────────────────────
+
+violations contains msg if {
+    not input.encryption.nonpublic_info.in_transit
+    msg := "23 NYCRR 500.15: Nonpublic information not encrypted in transit over external networks"
+}
+
+violations contains msg if {
+    not input.encryption.nonpublic_info.at_rest
+    msg := "23 NYCRR 500.15: Nonpublic information not encrypted at rest"
+}
+
+# ── 500.16 — Incident Response Plan ──────────────────────────────────────────
+
+violations contains msg if {
+    not input.incident_response.plan.documented
+    msg := "23 NYCRR 500.16: Written incident response plan not established and maintained"
+}
+
+violations contains msg if {
+    not input.incident_response.plan.tested_annually
+    msg := "23 NYCRR 500.16: Incident response plan not tested at least annually"
+}
+
+violations contains msg if {
+    not input.incident_response.plan.roles_defined
+    msg := "23 NYCRR 500.16(b)(1): Roles and responsibilities not defined in incident response plan"
+}
+
+violations contains msg if {
+    not input.business_continuity.plan.documented
+    msg := "23 NYCRR 500.16: Business continuity plan not established for material cybersecurity events"
+}
+
+# ── 500.17 — Notices to Superintendent ───────────────────────────────────────
+
+violations contains msg if {
+    not input.superintendent_notice.process.within_72_hours
+    msg := "23 NYCRR 500.17(a): Process not established to notify DFS Superintendent within 72 hours of material cybersecurity event"
+}
+
+violations contains msg if {
+    not input.superintendent_notice.annual_certification.filed
+    msg := "23 NYCRR 500.17(b): Annual certification of compliance not filed with DFS Superintendent"
+}
+
+# ── Compliance Report ────────────────────────────────────────────────────────
+
+compliance_report := {
+    "framework":      "NY DFS Cybersecurity Regulation",
+    "regulation":     "23 NYCRR Part 500 (v2, November 2023)",
+    "entity_name":    input.entity_name,
+    "entity_type":    input.entity_type,
+    "dfs_license":    input.dfs_license_number,
+    "assessed_at":    input.assessment_date,
+    "compliant":      compliant,
+    "total_controls": 41,
+    "violations":     violations,
+    "violation_count": count(violations),
+}

--- a/frameworks/financial/sec_cyber/sec_cyber_main.rego
+++ b/frameworks/financial/sec_cyber/sec_cyber_main.rego
@@ -1,0 +1,170 @@
+package sec_cyber.main
+
+import rego.v1
+
+# SEC Cybersecurity Disclosure Rules
+# Final Rule: "Cybersecurity Risk Management, Strategy, Governance, and Incident Disclosure"
+# Effective: December 18, 2023 (incident disclosure); June 15, 2023 (annual disclosures)
+#
+# Key requirements for SEC-registered public companies:
+#   1. Material incident disclosure — Form 8-K Item 1.05 within 4 business days
+#   2. Annual cybersecurity governance disclosure — Form 10-K
+#   3. Board oversight of cybersecurity risk
+#   4. Management cybersecurity expertise
+#   5. Cybersecurity risk strategy documentation
+#
+# OPA endpoint: POST http://<host>:8182/v1/data/sec_cyber/main/compliance_report
+
+default compliant := false
+
+compliant if {
+    count(violations) == 0
+}
+
+# ── Form 8-K Item 1.05 — Material Incident Disclosure ───────────────────────
+
+violations contains msg if {
+    not input.incident_disclosure.materiality_determination.process_documented
+    msg := "SEC Cyber Rule §229.106: No documented process to determine materiality of cybersecurity incidents"
+}
+
+violations contains msg if {
+    not input.incident_disclosure.materiality_determination.timely
+    msg := "SEC Cyber Rule Item 1.05: Materiality determination not made without unreasonable delay after discovery"
+}
+
+violations contains msg if {
+    not input.incident_disclosure.form_8k.filed_within_4_business_days
+    msg := "SEC Cyber Rule Item 1.05: Material cybersecurity incident disclosure not filed on Form 8-K within 4 business days"
+}
+
+violations contains msg if {
+    not input.incident_disclosure.form_8k.includes_nature_and_scope
+    msg := "SEC Cyber Rule Item 1.05(a): Form 8-K does not describe nature, scope, and timing of incident"
+}
+
+violations contains msg if {
+    not input.incident_disclosure.form_8k.includes_material_impact
+    msg := "SEC Cyber Rule Item 1.05(a): Form 8-K does not describe material impact on registrant"
+}
+
+violations contains msg if {
+    not input.incident_disclosure.delay_request.national_security_process
+    msg := "SEC Cyber Rule Item 1.05(c): No process to request disclosure delay when national security exception applies"
+}
+
+violations contains msg if {
+    not input.incident_disclosure.incident_register.maintained
+    msg := "SEC Cyber Rule §229.106: Cybersecurity incident register not maintained for materiality review"
+}
+
+# ── Form 10-K — Annual Cybersecurity Disclosures ────────────────────────────
+
+violations contains msg if {
+    not input.annual_disclosure.risk_management.strategy_documented
+    msg := "SEC Cyber Rule §229.106(b)(1): Cybersecurity risk management strategy not documented for 10-K disclosure"
+}
+
+violations contains msg if {
+    not input.annual_disclosure.risk_management.integrated_with_overall_risk
+    msg := "SEC Cyber Rule §229.106(b)(1): Cybersecurity risk management not integrated with overall enterprise risk management"
+}
+
+violations contains msg if {
+    not input.annual_disclosure.third_party_risk.assessment_process
+    msg := "SEC Cyber Rule §229.106(b)(1): Third-party cybersecurity risk assessment process not established and disclosed"
+}
+
+violations contains msg if {
+    not input.annual_disclosure.material_risks.identified_and_disclosed
+    msg := "SEC Cyber Rule §229.106(b)(2): Material cybersecurity risks and their potential impact not identified and disclosed"
+}
+
+violations contains msg if {
+    not input.annual_disclosure.previous_incidents.impact_disclosed
+    msg := "SEC Cyber Rule §229.106(b)(2): Prior material incidents not disclosed with description of impact on operations"
+}
+
+# ── Board Oversight Disclosures ──────────────────────────────────────────────
+
+violations contains msg if {
+    not input.governance.board.oversight_responsibility_assigned
+    msg := "SEC Cyber Rule §229.106(c)(1): Board-level committee or full board responsibility for cybersecurity oversight not assigned"
+}
+
+violations contains msg if {
+    not input.governance.board.informed_of_risks_frequency
+    msg := "SEC Cyber Rule §229.106(c)(1): Board not informed of cybersecurity risks at required frequency"
+}
+
+violations contains msg if {
+    not input.governance.board.oversight_process_disclosed
+    msg := "SEC Cyber Rule §229.106(c)(1): Board cybersecurity oversight process not disclosed in annual report"
+}
+
+# ── Management Cybersecurity Expertise ───────────────────────────────────────
+
+violations contains msg if {
+    not input.governance.management.cybersecurity_roles_defined
+    msg := "SEC Cyber Rule §229.106(c)(2): Management roles responsible for cybersecurity not defined"
+}
+
+violations contains msg if {
+    not input.governance.management.expertise_or_expertise_access
+    msg := "SEC Cyber Rule §229.106(c)(2): Management lacks cybersecurity expertise or access to expertise"
+}
+
+violations contains msg if {
+    not input.governance.management.reports_to_board
+    msg := "SEC Cyber Rule §229.106(c)(2): Management reporting process to board on cybersecurity risks not established"
+}
+
+violations contains msg if {
+    not input.governance.management.ciso_or_equivalent
+    msg := "SEC Cyber Rule §229.106(c)(2): No CISO or equivalent role with cybersecurity responsibility designated"
+}
+
+# ── Cybersecurity Risk Management Program ────────────────────────────────────
+
+violations contains msg if {
+    not input.risk_management.program.formal_program_exists
+    msg := "SEC Cyber Rule §229.106(b)(1): Formal cybersecurity risk management program not established"
+}
+
+violations contains msg if {
+    not input.risk_management.standards.framework_adopted
+    msg := "SEC Cyber Rule §229.106(b)(1): No recognized cybersecurity framework (NIST CSF, ISO 27001, etc.) adopted"
+}
+
+violations contains msg if {
+    not input.risk_management.assessments.regular_risk_assessments
+    msg := "SEC Cyber Rule §229.106(b)(1): Regular cybersecurity risk assessments not conducted"
+}
+
+violations contains msg if {
+    not input.risk_management.incident_response.plan_exists
+    msg := "SEC Cyber Rule §229.106(b)(1): Cybersecurity incident response plan not established"
+}
+
+# ── Compliance Report ────────────────────────────────────────────────────────
+
+compliance_report := {
+    "framework":       "SEC Cybersecurity Disclosure Rules",
+    "rule":            "17 CFR Parts 229, 232, 239, 240, and 249",
+    "effective_date":  "2023-12-18",
+    "entity_name":     input.entity_name,
+    "ticker":          input.ticker,
+    "assessed_at":     input.assessment_date,
+    "fiscal_year_end": input.fiscal_year_end,
+    "compliant":       compliant,
+    "total_controls":  22,
+    "violations":      violations,
+    "violation_count": count(violations),
+    "section_summary": {
+        "item_105_8k_disclosure":    [v | some v in violations; contains(v, "Item 1.05")],
+        "annual_10k_disclosure":     [v | some v in violations; contains(v, "§229.106(b)")],
+        "board_oversight":           [v | some v in violations; contains(v, "§229.106(c)(1)")],
+        "management_expertise":      [v | some v in violations; contains(v, "§229.106(c)(2)")],
+        "risk_management_program":   [v | some v in violations; contains(v, "§229.106(b)(1)")],
+    },
+}

--- a/frameworks/financial/swift_csp/swift_csp_main.rego
+++ b/frameworks/financial/swift_csp/swift_csp_main.rego
@@ -1,0 +1,297 @@
+package swift_csp.main
+
+import rego.v1
+
+# SWIFT Customer Security Programme (CSP)
+# Customer Security Controls Framework (CSCF) v2024
+#
+# Required for all SWIFT network participants (banks, financial institutions,
+# corporates, and market infrastructures using SWIFT messaging).
+#
+# Control architecture:
+#   Mandatory controls (M) — must be implemented by all users
+#   Advisory controls (A)  — strongly recommended best practices
+#
+# Three security objectives:
+#   1. Secure your environment   (controls 1.x, 2.x)
+#   2. Know and limit access     (controls 4.x, 5.x, 6.x)
+#   3. Detect and respond        (controls 6.x, 7.x)
+#
+# OPA endpoint: POST http://<host>:8182/v1/data/swift_csp/main/compliance_report
+
+default compliant := false
+
+compliant if {
+    count(mandatory_violations) == 0
+}
+
+# ── Objective 1: Secure Your Environment ─────────────────────────────────────
+
+# Control 1.1 — SWIFT Environment Protection (M)
+violations contains msg if {
+    not input.environment.secure_zone.defined
+    msg := "SWIFT CSP 1.1(M): SWIFT infrastructure not isolated in a secure zone separate from general IT"
+}
+
+violations contains msg if {
+    not input.environment.secure_zone.network_segmentation
+    msg := "SWIFT CSP 1.1(M): Network segmentation not implemented between SWIFT zone and other networks"
+}
+
+violations contains msg if {
+    not input.environment.data_flow.documented
+    msg := "SWIFT CSP 1.1(M): Data flows between SWIFT zone and other components not documented"
+}
+
+# Control 1.2 — Operating System Privilege Account Control (M)
+violations contains msg if {
+    not input.os_security.privileged_accounts.restricted
+    msg := "SWIFT CSP 1.2(M): OS privileged accounts on SWIFT systems not restricted to minimum required"
+}
+
+violations contains msg if {
+    not input.os_security.admin_accounts.not_used_for_daily_tasks
+    msg := "SWIFT CSP 1.2(M): Administrative accounts on SWIFT systems used for day-to-day tasks"
+}
+
+# Control 1.3 — Virtualisation Platform Security (M)
+violations contains msg if {
+    input.infrastructure.virtualised == true
+    not input.infrastructure.virtualisation.host_hardened
+    msg := "SWIFT CSP 1.3(M): Virtualisation platform hosting SWIFT components not hardened"
+}
+
+violations contains msg if {
+    input.infrastructure.virtualised == true
+    not input.infrastructure.virtualisation.swift_vms_isolated
+    msg := "SWIFT CSP 1.3(M): SWIFT VMs not isolated from non-SWIFT VMs on shared infrastructure"
+}
+
+# Control 1.4 — Restriction of Internet Access (M)
+violations contains msg if {
+    not input.network.internet_access.restricted_from_swift_zone
+    msg := "SWIFT CSP 1.4(M): Internet access not restricted from SWIFT infrastructure zone"
+}
+
+violations contains msg if {
+    not input.network.outbound_filtering.enabled
+    msg := "SWIFT CSP 1.4(M): Outbound internet traffic from SWIFT environment not controlled and filtered"
+}
+
+# Control 2.1 — Internal Data Flow Security (M)
+violations contains msg if {
+    not input.data_security.internal_flows.encrypted
+    msg := "SWIFT CSP 2.1(M): SWIFT data flows within internal network not protected with encryption"
+}
+
+# Control 2.2 — Security Updates (M)
+violations contains msg if {
+    not input.patch_management.swift_components.current
+    msg := "SWIFT CSP 2.2(M): SWIFT software components not updated with latest security patches"
+}
+
+violations contains msg if {
+    not input.patch_management.os.critical_patches_within_3_months
+    msg := "SWIFT CSP 2.2(M): Critical OS patches on SWIFT systems not applied within 3 months"
+}
+
+# Control 2.3 — System Hardening (M)
+violations contains msg if {
+    not input.hardening.swift_systems.baseline_applied
+    msg := "SWIFT CSP 2.3(M): Security hardening baseline not applied to SWIFT infrastructure systems"
+}
+
+violations contains msg if {
+    not input.hardening.unnecessary_services.disabled
+    msg := "SWIFT CSP 2.3(M): Unnecessary services, ports, and programs not disabled on SWIFT systems"
+}
+
+# Control 2.4 — Back Office Data Flow Security (M — for A4 and B user types)
+violations contains msg if {
+    not input.back_office.data_flows.encrypted
+    msg := "SWIFT CSP 2.4(M): Data flows between SWIFT infrastructure and back-office systems not encrypted"
+}
+
+# Control 2.5 — External Transmission Data Protection (M)
+violations contains msg if {
+    not input.transmission.swift_messages.integrity_protected
+    msg := "SWIFT CSP 2.5(M): SWIFT messages not integrity-protected for external transmission"
+}
+
+# Control 2.6 — Operator Session Confidentiality and Integrity (M)
+violations contains msg if {
+    not input.sessions.operator.encrypted
+    msg := "SWIFT CSP 2.6(M): Operator sessions to SWIFT systems not encrypted"
+}
+
+# Control 2.7 — Vulnerability Scanning (M)
+violations contains msg if {
+    not input.vulnerability_scanning.swift_zone.quarterly
+    msg := "SWIFT CSP 2.7(M): Vulnerability scanning of SWIFT infrastructure not conducted at least quarterly"
+}
+
+violations contains msg if {
+    not input.vulnerability_scanning.findings.remediated_timely
+    msg := "SWIFT CSP 2.7(M): Critical and high vulnerabilities on SWIFT systems not remediated within defined timeframes"
+}
+
+# Control 2.8 — Outsourced Critical Activity Protection (M)
+violations contains msg if {
+    input.outsourcing.swift_activities == true
+    not input.outsourcing.service_provider.cscf_compliant
+    msg := "SWIFT CSP 2.8(M): Outsourced SWIFT service provider not confirmed as CSCF compliant"
+}
+
+# ── Objective 2: Know and Limit Access ───────────────────────────────────────
+
+# Control 4.1 — Password Policy (M)
+violations contains msg if {
+    not input.authentication.passwords.strong_policy
+    msg := "SWIFT CSP 4.1(M): Strong password policy not enforced for all SWIFT system accounts"
+}
+
+violations contains msg if {
+    not input.authentication.passwords.change_on_compromise
+    msg := "SWIFT CSP 4.1(M): Process not in place to immediately change passwords on suspected compromise"
+}
+
+# Control 5.1 — Logical Access Controls (M)
+violations contains msg if {
+    not input.access_control.swift_systems.least_privilege
+    msg := "SWIFT CSP 5.1(M): Least privilege not enforced for access to SWIFT systems"
+}
+
+violations contains msg if {
+    not input.access_control.swift_systems.role_based
+    msg := "SWIFT CSP 5.1(M): Role-based access controls not implemented for SWIFT systems"
+}
+
+violations contains msg if {
+    not input.access_control.privileged_access.mfa
+    msg := "SWIFT CSP 5.1(M): MFA not required for all privileged access to SWIFT infrastructure"
+}
+
+violations contains msg if {
+    not input.access_control.access_reviews.periodic
+    msg := "SWIFT CSP 5.1(M): Periodic reviews of user access rights to SWIFT systems not conducted"
+}
+
+# Control 5.2 — Token Management (M)
+violations contains msg if {
+    not input.token_management.hardware_tokens.used_for_swift
+    msg := "SWIFT CSP 5.2(M): Hardware authentication tokens not used for SWIFT Business Application access"
+}
+
+violations contains msg if {
+    not input.token_management.tokens.secure_storage
+    msg := "SWIFT CSP 5.2(M): Authentication tokens not stored securely when not in use"
+}
+
+# Control 5.4 — Physical and Logical Password Storage (M)
+violations contains msg if {
+    not input.credential_storage.encrypted
+    msg := "SWIFT CSP 5.4(M): Stored credentials for SWIFT systems not encrypted"
+}
+
+# Control 6.1 — Malware Protection (M)
+violations contains msg if {
+    not input.malware_protection.swift_systems.antimalware_deployed
+    msg := "SWIFT CSP 6.1(M): Anti-malware software not deployed on all SWIFT infrastructure components"
+}
+
+violations contains msg if {
+    not input.malware_protection.swift_systems.signatures_current
+    msg := "SWIFT CSP 6.1(M): Anti-malware signatures on SWIFT systems not regularly updated"
+}
+
+# ── Objective 3: Detect and Respond ──────────────────────────────────────────
+
+# Control 6.4 — Logging and Monitoring (M)
+violations contains msg if {
+    not input.logging.swift_systems.all_events_captured
+    msg := "SWIFT CSP 6.4(M): All security events on SWIFT systems not captured in audit logs"
+}
+
+violations contains msg if {
+    not input.logging.swift_transactions.logged
+    msg := "SWIFT CSP 6.4(M): SWIFT transaction logs not maintained for all processed messages"
+}
+
+violations contains msg if {
+    not input.logging.retention.minimum_3_months_online
+    msg := "SWIFT CSP 6.4(M): Logs not retained for minimum 3 months in readily accessible form"
+}
+
+violations contains msg if {
+    not input.logging.retention.minimum_2_5_years_archived
+    msg := "SWIFT CSP 6.4(M): Logs not archived for minimum 2.5 years total"
+}
+
+# Control 7.1 — Cyber Incident Response Planning (M)
+violations contains msg if {
+    not input.incident_response.plan.swift_specific
+    msg := "SWIFT CSP 7.1(M): SWIFT-specific cyber incident response plan not established"
+}
+
+violations contains msg if {
+    not input.incident_response.plan.swift_notification_included
+    msg := "SWIFT CSP 7.1(M): Incident response plan does not include SWIFT notification procedures"
+}
+
+violations contains msg if {
+    not input.incident_response.swift_notification.process_exists
+    msg := "SWIFT CSP 7.1(M): Process not established to notify SWIFT of confirmed fraud or security incidents"
+}
+
+# Control 7.2 — Security Training and Awareness (M)
+violations contains msg if {
+    not input.training.swift_staff.annual
+    msg := "SWIFT CSP 7.2(M): Annual security training not provided to personnel handling SWIFT systems"
+}
+
+violations contains msg if {
+    not input.training.social_engineering.included
+    msg := "SWIFT CSP 7.2(M): Security training does not include social engineering and fraud awareness"
+}
+
+# ── Advisory Controls (non-blocking but tracked) ─────────────────────────────
+
+advisory_violations contains msg if {
+    not input.network.jump_server.deployed
+    msg := "SWIFT CSP 2.9(A): Jump server not deployed for administrative access to SWIFT infrastructure"
+}
+
+advisory_violations contains msg if {
+    not input.environment.transaction_business_controls.implemented
+    msg := "SWIFT CSP 6.2(A): Transaction business controls not implemented to detect unusual payment patterns"
+}
+
+advisory_violations contains msg if {
+    not input.software_integrity.swift_components.verified
+    msg := "SWIFT CSP 6.3(A): Software integrity of SWIFT applications not verified after installation"
+}
+
+# Mandatory violations are the subset that block compliance
+mandatory_violations := violations
+
+# ── Compliance Report ────────────────────────────────────────────────────────
+
+compliance_report := {
+    "framework":               "SWIFT Customer Security Programme (CSP)",
+    "version":                 "CSCF v2024",
+    "entity_name":             input.entity_name,
+    "swift_bic":               input.swift_bic,
+    "user_type":               input.user_type,
+    "assessed_at":             input.assessment_date,
+    "next_attestation_due":    input.next_attestation_due,
+    "compliant":               compliant,
+    "mandatory_violations":    mandatory_violations,
+    "mandatory_violation_count": count(mandatory_violations),
+    "advisory_violations":     advisory_violations,
+    "advisory_violation_count": count(advisory_violations),
+    "objective_summary": {
+        "secure_environment":  array.concat([v | some v in mandatory_violations; contains(v, "CSP 1.")], [v | some v in mandatory_violations; contains(v, "CSP 2.")]),
+        "know_limit_access":   array.concat([v | some v in mandatory_violations; contains(v, "CSP 4.")], [v | some v in mandatory_violations; contains(v, "CSP 5.")]),
+        "detect_respond":      array.concat([v | some v in mandatory_violations; contains(v, "CSP 6.")], [v | some v in mandatory_violations; contains(v, "CSP 7.")]),
+    },
+}

--- a/frameworks/management/hitrust/hitrust_main.rego
+++ b/frameworks/management/hitrust/hitrust_main.rego
@@ -1,0 +1,421 @@
+package hitrust.main
+
+import rego.v1
+
+# HITRUST Common Security Framework (CSF) v11.3.0
+# Published: 2023
+#
+# Applies to: Healthcare organizations, business associates, and
+#             technology vendors handling protected health information (PHI)
+#             or requiring HITRUST certification for healthcare customers.
+#
+# 19 Control Categories (mapped to HIPAA, NIST, ISO 27001, SOC 2):
+#   00 — Information Security Management Program
+#   01 — Access Control
+#   02 — Human Resources Security
+#   03 — Risk Management
+#   04 — Security Policy
+#   05 — Organization of Information Security
+#   06 — Compliance
+#   07 — Asset Management
+#   08 — Physical and Environmental Security
+#   09 — Communications and Operations Management
+#   10 — Information Systems Acquisition, Development and Maintenance
+#   11 — Information Access Management
+#   12 — Audit Logging and Monitoring
+#   13 — Education, Training and Awareness
+#   14 — Third Party Assurance
+#   15 — Incident Management
+#   16 — Business Continuity Management
+#   17 — Risk Management (specific)
+#   18 — Privacy Practices
+#
+# OPA endpoint: POST http://<host>:8182/v1/data/hitrust/main/compliance_report
+
+default compliant := false
+
+compliant if {
+    count(violations) == 0
+}
+
+# ── Category 00 — Information Security Management Program ───────────────────
+
+violations contains msg if {
+    not input.security_program.isms.established
+    msg := "HITRUST CSF 00.a: Information Security Management System (ISMS) not formally established"
+}
+
+violations contains msg if {
+    not input.security_program.policies.approved_by_management
+    msg := "HITRUST CSF 00.b: Information security policies not approved by senior management"
+}
+
+violations contains msg if {
+    not input.security_program.policies.annual_review
+    msg := "HITRUST CSF 00.c: Information security policies not reviewed at least annually"
+}
+
+# ── Category 01 — Access Control ────────────────────────────────────────────
+
+violations contains msg if {
+    not input.access_control.policy.documented
+    msg := "HITRUST CSF 01.a: Access control policy not established, documented, and implemented"
+}
+
+violations contains msg if {
+    not input.access_control.user_access.formal_registration
+    msg := "HITRUST CSF 01.b: Formal user access registration and de-registration process not established"
+}
+
+violations contains msg if {
+    not input.access_control.privileged_access.controlled
+    msg := "HITRUST CSF 01.c: Privileged access rights not managed through formal authorization process"
+}
+
+violations contains msg if {
+    not input.access_control.password_policy.strong
+    msg := "HITRUST CSF 01.d: Strong password/authentication policy not enforced"
+}
+
+violations contains msg if {
+    not input.access_control.mfa.critical_systems
+    msg := "HITRUST CSF 01.e: Multi-factor authentication not enforced for critical system access"
+}
+
+violations contains msg if {
+    not input.access_control.access_review.periodic
+    msg := "HITRUST CSF 01.f: Periodic review of user access rights not conducted (at minimum annually)"
+}
+
+violations contains msg if {
+    not input.access_control.termination.prompt_revocation
+    msg := "HITRUST CSF 01.g: Access rights not promptly revoked upon termination or role change"
+}
+
+# ── Category 02 — Human Resources Security ──────────────────────────────────
+
+violations contains msg if {
+    not input.hr_security.background_checks.performed
+    msg := "HITRUST CSF 02.a: Pre-employment background checks not performed for personnel with PHI access"
+}
+
+violations contains msg if {
+    not input.hr_security.confidentiality.agreements_signed
+    msg := "HITRUST CSF 02.b: Confidentiality/non-disclosure agreements not signed by employees with PHI access"
+}
+
+violations contains msg if {
+    not input.hr_security.sanctions.policy_documented
+    msg := "HITRUST CSF 02.c: Sanction policy for workforce members who fail to comply with security policies not documented"
+}
+
+# ── Category 03 — Risk Management ────────────────────────────────────────────
+
+violations contains msg if {
+    not input.risk_management.assessment.conducted
+    msg := "HITRUST CSF 03.a: Formal risk assessment not conducted"
+}
+
+violations contains msg if {
+    not input.risk_management.assessment.phi_scope
+    msg := "HITRUST CSF 03.b: Risk assessment does not include PHI confidentiality, integrity, and availability"
+}
+
+violations contains msg if {
+    not input.risk_management.treatment.plan_documented
+    msg := "HITRUST CSF 03.c: Risk treatment plan not documented with accepted residual risks"
+}
+
+violations contains msg if {
+    not input.risk_management.assessment.periodic_review
+    msg := "HITRUST CSF 03.d: Risk assessment not reviewed and updated periodically or after significant changes"
+}
+
+# ── Category 04 — Security Policy ────────────────────────────────────────────
+
+violations contains msg if {
+    not input.security_policy.phi_specific.documented
+    msg := "HITRUST CSF 04.a: PHI-specific security policies and procedures not documented"
+}
+
+violations contains msg if {
+    not input.security_policy.dissemination.to_workforce
+    msg := "HITRUST CSF 04.b: Security policies not disseminated to all relevant workforce members"
+}
+
+# ── Category 06 — Compliance ─────────────────────────────────────────────────
+
+violations contains msg if {
+    not input.compliance.hipaa.privacy_rule.policies
+    msg := "HITRUST CSF 06.a: HIPAA Privacy Rule compliance policies not implemented"
+}
+
+violations contains msg if {
+    not input.compliance.hipaa.security_rule.policies
+    msg := "HITRUST CSF 06.b: HIPAA Security Rule compliance policies not implemented"
+}
+
+violations contains msg if {
+    not input.compliance.hipaa.breach_notification.plan
+    msg := "HITRUST CSF 06.c: HIPAA Breach Notification Rule compliance plan not established"
+}
+
+violations contains msg if {
+    not input.compliance.legal.periodic_review
+    msg := "HITRUST CSF 06.d: Periodic compliance review not conducted to identify legal/regulatory changes"
+}
+
+# ── Category 07 — Asset Management ────────────────────────────────────────────
+
+violations contains msg if {
+    not input.asset_management.inventory.maintained
+    msg := "HITRUST CSF 07.a: Asset inventory not maintained for systems and media containing PHI"
+}
+
+violations contains msg if {
+    not input.asset_management.classification.phi_labeled
+    msg := "HITRUST CSF 07.b: PHI assets not classified and labeled according to sensitivity"
+}
+
+violations contains msg if {
+    not input.asset_management.disposal.secure_media_sanitization
+    msg := "HITRUST CSF 07.c: Secure media sanitization procedures not established for PHI disposal"
+}
+
+# ── Category 08 — Physical and Environmental Security ───────────────────────
+
+violations contains msg if {
+    not input.physical_security.perimeter.controlled_access
+    msg := "HITRUST CSF 08.a: Physical access to facilities containing PHI systems not controlled"
+}
+
+violations contains msg if {
+    not input.physical_security.equipment.secured
+    msg := "HITRUST CSF 08.b: Equipment containing PHI not secured against physical threats"
+}
+
+violations contains msg if {
+    not input.physical_security.visitor_access.logged
+    msg := "HITRUST CSF 08.c: Visitor access to secure areas not logged and controlled"
+}
+
+# ── Category 09 — Communications and Operations Management ──────────────────
+
+violations contains msg if {
+    not input.operations.change_management.formal_process
+    msg := "HITRUST CSF 09.a: Formal change management process not established for PHI systems"
+}
+
+violations contains msg if {
+    not input.operations.malware.protection_deployed
+    msg := "HITRUST CSF 09.b: Malware protection not deployed on all systems processing PHI"
+}
+
+violations contains msg if {
+    not input.operations.backup.phi_backed_up
+    msg := "HITRUST CSF 09.c: PHI not backed up with tested recovery procedures"
+}
+
+violations contains msg if {
+    not input.operations.vulnerability_management.scanning
+    msg := "HITRUST CSF 09.d: Regular vulnerability scanning not performed on systems processing PHI"
+}
+
+violations contains msg if {
+    not input.operations.patch_management.timely
+    msg := "HITRUST CSF 09.e: Timely patch management process not established for PHI systems"
+}
+
+violations contains msg if {
+    not input.operations.network_monitoring.enabled
+    msg := "HITRUST CSF 09.f: Network monitoring not implemented to detect anomalous activity involving PHI"
+}
+
+# ── Category 10 — Information Systems Acquisition, Development ──────────────
+
+violations contains msg if {
+    not input.secure_development.requirements.security_included
+    msg := "HITRUST CSF 10.a: Security requirements not included in information system development/acquisition"
+}
+
+violations contains msg if {
+    not input.secure_development.testing.security_testing
+    msg := "HITRUST CSF 10.b: Security testing not performed before PHI systems are placed into production"
+}
+
+violations contains msg if {
+    not input.secure_development.phi.no_phi_in_test
+    msg := "HITRUST CSF 10.c: PHI used in development or test environments — must use de-identified data"
+}
+
+# ── Category 11 — Information Access Management ──────────────────────────────
+
+violations contains msg if {
+    not input.access_management.phi.minimum_necessary
+    msg := "HITRUST CSF 11.a: Access to PHI not restricted to minimum necessary for job function"
+}
+
+violations contains msg if {
+    not input.access_management.remote_access.controlled
+    msg := "HITRUST CSF 11.b: Remote access to PHI systems not controlled and monitored"
+}
+
+violations contains msg if {
+    not input.access_management.wireless.secured
+    msg := "HITRUST CSF 11.c: Wireless access transmitting PHI not properly secured and encrypted"
+}
+
+# ── Category 12 — Audit Logging and Monitoring ──────────────────────────────
+
+violations contains msg if {
+    not input.audit.phi_access.logged
+    msg := "HITRUST CSF 12.a: All access to PHI (create, read, update, delete) not logged"
+}
+
+violations contains msg if {
+    not input.audit.logs.protected_from_tampering
+    msg := "HITRUST CSF 12.b: Audit logs not protected from unauthorized modification or deletion"
+}
+
+violations contains msg if {
+    not input.audit.logs.retention_6_years
+    msg := "HITRUST CSF 12.c: Audit logs for PHI not retained for minimum 6 years (HIPAA requirement)"
+}
+
+violations contains msg if {
+    not input.audit.review.regular
+    msg := "HITRUST CSF 12.d: Audit logs not reviewed regularly for suspicious activity"
+}
+
+# ── Category 13 — Education, Training and Awareness ─────────────────────────
+
+violations contains msg if {
+    not input.training.hipaa.all_workforce_annual
+    msg := "HITRUST CSF 13.a: Annual HIPAA security and privacy training not provided to all workforce members"
+}
+
+violations contains msg if {
+    not input.training.phi_handling.included
+    msg := "HITRUST CSF 13.b: PHI handling procedures not included in security awareness training"
+}
+
+violations contains msg if {
+    not input.training.completion.tracked
+    msg := "HITRUST CSF 13.c: Security training completion not tracked for all workforce members"
+}
+
+# ── Category 14 — Third Party Assurance ─────────────────────────────────────
+
+violations contains msg if {
+    not input.third_party.baa.executed
+    msg := "HITRUST CSF 14.a: Business Associate Agreements (BAA) not executed with all vendors accessing PHI"
+}
+
+violations contains msg if {
+    not input.third_party.assessment.security_evaluation
+    msg := "HITRUST CSF 14.b: Security evaluation of third parties with PHI access not performed"
+}
+
+violations contains msg if {
+    not input.third_party.contracts.security_requirements
+    msg := "HITRUST CSF 14.c: Contracts with PHI-handling vendors do not include security requirements"
+}
+
+# ── Category 15 — Incident Management ────────────────────────────────────────
+
+violations contains msg if {
+    not input.incident_response.plan.documented
+    msg := "HITRUST CSF 15.a: Security incident response plan not documented"
+}
+
+violations contains msg if {
+    not input.incident_response.phi_breach.procedures
+    msg := "HITRUST CSF 15.b: PHI breach response procedures not established (including HIPAA notification timelines)"
+}
+
+violations contains msg if {
+    not input.incident_response.plan.tested_annually
+    msg := "HITRUST CSF 15.c: Incident response plan not tested at least annually"
+}
+
+violations contains msg if {
+    not input.incident_response.reporting.hhs_60_days
+    msg := "HITRUST CSF 15.d: Process not established to report breaches affecting 500+ individuals to HHS within 60 days"
+}
+
+# ── Category 16 — Business Continuity Management ─────────────────────────────
+
+violations contains msg if {
+    not input.business_continuity.bcp.documented
+    msg := "HITRUST CSF 16.a: Business continuity plan not documented for critical PHI systems"
+}
+
+violations contains msg if {
+    not input.business_continuity.drp.phi_systems
+    msg := "HITRUST CSF 16.b: Disaster recovery plan not established for PHI system restoration"
+}
+
+violations contains msg if {
+    not input.business_continuity.bcp.tested
+    msg := "HITRUST CSF 16.c: Business continuity/disaster recovery plan not tested periodically"
+}
+
+# ── Category 17 — Risk Management Specific ────────────────────────────────────
+
+violations contains msg if {
+    not input.risk_management.encryption.phi_at_rest
+    msg := "HITRUST CSF 17.a: PHI not encrypted at rest on storage systems"
+}
+
+violations contains msg if {
+    not input.risk_management.encryption.phi_in_transit
+    msg := "HITRUST CSF 17.b: PHI not encrypted in transit over networks (TLS 1.2+ required)"
+}
+
+# ── Category 18 — Privacy Practices ──────────────────────────────────────────
+
+violations contains msg if {
+    not input.privacy.notice.provided_to_patients
+    msg := "HITRUST CSF 18.a: Notice of Privacy Practices not provided to patients"
+}
+
+violations contains msg if {
+    not input.privacy.minimum_necessary.enforced
+    msg := "HITRUST CSF 18.b: Minimum necessary standard not enforced for PHI access and disclosure"
+}
+
+violations contains msg if {
+    not input.privacy.patient_rights.process_exists
+    msg := "HITRUST CSF 18.c: Process not established to honor patient rights (access, amendment, accounting of disclosures)"
+}
+
+# ── Compliance Report ────────────────────────────────────────────────────────
+
+compliance_report := {
+    "framework":       "HITRUST Common Security Framework (CSF)",
+    "version":         "v11.3.0",
+    "published":       "2023",
+    "entity_name":     input.entity_name,
+    "entity_type":     input.entity_type,
+    "assessed_at":     input.assessment_date,
+    "compliant":       compliant,
+    "total_controls":  59,
+    "violations":      violations,
+    "violation_count": count(violations),
+    "category_summary": {
+        "security_mgmt_program":    [v | some v in violations; contains(v, "CSF 00.")],
+        "access_control":           [v | some v in violations; contains(v, "CSF 01.")],
+        "hr_security":              [v | some v in violations; contains(v, "CSF 02.")],
+        "risk_management":          array.concat([v | some v in violations; contains(v, "CSF 03.")], [v | some v in violations; contains(v, "CSF 17.")]),
+        "compliance":               [v | some v in violations; contains(v, "CSF 06.")],
+        "asset_management":         [v | some v in violations; contains(v, "CSF 07.")],
+        "physical_security":        [v | some v in violations; contains(v, "CSF 08.")],
+        "operations":               [v | some v in violations; contains(v, "CSF 09.")],
+        "audit_logging":            [v | some v in violations; contains(v, "CSF 12.")],
+        "training":                 [v | some v in violations; contains(v, "CSF 13.")],
+        "third_party":              [v | some v in violations; contains(v, "CSF 14.")],
+        "incident_management":      [v | some v in violations; contains(v, "CSF 15.")],
+        "business_continuity":      [v | some v in violations; contains(v, "CSF 16.")],
+        "privacy":                  [v | some v in violations; contains(v, "CSF 18.")],
+    },
+}

--- a/frameworks/management/technical_debt/debt_scoring.rego
+++ b/frameworks/management/technical_debt/debt_scoring.rego
@@ -21,11 +21,13 @@ import rego.v1
 #     debt_score, critical_count, high_count, by_category, items: [...] }
 #
 # Debt categories:
-#   security               — generic security hygiene (CIS, NIST hardening)
-#   compliance             — regulatory & audit controls (ISO 27001, NIST 800-53, NCSC CAF)
+#   security               — generic security hygiene (CIS, NIST hardening, SWIFT CSP)
+#   compliance             — regulatory & audit controls (ISO 27001, DORA, NIS2, NY DFS, SEC Cyber,
+#                            HITRUST, 21 CFR Part 11, TISAX, NCSC CAF)
 #   operational            — operational hygiene (patching, config drift)
-#   critical_infrastructure — NERC-CIP and AMI 2.0 / NIST IR 7628 violations
+#   critical_infrastructure — NERC-CIP, AMI 2.0 / NIST IR 7628, NIST 800-82 (OT/ICS)
 #   sovereignty            — Digital Sovereignty controls (data residency, legal exposure, etc.)
+#   technology_lifecycle   — EOL software, deprecated protocols, obsolete OT firmware
 # =============================================================================
 
 # ---------------------------------------------------------------------------
@@ -198,6 +200,181 @@ effort_catalog := {
         "BN":   {"hours": 8.0,  "category": "sovereignty", "complexity": "moderate", "severity": "MEDIUM"},
         "DORA": {"hours": 24.0, "category": "sovereignty", "complexity": "complex",  "severity": "CRITICAL"},
         "_default": {"hours": 16.0, "category": "sovereignty", "complexity": "complex", "severity": "HIGH"}
+    },
+
+    # ── DORA (EU Digital Operational Resilience Act) ──────────────────────────
+    # Violations: "DORA Art.5(1): ..." — key: article number "Art.5"
+    "dora": {
+        "Art.5":  {"hours": 16.0, "category": "compliance", "complexity": "complex",   "severity": "CRITICAL"},
+        "Art.6":  {"hours": 12.0, "category": "compliance", "complexity": "moderate",  "severity": "HIGH"},
+        "Art.8":  {"hours": 12.0, "category": "compliance", "complexity": "moderate",  "severity": "HIGH"},
+        "Art.9":  {"hours": 8.0,  "category": "compliance", "complexity": "moderate",  "severity": "HIGH"},
+        "Art.10": {"hours": 8.0,  "category": "compliance", "complexity": "moderate",  "severity": "MEDIUM"},
+        "Art.12": {"hours": 16.0, "category": "compliance", "complexity": "complex",   "severity": "CRITICAL"},
+        "Art.13": {"hours": 12.0, "category": "compliance", "complexity": "complex",   "severity": "HIGH"},
+        "Art.17": {"hours": 8.0,  "category": "compliance", "complexity": "moderate",  "severity": "CRITICAL"},
+        "Art.18": {"hours": 8.0,  "category": "compliance", "complexity": "moderate",  "severity": "CRITICAL"},
+        "Art.19": {"hours": 6.0,  "category": "compliance", "complexity": "moderate",  "severity": "HIGH"},
+        "Art.25": {"hours": 20.0, "category": "compliance", "complexity": "complex",   "severity": "HIGH"},
+        "Art.26": {"hours": 16.0, "category": "compliance", "complexity": "complex",   "severity": "HIGH"},
+        "Art.28": {"hours": 16.0, "category": "compliance", "complexity": "complex",   "severity": "HIGH"},
+        "Art.29": {"hours": 12.0, "category": "compliance", "complexity": "complex",   "severity": "HIGH"},
+        "Art.30": {"hours": 8.0,  "category": "compliance", "complexity": "moderate",  "severity": "HIGH"},
+        "Art.45": {"hours": 4.0,  "category": "compliance", "complexity": "quick_win", "severity": "LOW"},
+        "_default": {"hours": 12.0, "category": "compliance", "complexity": "moderate", "severity": "HIGH"}
+    },
+
+    # ── NIS2 (EU Network and Information Security Directive 2) ────────────────
+    # Violations: "NIS2 Art.21(2)(a): ..." — key: "Art.20", "Art.21", "Art.23"
+    "nis2": {
+        "Art.20": {"hours": 16.0, "category": "compliance", "complexity": "complex",  "severity": "CRITICAL"},
+        "Art.21": {"hours": 12.0, "category": "compliance", "complexity": "moderate", "severity": "HIGH"},
+        "Art.23": {"hours": 8.0,  "category": "compliance", "complexity": "moderate", "severity": "CRITICAL"},
+        "_default": {"hours": 10.0, "category": "compliance", "complexity": "moderate", "severity": "HIGH"}
+    },
+
+    # ── SEC Cybersecurity Disclosure Rules ────────────────────────────────────
+    # Violations: "SEC Cyber Rule Item 1.05: ..." or "SEC Cyber Rule §229.106(b)(1): ..."
+    # Key: "Item 1.05", "§229.106(b)", "§229.106(c)"
+    "sec_cyber": {
+        "Item 1.05":   {"hours": 8.0,  "category": "compliance", "complexity": "moderate", "severity": "CRITICAL"},
+        "§229.106(b)": {"hours": 16.0, "category": "compliance", "complexity": "complex",  "severity": "HIGH"},
+        "§229.106(c)": {"hours": 20.0, "category": "compliance", "complexity": "complex",  "severity": "HIGH"},
+        "_default":    {"hours": 12.0, "category": "compliance", "complexity": "moderate", "severity": "HIGH"}
+    },
+
+    # ── NY DFS 23 NYCRR Part 500 ──────────────────────────────────────────────
+    # Violations: "23 NYCRR 500.4(a): ..." — key: "500.4"
+    "ny_dfs": {
+        "500.2":  {"hours": 16.0, "category": "compliance", "complexity": "complex",   "severity": "CRITICAL"},
+        "500.3":  {"hours": 8.0,  "category": "compliance", "complexity": "moderate",  "severity": "HIGH"},
+        "500.4":  {"hours": 12.0, "category": "compliance", "complexity": "moderate",  "severity": "HIGH"},
+        "500.5":  {"hours": 16.0, "category": "compliance", "complexity": "moderate",  "severity": "HIGH"},
+        "500.6":  {"hours": 8.0,  "category": "compliance", "complexity": "moderate",  "severity": "HIGH"},
+        "500.7":  {"hours": 4.0,  "category": "security",   "complexity": "moderate",  "severity": "HIGH"},
+        "500.9":  {"hours": 16.0, "category": "compliance", "complexity": "complex",   "severity": "HIGH"},
+        "500.10": {"hours": 8.0,  "category": "compliance", "complexity": "moderate",  "severity": "MEDIUM"},
+        "500.11": {"hours": 8.0,  "category": "compliance", "complexity": "moderate",  "severity": "HIGH"},
+        "500.12": {"hours": 4.0,  "category": "security",   "complexity": "quick_win", "severity": "CRITICAL"},
+        "500.13": {"hours": 8.0,  "category": "compliance", "complexity": "moderate",  "severity": "MEDIUM"},
+        "500.14": {"hours": 6.0,  "category": "compliance", "complexity": "moderate",  "severity": "HIGH"},
+        "500.15": {"hours": 6.0,  "category": "security",   "complexity": "moderate",  "severity": "CRITICAL"},
+        "500.16": {"hours": 16.0, "category": "compliance", "complexity": "complex",   "severity": "HIGH"},
+        "500.17": {"hours": 8.0,  "category": "compliance", "complexity": "moderate",  "severity": "CRITICAL"},
+        "_default": {"hours": 8.0, "category": "compliance", "complexity": "moderate", "severity": "HIGH"}
+    },
+
+    # ── SWIFT CSP CSCF v2024 ──────────────────────────────────────────────────
+    # Violations: "SWIFT CSP 1.1(M): ..." — key: "1.1"
+    "swift_csp": {
+        "1.1": {"hours": 16.0, "category": "security",    "complexity": "complex",   "severity": "CRITICAL"},
+        "1.2": {"hours": 4.0,  "category": "security",    "complexity": "quick_win", "severity": "HIGH"},
+        "1.3": {"hours": 8.0,  "category": "security",    "complexity": "moderate",  "severity": "HIGH"},
+        "1.4": {"hours": 8.0,  "category": "security",    "complexity": "moderate",  "severity": "CRITICAL"},
+        "2.1": {"hours": 6.0,  "category": "security",    "complexity": "moderate",  "severity": "HIGH"},
+        "2.2": {"hours": 4.0,  "category": "operational", "complexity": "moderate",  "severity": "HIGH"},
+        "2.3": {"hours": 6.0,  "category": "security",    "complexity": "moderate",  "severity": "HIGH"},
+        "2.4": {"hours": 6.0,  "category": "security",    "complexity": "moderate",  "severity": "HIGH"},
+        "2.5": {"hours": 8.0,  "category": "security",    "complexity": "moderate",  "severity": "CRITICAL"},
+        "2.6": {"hours": 4.0,  "category": "security",    "complexity": "quick_win", "severity": "HIGH"},
+        "2.7": {"hours": 4.0,  "category": "security",    "complexity": "quick_win", "severity": "HIGH"},
+        "2.8": {"hours": 8.0,  "category": "compliance",  "complexity": "moderate",  "severity": "HIGH"},
+        "4.1": {"hours": 2.0,  "category": "security",    "complexity": "quick_win", "severity": "HIGH"},
+        "5.1": {"hours": 4.0,  "category": "security",    "complexity": "moderate",  "severity": "CRITICAL"},
+        "5.2": {"hours": 4.0,  "category": "security",    "complexity": "moderate",  "severity": "HIGH"},
+        "5.4": {"hours": 3.0,  "category": "security",    "complexity": "quick_win", "severity": "HIGH"},
+        "6.1": {"hours": 2.0,  "category": "security",    "complexity": "quick_win", "severity": "HIGH"},
+        "6.4": {"hours": 4.0,  "category": "compliance",  "complexity": "moderate",  "severity": "HIGH"},
+        "7.1": {"hours": 8.0,  "category": "compliance",  "complexity": "moderate",  "severity": "CRITICAL"},
+        "7.2": {"hours": 3.0,  "category": "compliance",  "complexity": "quick_win", "severity": "MEDIUM"},
+        "_default": {"hours": 6.0, "category": "security", "complexity": "moderate", "severity": "HIGH"}
+    },
+
+    # ── NIST SP 800-82 Rev 3 (OT Security) ───────────────────────────────────
+    # Violations: "NIST 800-82 RA-3(OT): ..." — key: NIST 800-53 family "RA", "SC", etc.
+    # All OT controls → critical_infrastructure (OT specialist rates apply)
+    "nist_800_82": {
+        "RA": {"hours": 16.0, "category": "critical_infrastructure", "complexity": "complex",  "severity": "CRITICAL"},
+        "CM": {"hours": 12.0, "category": "critical_infrastructure", "complexity": "moderate", "severity": "HIGH"},
+        "SC": {"hours": 20.0, "category": "critical_infrastructure", "complexity": "complex",  "severity": "CRITICAL"},
+        "AC": {"hours": 8.0,  "category": "critical_infrastructure", "complexity": "moderate", "severity": "HIGH"},
+        "AU": {"hours": 6.0,  "category": "critical_infrastructure", "complexity": "moderate", "severity": "HIGH"},
+        "SI": {"hours": 8.0,  "category": "critical_infrastructure", "complexity": "moderate", "severity": "HIGH"},
+        "IR": {"hours": 12.0, "category": "critical_infrastructure", "complexity": "moderate", "severity": "HIGH"},
+        "CP": {"hours": 16.0, "category": "critical_infrastructure", "complexity": "complex",  "severity": "HIGH"},
+        "MA": {"hours": 8.0,  "category": "critical_infrastructure", "complexity": "moderate", "severity": "MEDIUM"},
+        "MP": {"hours": 6.0,  "category": "critical_infrastructure", "complexity": "moderate", "severity": "MEDIUM"},
+        "PE": {"hours": 12.0, "category": "critical_infrastructure", "complexity": "moderate", "severity": "HIGH"},
+        "SA": {"hours": 16.0, "category": "critical_infrastructure", "complexity": "complex",  "severity": "HIGH"},
+        "SR": {"hours": 16.0, "category": "critical_infrastructure", "complexity": "complex",  "severity": "HIGH"},
+        "_default": {"hours": 12.0, "category": "critical_infrastructure", "complexity": "moderate", "severity": "HIGH"}
+    },
+
+    # ── HITRUST CSF v11.3.0 ───────────────────────────────────────────────────
+    # Violations: "HITRUST CSF 01.a: ..." — key: 2-digit category "00"–"18"
+    "hitrust": {
+        "00": {"hours": 16.0, "category": "compliance",  "complexity": "complex",   "severity": "CRITICAL"},
+        "01": {"hours": 4.0,  "category": "security",    "complexity": "moderate",  "severity": "HIGH"},
+        "02": {"hours": 4.0,  "category": "compliance",  "complexity": "quick_win", "severity": "MEDIUM"},
+        "03": {"hours": 12.0, "category": "compliance",  "complexity": "moderate",  "severity": "CRITICAL"},
+        "04": {"hours": 8.0,  "category": "compliance",  "complexity": "moderate",  "severity": "HIGH"},
+        "06": {"hours": 8.0,  "category": "compliance",  "complexity": "moderate",  "severity": "CRITICAL"},
+        "07": {"hours": 4.0,  "category": "compliance",  "complexity": "quick_win", "severity": "MEDIUM"},
+        "08": {"hours": 8.0,  "category": "security",    "complexity": "moderate",  "severity": "HIGH"},
+        "09": {"hours": 6.0,  "category": "operational", "complexity": "moderate",  "severity": "HIGH"},
+        "10": {"hours": 12.0, "category": "compliance",  "complexity": "moderate",  "severity": "HIGH"},
+        "11": {"hours": 4.0,  "category": "security",    "complexity": "moderate",  "severity": "HIGH"},
+        "12": {"hours": 6.0,  "category": "compliance",  "complexity": "moderate",  "severity": "HIGH"},
+        "13": {"hours": 4.0,  "category": "compliance",  "complexity": "quick_win", "severity": "MEDIUM"},
+        "14": {"hours": 8.0,  "category": "compliance",  "complexity": "moderate",  "severity": "CRITICAL"},
+        "15": {"hours": 12.0, "category": "compliance",  "complexity": "moderate",  "severity": "CRITICAL"},
+        "16": {"hours": 8.0,  "category": "operational", "complexity": "moderate",  "severity": "HIGH"},
+        "17": {"hours": 8.0,  "category": "security",    "complexity": "moderate",  "severity": "CRITICAL"},
+        "18": {"hours": 8.0,  "category": "compliance",  "complexity": "moderate",  "severity": "HIGH"},
+        "_default": {"hours": 8.0, "category": "compliance", "complexity": "moderate", "severity": "HIGH"}
+    },
+
+    # ── 21 CFR Part 11 (FDA Electronic Records) ───────────────────────────────
+    # Violations: "21 CFR 11.10(a): ..." — key: "11.10", "11.30", etc.
+    "cfr_part_11": {
+        "11.10":  {"hours": 16.0, "category": "compliance", "complexity": "complex",   "severity": "CRITICAL"},
+        "11.30":  {"hours": 8.0,  "category": "compliance", "complexity": "moderate",  "severity": "HIGH"},
+        "11.50":  {"hours": 6.0,  "category": "compliance", "complexity": "moderate",  "severity": "HIGH"},
+        "11.70":  {"hours": 8.0,  "category": "compliance", "complexity": "moderate",  "severity": "CRITICAL"},
+        "11.100": {"hours": 4.0,  "category": "compliance", "complexity": "quick_win", "severity": "HIGH"},
+        "11.200": {"hours": 6.0,  "category": "compliance", "complexity": "moderate",  "severity": "HIGH"},
+        "11.300": {"hours": 4.0,  "category": "compliance", "complexity": "quick_win", "severity": "HIGH"},
+        "_default": {"hours": 8.0, "category": "compliance", "complexity": "moderate", "severity": "HIGH"}
+    },
+
+    # ── TISAX VDA ISA v6.0.3 ─────────────────────────────────────────────────
+    # Violations: "TISAX VDA ISA 1.1.1: ..." → key "1"; "TISAX PD AL2: ..." → key "PD"
+    "tisax": {
+        "1":  {"hours": 16.0, "category": "compliance", "complexity": "complex",   "severity": "CRITICAL"},
+        "2":  {"hours": 8.0,  "category": "compliance", "complexity": "moderate",  "severity": "HIGH"},
+        "3":  {"hours": 4.0,  "category": "compliance", "complexity": "moderate",  "severity": "MEDIUM"},
+        "4":  {"hours": 8.0,  "category": "security",   "complexity": "moderate",  "severity": "HIGH"},
+        "5":  {"hours": 8.0,  "category": "security",   "complexity": "moderate",  "severity": "HIGH"},
+        "6":  {"hours": 4.0,  "category": "security",   "complexity": "moderate",  "severity": "HIGH"},
+        "7":  {"hours": 12.0, "category": "compliance", "complexity": "moderate",  "severity": "HIGH"},
+        "8":  {"hours": 8.0,  "category": "compliance", "complexity": "moderate",  "severity": "HIGH"},
+        "9":  {"hours": 6.0,  "category": "compliance", "complexity": "moderate",  "severity": "HIGH"},
+        "PD": {"hours": 16.0, "category": "compliance", "complexity": "complex",   "severity": "CRITICAL"},
+        "_default": {"hours": 8.0, "category": "compliance", "complexity": "moderate", "severity": "HIGH"}
+    },
+
+    # ── CIS GCP Foundation Benchmark v2.0.0 ──────────────────────────────────
+    # Violations: "CIS GCP 1.1: ..." — key: section number "1"–"8"
+    "cis_gcp": {
+        "1": {"hours": 4.0, "category": "security",    "complexity": "moderate",  "severity": "HIGH"},
+        "2": {"hours": 2.0, "category": "compliance",  "complexity": "quick_win", "severity": "MEDIUM"},
+        "3": {"hours": 4.0, "category": "security",    "complexity": "moderate",  "severity": "HIGH"},
+        "4": {"hours": 2.0, "category": "security",    "complexity": "quick_win", "severity": "HIGH"},
+        "5": {"hours": 2.0, "category": "security",    "complexity": "quick_win", "severity": "HIGH"},
+        "6": {"hours": 4.0, "category": "security",    "complexity": "moderate",  "severity": "HIGH"},
+        "7": {"hours": 4.0, "category": "security",    "complexity": "moderate",  "severity": "HIGH"},
+        "8": {"hours": 6.0, "category": "operational", "complexity": "moderate",  "severity": "HIGH"},
+        "_default": {"hours": 4.0, "category": "security", "complexity": "moderate", "severity": "HIGH"}
     }
 }
 
@@ -331,6 +508,120 @@ _ds_key(violation) := key if {
     key        := ctrl_parts[0]
 }
 
+# DORA: "DORA Art.5(1): ..." → "Art.5"
+_dora_key(violation) := key if {
+    is_string(violation)
+    startswith(violation, "DORA ")
+    parts := split(violation, " ")
+    count(parts) >= 2
+    art_raw := parts[1]                          # "Art.5(1):" or "Art.17:"
+    key     := split(split(art_raw, "(")[0], ":")[0]  # "Art.5" or "Art.17"
+}
+
+# NIS2: "NIS2 Art.21(2)(a): ..." → "Art.21"; "NIS2 Art.20: ..." → "Art.20"
+_nis2_key(violation) := key if {
+    is_string(violation)
+    startswith(violation, "NIS2 ")
+    parts := split(violation, " ")
+    count(parts) >= 2
+    art_raw := parts[1]                          # "Art.21(2)(a):" or "Art.20:"
+    key     := split(split(art_raw, "(")[0], ":")[0]
+}
+
+# SEC Cyber: "SEC Cyber Rule Item 1.05: ..." → "Item 1.05"
+_sec_key(violation) := "Item 1.05" if {
+    is_string(violation)
+    contains(violation, "Item 1.05")
+}
+
+# SEC Cyber: "SEC Cyber Rule §229.106(c)(1): ..." → "§229.106(c)"
+_sec_key(violation) := "§229.106(c)" if {
+    is_string(violation)
+    contains(violation, "§229.106(c)")
+}
+
+# SEC Cyber: "SEC Cyber Rule §229.106(b)(1): ..." → "§229.106(b)"
+_sec_key(violation) := "§229.106(b)" if {
+    is_string(violation)
+    contains(violation, "§229.106(b)")
+    not contains(violation, "§229.106(c)")
+}
+
+# NY DFS: "23 NYCRR 500.4(a): ..." → "500.4"
+_nydfs_key(violation) := key if {
+    is_string(violation)
+    startswith(violation, "23 NYCRR ")
+    parts := split(violation, " ")
+    count(parts) >= 3
+    sect_raw := parts[2]                         # "500.4(a):" or "500.12:"
+    key      := split(split(sect_raw, "(")[0], ":")[0]
+}
+
+# SWIFT CSP: "SWIFT CSP 1.1(M): ..." → "1.1"
+_swift_key(violation) := key if {
+    is_string(violation)
+    startswith(violation, "SWIFT CSP ")
+    parts := split(violation, " ")
+    count(parts) >= 3
+    ctrl_raw := parts[2]                         # "1.1(M):" or "6.4(M):"
+    key      := split(split(ctrl_raw, "(")[0], ":")[0]
+}
+
+# NIST 800-82 (OT): "NIST 800-82 RA-3(OT): ..." → "RA"
+_nist_ot_key(violation) := key if {
+    is_string(violation)
+    startswith(violation, "NIST 800-82 ")
+    rest  := substring(violation, 12, count(violation))  # "RA-3(OT): ..."
+    parts := split(rest, "-")
+    count(parts) >= 2
+    key   := parts[0]
+}
+
+# HITRUST: "HITRUST CSF 01.a: ..." → "01"
+_hitrust_key(violation) := key if {
+    is_string(violation)
+    startswith(violation, "HITRUST CSF ")
+    parts := split(violation, " ")
+    count(parts) >= 3
+    ctrl_raw := parts[2]                         # "01.a:" or "14.a:"
+    key      := split(split(ctrl_raw, ".")[0], ":")[0]
+}
+
+# 21 CFR Part 11: "21 CFR 11.10(a): ..." → "11.10"
+_cfr11_key(violation) := key if {
+    is_string(violation)
+    startswith(violation, "21 CFR ")
+    parts := split(violation, " ")
+    count(parts) >= 3
+    ctrl_raw := parts[2]                         # "11.10(a):" or "11.100(c):"
+    key      := split(split(ctrl_raw, "(")[0], ":")[0]
+}
+
+# TISAX: "TISAX VDA ISA 1.1.1: ..." → "1"; "TISAX PD AL2: ..." → "PD"
+_tisax_key(violation) := key if {
+    is_string(violation)
+    startswith(violation, "TISAX VDA ISA ")
+    parts := split(violation, " ")
+    count(parts) >= 4
+    ctrl_raw := parts[3]                         # "1.1.1:" or "9.2.1:"
+    key      := split(split(ctrl_raw, ".")[0], ":")[0]
+}
+
+_tisax_key(violation) := "PD" if {
+    is_string(violation)
+    startswith(violation, "TISAX PD ")
+}
+
+# CIS GCP: "CIS GCP 1.1: ..." → "1"
+_cis_gcp_key(violation) := key if {
+    is_string(violation)
+    startswith(violation, "CIS GCP ")
+    parts := split(violation, " ")
+    count(parts) >= 3
+    ctrl_raw := parts[2]                         # "1.1:" or "8.9:"
+    key      := split(split(ctrl_raw, ".")[0], ":")[0]
+}
+
 # ---------------------------------------------------------------------------
 # get_estimate — routes to framework-specific lookup, falls back gracefully.
 # No mutual recursion: each clause is independent.
@@ -448,6 +739,156 @@ get_estimate("digital_sovereignty", violation) := effort_catalog.digital_soverei
     not effort_catalog.digital_sovereignty[key]
 }
 
+# DORA — specific match
+get_estimate("dora", violation) := estimate if {
+    key      := _dora_key(violation)
+    estimate := effort_catalog.dora[key]
+}
+
+get_estimate("dora", violation) := effort_catalog.dora["_default"] if {
+    not _dora_key(violation)
+}
+
+get_estimate("dora", violation) := effort_catalog.dora["_default"] if {
+    key := _dora_key(violation)
+    not effort_catalog.dora[key]
+}
+
+# NIS2 — specific match
+get_estimate("nis2", violation) := estimate if {
+    key      := _nis2_key(violation)
+    estimate := effort_catalog.nis2[key]
+}
+
+get_estimate("nis2", violation) := effort_catalog.nis2["_default"] if {
+    not _nis2_key(violation)
+}
+
+get_estimate("nis2", violation) := effort_catalog.nis2["_default"] if {
+    key := _nis2_key(violation)
+    not effort_catalog.nis2[key]
+}
+
+# SEC Cyber — specific match
+get_estimate("sec_cyber", violation) := estimate if {
+    key      := _sec_key(violation)
+    estimate := effort_catalog.sec_cyber[key]
+}
+
+get_estimate("sec_cyber", violation) := effort_catalog.sec_cyber["_default"] if {
+    not _sec_key(violation)
+}
+
+get_estimate("sec_cyber", violation) := effort_catalog.sec_cyber["_default"] if {
+    key := _sec_key(violation)
+    not effort_catalog.sec_cyber[key]
+}
+
+# NY DFS — specific match
+get_estimate("ny_dfs", violation) := estimate if {
+    key      := _nydfs_key(violation)
+    estimate := effort_catalog.ny_dfs[key]
+}
+
+get_estimate("ny_dfs", violation) := effort_catalog.ny_dfs["_default"] if {
+    not _nydfs_key(violation)
+}
+
+get_estimate("ny_dfs", violation) := effort_catalog.ny_dfs["_default"] if {
+    key := _nydfs_key(violation)
+    not effort_catalog.ny_dfs[key]
+}
+
+# SWIFT CSP — specific match
+get_estimate("swift_csp", violation) := estimate if {
+    key      := _swift_key(violation)
+    estimate := effort_catalog.swift_csp[key]
+}
+
+get_estimate("swift_csp", violation) := effort_catalog.swift_csp["_default"] if {
+    not _swift_key(violation)
+}
+
+get_estimate("swift_csp", violation) := effort_catalog.swift_csp["_default"] if {
+    key := _swift_key(violation)
+    not effort_catalog.swift_csp[key]
+}
+
+# NIST 800-82 (OT) — specific match
+get_estimate("nist_800_82", violation) := estimate if {
+    key      := _nist_ot_key(violation)
+    estimate := effort_catalog.nist_800_82[key]
+}
+
+get_estimate("nist_800_82", violation) := effort_catalog.nist_800_82["_default"] if {
+    not _nist_ot_key(violation)
+}
+
+get_estimate("nist_800_82", violation) := effort_catalog.nist_800_82["_default"] if {
+    key := _nist_ot_key(violation)
+    not effort_catalog.nist_800_82[key]
+}
+
+# HITRUST — specific match
+get_estimate("hitrust", violation) := estimate if {
+    key      := _hitrust_key(violation)
+    estimate := effort_catalog.hitrust[key]
+}
+
+get_estimate("hitrust", violation) := effort_catalog.hitrust["_default"] if {
+    not _hitrust_key(violation)
+}
+
+get_estimate("hitrust", violation) := effort_catalog.hitrust["_default"] if {
+    key := _hitrust_key(violation)
+    not effort_catalog.hitrust[key]
+}
+
+# 21 CFR Part 11 — specific match
+get_estimate("cfr_part_11", violation) := estimate if {
+    key      := _cfr11_key(violation)
+    estimate := effort_catalog.cfr_part_11[key]
+}
+
+get_estimate("cfr_part_11", violation) := effort_catalog.cfr_part_11["_default"] if {
+    not _cfr11_key(violation)
+}
+
+get_estimate("cfr_part_11", violation) := effort_catalog.cfr_part_11["_default"] if {
+    key := _cfr11_key(violation)
+    not effort_catalog.cfr_part_11[key]
+}
+
+# TISAX — specific match
+get_estimate("tisax", violation) := estimate if {
+    key      := _tisax_key(violation)
+    estimate := effort_catalog.tisax[key]
+}
+
+get_estimate("tisax", violation) := effort_catalog.tisax["_default"] if {
+    not _tisax_key(violation)
+}
+
+get_estimate("tisax", violation) := effort_catalog.tisax["_default"] if {
+    key := _tisax_key(violation)
+    not effort_catalog.tisax[key]
+}
+
+# CIS GCP — specific match
+get_estimate("cis_gcp", violation) := estimate if {
+    key      := _cis_gcp_key(violation)
+    estimate := effort_catalog.cis_gcp[key]
+}
+
+get_estimate("cis_gcp", violation) := effort_catalog.cis_gcp["_default"] if {
+    not _cis_gcp_key(violation)
+}
+
+get_estimate("cis_gcp", violation) := effort_catalog.cis_gcp["_default"] if {
+    key := _cis_gcp_key(violation)
+    not effort_catalog.cis_gcp[key]
+}
+
 # Unknown framework — global fallback
 get_estimate(framework, _violation) := _global_default if {
     not effort_catalog[framework]
@@ -547,7 +988,7 @@ critical_count := count([item | some item in debt_items; item.severity == "CRITI
 high_count := count([item | some item in debt_items; item.severity == "HIGH"])
 
 debt_by_category[cat] := totals if {
-    some cat in {"security", "compliance", "operational", "critical_infrastructure", "sovereignty"}
+    some cat in {"security", "compliance", "operational", "critical_infrastructure", "sovereignty", "technology_lifecycle"}
     cat_items := [item | some item in debt_items; item.debt_category == cat]
     totals := {
         "item_count":     count(cat_items),

--- a/frameworks/management/tisax/tisax_main.rego
+++ b/frameworks/management/tisax/tisax_main.rego
@@ -1,0 +1,348 @@
+package tisax.main
+
+import rego.v1
+
+# TISAX — Trusted Information Security Assessment Exchange
+# Assessment Levels: AL 1 (normal), AL 2 (high), AL 3 (very high)
+# Based on: VDA ISA (Information Security Assessment) Catalog v6.0.3 (2023)
+# Managed by: ENX Association (European automotive exchange network)
+#
+# Applies to:
+#   - Automotive OEMs (BMW, VW, Mercedes, Stellantis, Renault, etc.)
+#   - Tier 1, 2, and 3 automotive suppliers
+#   - Engineering service providers handling vehicle designs, prototypes, test data
+#   - IT/technology vendors to automotive industry
+#
+# Three assessment objectives:
+#   IS  — Information Security (all three ALs)
+#   PD  — Prototype and Test Vehicle Protection (AL 2 and 3 for prototype handling)
+#   SD  — Connection to Third Parties / Availability of IT Systems (AL 2 and 3 for special requirements)
+#
+# VDA ISA Control Domains:
+#   1.x — Information Security Management
+#   2.x — Security Organization and Responsibilities
+#   3.x — Asset Management
+#   4.x — Physical Security
+#   5.x — IT Security
+#   6.x — Identity and Access Management
+#   7.x — Third Party Management
+#   8.x — Incident Management
+#   9.x — Compliance and Auditing
+#
+# OPA endpoint: POST http://<host>:8182/v1/data/tisax/main/compliance_report
+
+default compliant := false
+
+compliant if {
+    count(violations) == 0
+}
+
+# ── 1.x — Information Security Management ────────────────────────────────────
+
+violations contains msg if {
+    not input.isms.established
+    msg := "TISAX VDA ISA 1.1.1: Information Security Management System (ISMS) not established and maintained"
+}
+
+violations contains msg if {
+    not input.isms.scope.defined
+    msg := "TISAX VDA ISA 1.1.2: ISMS scope not formally defined to include automotive customer information"
+}
+
+violations contains msg if {
+    not input.isms.policies.information_security.documented
+    msg := "TISAX VDA ISA 1.2.1: Information security policy not documented and approved by top management"
+}
+
+violations contains msg if {
+    not input.isms.policies.annual_review
+    msg := "TISAX VDA ISA 1.2.2: Information security policies not reviewed at least annually"
+}
+
+violations contains msg if {
+    not input.isms.risk_assessment.conducted
+    msg := "TISAX VDA ISA 1.3.1: Information security risk assessment not conducted for automotive customer data"
+}
+
+violations contains msg if {
+    not input.isms.risk_treatment.plan_documented
+    msg := "TISAX VDA ISA 1.3.2: Risk treatment plan not documented with accepted residual risks"
+}
+
+violations contains msg if {
+    not input.isms.internal_audit.conducted_annually
+    msg := "TISAX VDA ISA 1.4.1: Internal ISMS audits not conducted at least annually"
+}
+
+violations contains msg if {
+    not input.isms.management_review.conducted
+    msg := "TISAX VDA ISA 1.4.2: Management review of ISMS not conducted at defined intervals"
+}
+
+violations contains msg if {
+    not input.isms.continuous_improvement.process
+    msg := "TISAX VDA ISA 1.5.1: Continual improvement process not established for the ISMS"
+}
+
+# ── 2.x — Security Organization and Responsibilities ─────────────────────────
+
+violations contains msg if {
+    not input.organization.isms_responsible.designated
+    msg := "TISAX VDA ISA 2.1.1: Responsible person for information security not designated (CISO or equivalent)"
+}
+
+violations contains msg if {
+    not input.organization.security_roles.defined
+    msg := "TISAX VDA ISA 2.1.2: Information security roles and responsibilities not defined and communicated"
+}
+
+violations contains msg if {
+    not input.organization.confidentiality.agreements_signed
+    msg := "TISAX VDA ISA 2.2.1: Confidentiality agreements not signed by personnel handling OEM sensitive information"
+}
+
+violations contains msg if {
+    not input.organization.hr_security.joiners_process
+    msg := "TISAX VDA ISA 2.2.2: Security screening and onboarding process not established for new employees with sensitive access"
+}
+
+violations contains msg if {
+    not input.organization.hr_security.leavers_process
+    msg := "TISAX VDA ISA 2.2.3: Offboarding process not established — access rights not revoked upon termination"
+}
+
+violations contains msg if {
+    not input.organization.training.security_awareness.annual
+    msg := "TISAX VDA ISA 2.3.1: Annual security awareness training not provided to all personnel handling OEM data"
+}
+
+# ── 3.x — Asset Management ────────────────────────────────────────────────────
+
+violations contains msg if {
+    not input.assets.inventory.maintained
+    msg := "TISAX VDA ISA 3.1.1: Asset inventory not maintained for information assets containing OEM sensitive data"
+}
+
+violations contains msg if {
+    not input.assets.classification.scheme
+    msg := "TISAX VDA ISA 3.1.2: Information classification scheme not established (e.g., confidential, internal, public)"
+}
+
+violations contains msg if {
+    not input.assets.oem_data.classified_appropriately
+    msg := "TISAX VDA ISA 3.1.3: OEM-provided information not classified according to OEM classification requirements"
+}
+
+violations contains msg if {
+    not input.assets.media.secure_handling
+    msg := "TISAX VDA ISA 3.2.1: Removable media containing OEM sensitive data not securely handled and controlled"
+}
+
+violations contains msg if {
+    not input.assets.disposal.secure_data_destruction
+    msg := "TISAX VDA ISA 3.2.2: Secure data destruction process not established for media containing OEM sensitive information"
+}
+
+# ── 4.x — Physical Security ───────────────────────────────────────────────────
+
+violations contains msg if {
+    not input.physical_security.zones.defined
+    msg := "TISAX VDA ISA 4.1.1: Physical security zones for OEM sensitive information not defined"
+}
+
+violations contains msg if {
+    not input.physical_security.access_control.implemented
+    msg := "TISAX VDA ISA 4.1.2: Physical access controls not implemented for areas containing OEM sensitive systems"
+}
+
+violations contains msg if {
+    not input.physical_security.visitor_management.logged
+    msg := "TISAX VDA ISA 4.1.3: Visitor access to secured areas not logged and escorted"
+}
+
+violations contains msg if {
+    not input.physical_security.clear_desk.policy
+    msg := "TISAX VDA ISA 4.2.1: Clear desk and clear screen policy not established for OEM sensitive information"
+}
+
+# ── 5.x — IT Security ──────────────────────────────────────────────────────────
+
+violations contains msg if {
+    not input.it_security.network_segmentation.ot_it_separated
+    msg := "TISAX VDA ISA 5.1.1: Network not segmented to separate OEM sensitive systems from general IT"
+}
+
+violations contains msg if {
+    not input.it_security.encryption.data_at_rest
+    msg := "TISAX VDA ISA 5.1.2: OEM sensitive data not encrypted at rest on storage systems"
+}
+
+violations contains msg if {
+    not input.it_security.encryption.data_in_transit
+    msg := "TISAX VDA ISA 5.1.3: OEM sensitive data not encrypted in transit (TLS 1.2+ required)"
+}
+
+violations contains msg if {
+    not input.it_security.vulnerability_management.scanning
+    msg := "TISAX VDA ISA 5.2.1: Regular vulnerability scanning not performed on systems processing OEM data"
+}
+
+violations contains msg if {
+    not input.it_security.patch_management.timely
+    msg := "TISAX VDA ISA 5.2.2: Timely patching of systems processing OEM sensitive data not implemented"
+}
+
+violations contains msg if {
+    not input.it_security.malware.protection_deployed
+    msg := "TISAX VDA ISA 5.3.1: Malware protection not deployed on all systems processing OEM data"
+}
+
+violations contains msg if {
+    not input.it_security.backup.tested_regularly
+    msg := "TISAX VDA ISA 5.4.1: Backup procedures for OEM data not established and regularly tested"
+}
+
+violations contains msg if {
+    not input.it_security.change_management.formal_process
+    msg := "TISAX VDA ISA 5.5.1: Formal change management process not established for systems processing OEM data"
+}
+
+violations contains msg if {
+    not input.it_security.penetration_testing.conducted
+    msg := "TISAX VDA ISA 5.6.1: Penetration testing not conducted to verify security of OEM data systems"
+}
+
+# ── 6.x — Identity and Access Management ─────────────────────────────────────
+
+violations contains msg if {
+    not input.iam.access_control.least_privilege
+    msg := "TISAX VDA ISA 6.1.1: Least privilege not enforced for access to OEM sensitive information"
+}
+
+violations contains msg if {
+    not input.iam.access_control.need_to_know
+    msg := "TISAX VDA ISA 6.1.2: Access to OEM sensitive data not restricted on need-to-know basis"
+}
+
+violations contains msg if {
+    not input.iam.authentication.strong_policy
+    msg := "TISAX VDA ISA 6.2.1: Strong authentication not enforced for access to OEM sensitive systems"
+}
+
+violations contains msg if {
+    not input.iam.privileged_access.managed
+    msg := "TISAX VDA ISA 6.2.2: Privileged access to OEM data systems not managed through formal process"
+}
+
+violations contains msg if {
+    not input.iam.remote_access.mfa_enforced
+    msg := "TISAX VDA ISA 6.3.1: MFA not enforced for remote access to systems containing OEM data"
+}
+
+violations contains msg if {
+    not input.iam.access_review.periodic
+    msg := "TISAX VDA ISA 6.4.1: Periodic review of access rights to OEM sensitive data not conducted"
+}
+
+# ── 7.x — Third Party Management ──────────────────────────────────────────────
+
+violations contains msg if {
+    not input.third_party.assessment.security_evaluation
+    msg := "TISAX VDA ISA 7.1.1: Security evaluation not performed for third parties accessing OEM sensitive information"
+}
+
+violations contains msg if {
+    not input.third_party.contracts.security_requirements
+    msg := "TISAX VDA ISA 7.1.2: Security requirements not included in contracts with third parties handling OEM data"
+}
+
+violations contains msg if {
+    not input.third_party.subcontractors.tisax_or_equivalent
+    msg := "TISAX VDA ISA 7.1.3: Subcontractors handling OEM data not required to meet TISAX or equivalent security standard"
+}
+
+violations contains msg if {
+    not input.third_party.cloud.assessment_performed
+    msg := "TISAX VDA ISA 7.2.1: Security assessment not performed before storing OEM sensitive data in cloud environments"
+}
+
+# ── 8.x — Incident Management ─────────────────────────────────────────────────
+
+violations contains msg if {
+    not input.incident_management.plan.documented
+    msg := "TISAX VDA ISA 8.1.1: Information security incident management plan not documented"
+}
+
+violations contains msg if {
+    not input.incident_management.oem_notification.process
+    msg := "TISAX VDA ISA 8.1.2: Process not established to notify OEM customers of security incidents affecting their data"
+}
+
+violations contains msg if {
+    not input.incident_management.plan.tested
+    msg := "TISAX VDA ISA 8.1.3: Incident management plan not periodically tested"
+}
+
+# ── 9.x — Compliance and Auditing ─────────────────────────────────────────────
+
+violations contains msg if {
+    not input.compliance.legal_requirements.identified
+    msg := "TISAX VDA ISA 9.1.1: Legal, regulatory, and contractual information security requirements not identified"
+}
+
+violations contains msg if {
+    not input.compliance.oem_requirements.implemented
+    msg := "TISAX VDA ISA 9.1.2: OEM-specific information security contractual requirements not fully implemented"
+}
+
+violations contains msg if {
+    not input.compliance.audit_trail.maintained
+    msg := "TISAX VDA ISA 9.2.1: Audit trail not maintained for access to and processing of OEM sensitive data"
+}
+
+# ── Prototype and Test Vehicle Protection (PD) — AL 2/3 ──────────────────────
+
+violations contains msg if {
+    input.assessment_level >= 2
+    not input.prototype_protection.handling.procedures_documented
+    msg := "TISAX PD AL2: Prototype handling procedures not documented — physical protection of pre-series vehicles not defined"
+}
+
+violations contains msg if {
+    input.assessment_level >= 2
+    not input.prototype_protection.photography.controls
+    msg := "TISAX PD AL2: Photography and recording controls not established for prototype/test vehicle environments"
+}
+
+violations contains msg if {
+    input.assessment_level >= 2
+    not input.prototype_protection.transport.secured
+    msg := "TISAX PD AL2: Secure transport procedures not established for prototypes and test vehicles"
+}
+
+# ── Compliance Report ────────────────────────────────────────────────────────
+
+compliance_report := {
+    "framework":           "TISAX (Trusted Information Security Assessment Exchange)",
+    "catalog":             "VDA ISA v6.0.3",
+    "assessment_level":    input.assessment_level,
+    "entity_name":         input.entity_name,
+    "company_scope":       input.company_scope,
+    "assessed_at":         input.assessment_date,
+    "compliant":           compliant,
+    "total_controls":      51,
+    "violations":          violations,
+    "violation_count":     count(violations),
+    "domain_summary": {
+        "isms_management":          [v | some v in violations; contains(v, "ISA 1.")],
+        "security_organization":    [v | some v in violations; contains(v, "ISA 2.")],
+        "asset_management":         [v | some v in violations; contains(v, "ISA 3.")],
+        "physical_security":        [v | some v in violations; contains(v, "ISA 4.")],
+        "it_security":              [v | some v in violations; contains(v, "ISA 5.")],
+        "iam":                      [v | some v in violations; contains(v, "ISA 6.")],
+        "third_party":              [v | some v in violations; contains(v, "ISA 7.")],
+        "incident_management":      [v | some v in violations; contains(v, "ISA 8.")],
+        "compliance_auditing":      [v | some v in violations; contains(v, "ISA 9.")],
+        "prototype_protection":     [v | some v in violations; contains(v, "TISAX PD")],
+    },
+}

--- a/frameworks/regulatory/cfr_part_11/cfr_part_11_main.rego
+++ b/frameworks/regulatory/cfr_part_11/cfr_part_11_main.rego
@@ -1,0 +1,291 @@
+package cfr_part_11.main
+
+import rego.v1
+
+# FDA 21 CFR Part 11 — Electronic Records; Electronic Signatures
+# Published: 1997 (foundational rule), FDA Guidance: 2003
+# Enforced by: U.S. Food and Drug Administration (FDA)
+#
+# Applies to:
+#   - Pharmaceutical manufacturers
+#   - Biotech and medical device companies
+#   - Clinical research organizations (CROs)
+#   - Any FDA-regulated industry using electronic records and e-signatures
+#     in place of paper records required under FDA regulations (Predicate Rules)
+#
+# Key sections:
+#   11.10  — Controls for closed systems
+#   11.30  — Controls for open systems
+#   11.50  — Signature manifestations
+#   11.70  — Signature/record linking
+#   11.100 — General requirements for electronic signatures
+#   11.200 — Electronic signature components and controls
+#   11.300 — Controls for identification codes/passwords
+#
+# OPA endpoint: POST http://<host>:8182/v1/data/cfr_part_11/main/compliance_report
+
+default compliant := false
+
+compliant if {
+    count(violations) == 0
+}
+
+# ── §11.10 — Controls for Closed Systems ──────────────────────────────────────
+
+# §11.10(a) — Validation
+violations contains msg if {
+    not input.system_validation.validated
+    msg := "21 CFR 11.10(a): System not validated to ensure accuracy, reliability, consistent intended performance, and ability to discern invalid/altered records"
+}
+
+violations contains msg if {
+    not input.system_validation.iq_oq_pq.documented
+    msg := "21 CFR 11.10(a): Installation Qualification (IQ), Operational Qualification (OQ), Performance Qualification (PQ) not documented"
+}
+
+violations contains msg if {
+    not input.system_validation.revalidation.on_change
+    msg := "21 CFR 11.10(a): System not revalidated after significant changes affecting electronic records or signatures"
+}
+
+# §11.10(b) — Ability to generate accurate copies of records
+violations contains msg if {
+    not input.records.human_readable.capable
+    msg := "21 CFR 11.10(b): System cannot produce accurate and complete copies of records in human readable form"
+}
+
+violations contains msg if {
+    not input.records.electronic_copy.capable
+    msg := "21 CFR 11.10(b): System cannot produce accurate electronic copies of records for authorized agency inspection"
+}
+
+# §11.10(c) — Protection of records
+violations contains msg if {
+    not input.records.retention.protected_during_retention_period
+    msg := "21 CFR 11.10(c): Electronic records not protected to enable their accurate and ready retrieval throughout record retention period"
+}
+
+violations contains msg if {
+    not input.records.backup.regular_and_tested
+    msg := "21 CFR 11.10(c): Electronic records not regularly backed up with tested restoration procedures"
+}
+
+# §11.10(d) — System access limited to authorized individuals
+violations contains msg if {
+    not input.access_control.authorized_users.only
+    msg := "21 CFR 11.10(d): System access not limited to authorized individuals"
+}
+
+violations contains msg if {
+    not input.access_control.unique_user_ids.enforced
+    msg := "21 CFR 11.10(d): Unique user IDs not enforced — shared accounts not acceptable for 21 CFR Part 11"
+}
+
+# §11.10(e) — Secure, computer-generated, time-stamped audit trails
+violations contains msg if {
+    not input.audit_trail.computer_generated
+    msg := "21 CFR 11.10(e): Audit trails not computer-generated (no manual audit trail entries permitted)"
+}
+
+violations contains msg if {
+    not input.audit_trail.timestamps.accurate
+    msg := "21 CFR 11.10(e): Audit trail timestamps not accurate and synchronized to authoritative time source"
+}
+
+violations contains msg if {
+    not input.audit_trail.captures_record_changes
+    msg := "21 CFR 11.10(e): Audit trail does not record date/time, operator ID, and nature of record changes"
+}
+
+violations contains msg if {
+    not input.audit_trail.protected_from_modification
+    msg := "21 CFR 11.10(e): Audit trail records not protected against modification or deletion by users"
+}
+
+violations contains msg if {
+    not input.audit_trail.retention.at_least_as_long_as_record
+    msg := "21 CFR 11.10(e): Audit trail not retained for at least as long as the records it covers, and available for agency review"
+}
+
+# §11.10(f) — Operational system checks
+violations contains msg if {
+    not input.operational_checks.sequence_enforcement
+    msg := "21 CFR 11.10(f): System checks not in place to enforce permitted sequencing of steps and events where required"
+}
+
+# §11.10(g) — Authority checks
+violations contains msg if {
+    not input.authority_checks.enabled
+    msg := "21 CFR 11.10(g): System does not check authority to sign, access system, or perform operations at time of attempted action"
+}
+
+# §11.10(h) — Device checks
+violations contains msg if {
+    not input.device_checks.input_validation
+    msg := "21 CFR 11.10(h): Device checks not used to determine validity of source of data input or operational instruction"
+}
+
+# §11.10(i) — Personnel qualification
+violations contains msg if {
+    not input.personnel.training.system_specific
+    msg := "21 CFR 11.10(i): Personnel not trained and qualified on the use of the electronic records/signatures system"
+}
+
+violations contains msg if {
+    not input.personnel.training.records.maintained
+    msg := "21 CFR 11.10(i): Training records for electronic records system use not maintained"
+}
+
+# §11.10(j) — Written policies holding individuals accountable
+violations contains msg if {
+    not input.policies.individual_accountability.documented
+    msg := "21 CFR 11.10(j): Written policies holding individuals accountable for actions initiated under their electronic signatures not established"
+}
+
+# §11.10(k) — Controls over systems documentation
+violations contains msg if {
+    not input.documentation.distribution.controlled
+    msg := "21 CFR 11.10(k)(1): Controls not established for distribution of, access to, and use of system documentation"
+}
+
+violations contains msg if {
+    not input.documentation.revision.controlled
+    msg := "21 CFR 11.10(k)(2): Revision and change control procedures not established for system documentation"
+}
+
+# ── §11.30 — Controls for Open Systems ────────────────────────────────────────
+
+violations contains msg if {
+    not input.open_systems.encryption.records_in_transit
+    msg := "21 CFR 11.30: Electronic records transmitted over open networks not encrypted to ensure authenticity and integrity"
+}
+
+violations contains msg if {
+    not input.open_systems.digital_signatures.where_appropriate
+    msg := "21 CFR 11.30: Digital signatures or equivalent controls not used to ensure record authenticity on open systems"
+}
+
+# ── §11.50 — Signature Manifestations ─────────────────────────────────────────
+
+violations contains msg if {
+    not input.electronic_signatures.manifestation.printed_name
+    msg := "21 CFR 11.50(a)(1): Electronic signature does not include the printed name of the signer"
+}
+
+violations contains msg if {
+    not input.electronic_signatures.manifestation.date_time
+    msg := "21 CFR 11.50(a)(2): Electronic signature does not include the date and time of signing"
+}
+
+violations contains msg if {
+    not input.electronic_signatures.manifestation.meaning
+    msg := "21 CFR 11.50(a)(3): Electronic signature does not indicate the meaning of the signature (review, approval, responsibility)"
+}
+
+violations contains msg if {
+    not input.electronic_signatures.manifestation.human_readable
+    msg := "21 CFR 11.50(b): Electronic signature manifestation not included in human readable form of signed records"
+}
+
+# ── §11.70 — Signature/Record Linking ─────────────────────────────────────────
+
+violations contains msg if {
+    not input.electronic_signatures.record_linking.cryptographically_bound
+    msg := "21 CFR 11.70: Electronic signatures not cryptographically or procedurally linked to their respective records"
+}
+
+violations contains msg if {
+    not input.electronic_signatures.record_linking.tamper_evident
+    msg := "21 CFR 11.70: Signed records not tamper-evident — signature cannot be copied/transferred to falsify records"
+}
+
+# ── §11.100 — General Requirements for Electronic Signatures ──────────────────
+
+violations contains msg if {
+    not input.electronic_signatures.uniqueness.guaranteed
+    msg := "21 CFR 11.100(a): Electronic signatures not proven unique to one individual and not reused or reassigned"
+}
+
+violations contains msg if {
+    not input.electronic_signatures.identity_verification.before_assignment
+    msg := "21 CFR 11.100(b): Identity not verified before electronic signature privileges assigned"
+}
+
+violations contains msg if {
+    not input.electronic_signatures.fda_certification.filed
+    msg := "21 CFR 11.100(c): Certification to FDA that electronic signatures are intended to be equivalent to handwritten signatures not filed"
+}
+
+# ── §11.200 — Electronic Signature Components and Controls ────────────────────
+
+violations contains msg if {
+    not input.electronic_signatures.non_biometric.two_distinct_components
+    msg := "21 CFR 11.200(a)(1): Non-biometric electronic signatures do not use at least two distinct identification components (e.g., ID code + password)"
+}
+
+violations contains msg if {
+    not input.electronic_signatures.non_biometric.single_session_reauth
+    msg := "21 CFR 11.200(a)(2): Executing multiple signings in one session does not require all components at first signing and at least one component thereafter"
+}
+
+violations contains msg if {
+    not input.electronic_signatures.non_biometric.different_session_full_auth
+    msg := "21 CFR 11.200(a)(3): Executing signatures not during a single continuous session requires use of all signature components"
+}
+
+violations contains msg if {
+    not input.electronic_signatures.biometric.designed_exclusively_for_individual
+    msg := "21 CFR 11.200(b): Biometric electronic signatures not designed to ensure they cannot be used by anyone other than the genuine owner"
+}
+
+# ── §11.300 — Controls for Identification Codes/Passwords ─────────────────────
+
+violations contains msg if {
+    not input.identification_codes.uniqueness.maintained
+    msg := "21 CFR 11.300(a): Identification code/password combinations not maintained to ensure uniqueness"
+}
+
+violations contains msg if {
+    not input.identification_codes.periodic_revision
+    msg := "21 CFR 11.300(b): Identification codes or passwords not periodically checked, recalled, or revised"
+}
+
+violations contains msg if {
+    not input.identification_codes.unauthorized_use.detection
+    msg := "21 CFR 11.300(c): Controls not in place to detect unauthorized use of passwords or identification codes"
+}
+
+violations contains msg if {
+    not input.identification_codes.loss_management.procedures
+    msg := "21 CFR 11.300(d): Device loss management procedures not established (for token/card-based systems)"
+}
+
+violations contains msg if {
+    not input.identification_codes.transaction_safeguards
+    msg := "21 CFR 11.300(e): Transaction safeguards not used to prevent unauthorized use of passwords"
+}
+
+# ── Compliance Report ────────────────────────────────────────────────────────
+
+compliance_report := {
+    "framework":       "FDA 21 CFR Part 11",
+    "title":           "Electronic Records; Electronic Signatures",
+    "regulation":      "21 Code of Federal Regulations Part 11",
+    "entity_name":     input.entity_name,
+    "entity_type":     input.entity_type,
+    "system_name":     input.system_name,
+    "assessed_at":     input.assessment_date,
+    "compliant":       compliant,
+    "total_controls":  43,
+    "violations":      violations,
+    "violation_count": count(violations),
+    "section_summary": {
+        "s11_10_closed_systems":    [v | some v in violations; contains(v, "11.10")],
+        "s11_30_open_systems":      [v | some v in violations; contains(v, "11.30")],
+        "s11_50_manifestations":    [v | some v in violations; contains(v, "11.50")],
+        "s11_70_record_linking":    [v | some v in violations; contains(v, "11.70")],
+        "s11_100_general_esig":     [v | some v in violations; contains(v, "11.100")],
+        "s11_200_esig_components":  [v | some v in violations; contains(v, "11.200")],
+        "s11_300_id_codes":         [v | some v in violations; contains(v, "11.300")],
+    },
+}


### PR DESCRIPTION
## Summary

Updates `debt_scoring.rego` to add scoring support for the 10 new frameworks added in PR #9:

- **Effort catalog** — per-section hour estimates for all 10 frameworks
- **Key extractors** — parse violation message prefix to catalog lookup key
- **`get_estimate` routing** — three-clause pattern (specific match / no key / key miss) for each framework
- **`debt_by_category`** — adds `technology_lifecycle` to category set (prep for Phase 5c EOL tracking)

NIST 800-82 violations score to `critical_infrastructure` → OT specialist hourly rates ($285/hr) apply when `remediation_rates` table is implemented in Phase 5a.

## Test plan

- [ ] `opa check frameworks/management/technical_debt/debt_scoring.rego` passes
- [ ] POST with `framework: "nist_800_82"`, violation `"NIST 800-82 RA-3(OT): ..."` → `debt_category: "critical_infrastructure"`
- [ ] POST with `framework: "dora"`, violation `"DORA Art.17(3): ..."` → `effort_hours: 8.0`, `debt_category: "compliance"`
- [ ] POST with unknown framework → `_global_default` fallback applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)