### PR TITLE
fix: add workflow_jobs_workflow_nodes_list to MCP read-only tools

### DIFF
--- a/governance/mcp/mcp_governance.rego
+++ b/governance/mcp/mcp_governance.rego
@@ -42,6 +42,7 @@ read_only_tools := {
     "api_workflow_job_templates_read", "api_workflow_job_templates_list",
     "api_workflow_job_templates_launch_read",
     "api_workflow_jobs_read", "api_workflow_jobs_list",
+    "api_workflow_jobs_workflow_nodes_list",
     "api_workflow_job_nodes_read", "api_workflow_job_nodes_list",
     "api_workflow_job_template_nodes_read", "api_workflow_job_template_nodes_list",
     "api_execution_environments_read", "api_execution_environments_list",


### PR DESCRIPTION
## Summary
- Adds `api_workflow_jobs_workflow_nodes_list` to `read_only_tools` in `mcp_governance.rego`
- This endpoint lists workflow job nodes for a running/completed workflow job (`/workflow_jobs/{id}/workflow_nodes/`)
- Without this, OPA defaults to DENY for the tool, blocking AI agents from checking workflow progress

## Test plan
- [ ] Reload OPA compliance container after merge
- [ ] Verify `api_workflow_jobs_workflow_nodes_list` tool calls succeed without OPA DENY

🤖 Generated with [Claude Code](https://claude.com/claude-code)