### PR TITLE
fix: add workflow + EE read ops to MCP governance allowlist

### DIFF
--- a/governance/mcp/mcp_governance.rego
+++ b/governance/mcp/mcp_governance.rego
@@ -39,6 +39,14 @@ read_only_tools := {
     "api_credentials_read", "api_credentials_list",
     "api_organizations_read", "api_organizations_list",
     "api_users_read", "api_users_list",
+    "api_workflow_job_templates_read", "api_workflow_job_templates_list",
+    "api_workflow_job_templates_launch_read",
+    "api_workflow_jobs_read", "api_workflow_jobs_list",
+    "api_workflow_job_nodes_read", "api_workflow_job_nodes_list",
+    "api_workflow_job_template_nodes_read", "api_workflow_job_template_nodes_list",
+    "api_execution_environments_read", "api_execution_environments_list",
+    "api_schedules_read", "api_schedules_list",
+    "api_unified_job_templates_list", "api_unified_jobs_list",
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`api_workflow_job_templates_list` and related workflow read operations were missing from `read_only_tools` in the MCP governance policy, causing OPA to default-deny them as unknown-risk tools. These are safe read-only operations needed for AI agents to inspect and launch provisioning workflows.

**Added to `read_only_tools`:**
- `api_workflow_job_templates_{read,list,launch_read}`
- `api_workflow_jobs_{read,list}`
- `api_workflow_job{,_template}_nodes_{read,list}`
- `api_execution_environments_{read,list}`
- `api_schedules_{read,list}`
- `api_unified_job_templates_list`, `api_unified_jobs_list`

## Test plan
- [ ] Query MCP with `api_workflow_job_templates_list` — confirm ALLOW
- [ ] Query MCP with a destructive tool — confirm still DENY

🤖 Generated with [Claude Code](https://claude.com/claude-code)