### PR TITLE
feat: add community files, coverage table, and opcr.io publishing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Report an incorrect policy evaluation, wrong control mapping, or Rego error
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please describe the issue as specifically as possible. Include the policy file, control ID, and what you expected vs. what you got.
+
+  - type: input
+    id: policy_file
+    attributes:
+      label: Policy file
+      description: e.g. `benchmarks/cis/os/linux/rhel_9/pam_validation.rego`
+      placeholder: "path/to/policy.rego"
+    validations:
+      required: true
+
+  - type: input
+    id: control_id
+    attributes:
+      label: Control ID (if applicable)
+      description: e.g. "CIS 5.3.2", "CIP-007 R2", "SR 1.3"
+      placeholder: "CIS 5.3.2"
+
+  - type: textarea
+    id: input_data
+    attributes:
+      label: Input data that triggers the bug
+      description: Paste the JSON input that causes the incorrect result
+      render: json
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+      description: What should the policy return?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual result
+      description: What does the policy actually return? Include the full OPA response.
+      render: json
+    validations:
+      required: true
+
+  - type: input
+    id: opa_version
+    attributes:
+      label: OPA version
+      description: Output of `opa version`
+      placeholder: "OPA 1.10.0 ..."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/framework_request.yml
+++ b/.github/ISSUE_TEMPLATE/framework_request.yml
@@ -1,0 +1,60 @@
+name: Framework request
+description: Request a new compliance framework or standard
+labels: ["enhancement", "new-framework"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for requesting a new framework. Providing the information below helps us prioritize and implement it correctly.
+
+  - type: input
+    id: framework_name
+    attributes:
+      label: Framework name and version
+      description: e.g. "CIS Amazon Linux 2023 v1.0.0", "NIST SP 800-171 Rev 3"
+      placeholder: "Framework name and version"
+    validations:
+      required: true
+
+  - type: input
+    id: source_document
+    attributes:
+      label: Source document URL
+      description: Link to the public standard, benchmark PDF, or reference page
+      placeholder: "https://..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: domain
+    attributes:
+      label: Domain
+      description: Which policy taxonomy does this fall under?
+      options:
+        - CIS Benchmark
+        - DISA STIG
+        - Federal (NIST, FISMA, FedRAMP, CMMC)
+        - Management (ISO, SOC 2, NCSC CAF)
+        - Financial (PCI-DSS, SOX, SWIFT)
+        - Privacy (GDPR, HIPAA)
+        - Critical Infrastructure (NERC-CIP, IEC 62443)
+        - Regulatory (DORA, NIS2)
+        - Enforcement (Ansible, Terraform, K8s)
+        - Governance / AI
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use case (optional)
+      description: Brief description of your use case — helps with prioritization
+      placeholder: "We need to assess RHEL 9 hosts against this standard for a FedRAMP moderate authorization..."
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I'm willing to contribute a draft Rego policy for this framework

--- a/.github/workflows/publish-opcr.yml
+++ b/.github/workflows/publish-opcr.yml
@@ -1,0 +1,74 @@
+name: Publish to opcr.io
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build and push OPA bundle to opcr.io
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install OPA
+        run: |
+          curl -L -o opa https://github.com/open-policy-agent/opa/releases/download/v1.10.0/opa_linux_amd64_static
+          chmod +x opa
+          sudo mv opa /usr/local/bin/opa
+          opa version
+
+      - name: Determine image tag
+        id: tag
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            TAG="${{ github.ref_name }}"
+          else
+            TAG="latest"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Publishing as: $TAG"
+
+      - name: Build OPA bundle
+        run: |
+          opa build \
+            benchmarks/ \
+            frameworks/ \
+            enforcement/ \
+            governance/ \
+            threat_detection/ \
+            -o bundle.tar.gz
+          echo "Bundle size: $(du -sh bundle.tar.gz)"
+
+      - name: Push to opcr.io
+        env:
+          OPCR_TOKEN: ${{ secrets.OPCR_TOKEN }}
+        run: |
+          # Install oras (OCI Registry As Storage) for pushing OPA bundles
+          ORAS_VERSION="1.2.0"
+          curl -LO "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz"
+          tar -xzf "oras_${ORAS_VERSION}_linux_amd64.tar.gz"
+          sudo mv oras /usr/local/bin/oras
+
+          # Login to opcr.io
+          echo "$OPCR_TOKEN" | oras login opcr.io \
+            --username "${{ secrets.OPCR_USERNAME }}" \
+            --password-stdin
+
+          # Push bundle as OCI artifact
+          oras push \
+            "opcr.io/ynotbhatc/rego_policy_libraries:${{ steps.tag.outputs.tag }}" \
+            --artifact-type "application/vnd.opa.bundle" \
+            bundle.tar.gz:application/vnd.opa.bundle.layer.v1.tar+gzip
+
+          echo "Published: opcr.io/ynotbhatc/rego_policy_libraries:${{ steps.tag.outputs.tag }}"
+          echo ""
+          echo "Pull with:"
+          echo "  opa pull opcr.io/ynotbhatc/rego_policy_libraries:${{ steps.tag.outputs.tag }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,134 @@
+# Contributing to Rego Policy Libraries
+
+Thank you for contributing! This library grows by community submissions. Whether you're adding a new framework, extending coverage of an existing one, or fixing a bug — contributions are welcome.
+
+---
+
+## Quick contribution guide
+
+### 1. Adding a new framework
+
+**Taxonomy:** place your policy in the matching subdirectory:
+
+| Type | Location |
+|------|----------|
+| CIS Benchmark | `benchmarks/cis/os/linux/`, `benchmarks/cis/cloud/`, etc. |
+| DISA STIG | `benchmarks/stig/` |
+| Federal (NIST, FISMA, FedRAMP, CMMC) | `frameworks/federal/` |
+| Management (ISO, SOC 2, NCSC CAF) | `frameworks/management/` |
+| Financial (PCI-DSS, SOX, SWIFT) | `frameworks/financial/` |
+| Privacy (GDPR, HIPAA) | `frameworks/privacy/` |
+| Critical infrastructure (NERC-CIP, IEC 62443) | `frameworks/critical_infrastructure/` |
+| Regulatory (DORA, NIS2) | `frameworks/regulatory/` |
+| Enforcement (Ansible, Terraform, K8s) | `enforcement/` |
+| AI / Governance | `governance/` |
+
+**Required structure:**
+
+```rego
+package <framework>.<module_name>
+
+import rego.v1
+
+# ---------------------------------------------------------------------------
+# <Framework Name> — <section or control group>
+# Reference: <link to standard or source document>
+# ---------------------------------------------------------------------------
+
+default compliant := false
+
+violations contains msg if {
+    # condition
+    msg := "<control-id>: <human-readable description of violation>"
+}
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "framework":      "<framework name>",
+    "section":        "<section name>",
+    "total_controls": <N>,
+    "violations":     violations,
+    "compliant":      compliant,
+}
+```
+
+**Rules:**
+- `import rego.v1` is mandatory — no exceptions
+- Every policy must export a `compliance_report` rule with at minimum: `compliant`, `violations`
+- Violation messages must include a control identifier (e.g., `"CIS 1.1.1: ..."`, `"CIP-007 R2: ..."`)
+- `default compliant := false` is required — without it, a rule that never fires is `undefined`, which breaks aggregation
+
+### 2. Extending an existing framework
+
+Open a PR against the specific `.rego` file. Include:
+- Which control(s) you're adding or fixing
+- A reference link to the source standard
+
+### 3. Writing tests
+
+OPA tests live alongside policies. Name your test file `<policy_name>_test.rego`:
+
+```rego
+package <framework>.<module_name>_test
+
+import rego.v1
+
+test_violation_fires_when_control_missing if {
+    result := violations with input as {"some_fact": false}
+    count(result) > 0
+}
+
+test_compliant_when_all_controls_pass if {
+    result := compliant with input as {"some_fact": true, ...}
+    result == true
+}
+```
+
+Run tests locally:
+```bash
+opa test benchmarks/cis/os/linux/rhel_9/ -v
+```
+
+The CI pipeline (`.github/workflows/opa-test.yml`) runs all tests on every PR.
+
+---
+
+## Pull request checklist
+
+- [ ] `import rego.v1` present in every new `.rego` file
+- [ ] `default compliant := false` present
+- [ ] `compliance_report` rule exported
+- [ ] Violation messages include a control identifier
+- [ ] Tests added for new controls (or existing tests still pass)
+- [ ] PR title follows the pattern: `feat(<framework>): add <description>` or `fix(<framework>): <description>`
+
+---
+
+## array.concat() — the most common Rego v1 mistake
+
+`array.concat()` takes **exactly 2 arrays**. For 3+ arrays, nest the calls:
+
+```rego
+# WRONG — 3-argument concat does not exist in Rego v1
+all := array.concat([a], [b], [c])
+
+# CORRECT — nested 2-argument calls
+ab   := array.concat([a], [b])
+all  := array.concat(ab, [c])
+```
+
+---
+
+## Requesting a framework
+
+Open an issue using the **"Framework request"** template. Include:
+- Framework name and version (e.g., "CIS Amazon Linux 2023 v1.0.0")
+- Link to the source document (public PDF or webpage)
+- Your use case (optional but helps prioritize)
+
+---
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [Apache 2.0 License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -6,6 +6,51 @@
 [![OPA](https://img.shields.io/badge/OPA-v0.60%2B-blue)](https://www.openpolicyagent.org/)
 [![Rego](https://img.shields.io/badge/Rego-v1-green)](https://www.openpolicyagent.org/docs/latest/policy-language/)
 [![CIS RHEL 9](https://img.shields.io/badge/CIS%20RHEL%209-338%2F338%20(100%25)-brightgreen)](benchmarks/cis/os/linux/rhel_9/)
+[![GitHub Stars](https://img.shields.io/github/stars/ynotbhatc/rego_policy_libraries?style=social)](https://github.com/ynotbhatc/rego_policy_libraries/stargazers)
+
+---
+
+## Why this repo?
+
+Writing compliance policies from scratch is expensive and error-prone. A typical enterprise deploying OPA for CIS RHEL 9 alone needs 338 individual control checks — and that's one framework for one OS.
+
+This library gives you a **complete, working policy set on day one**, covering 22 platforms, 50+ regulatory frameworks, and every major compliance standard from CIS and DISA STIGs to NERC-CIP and IEC 62443. All policies:
+
+- Use **Rego v1 syntax** (`import rego.v1`) — no deprecation warnings, forward-compatible
+- Return **structured JSON reports** (compliant, score, violations list) — wire directly to dashboards or CI
+- Are **independently loadable** — use one framework or all 396 policies; no coupling
+- Are **Apache 2.0 licensed** — use commercially without restriction
+
+> **Why not build your own?** You can — but CIS RHEL 9 alone has 338 controls across 14 sections. NERC-CIP covers 14 standards (CIP-002 through CIP-015) with 200+ requirements. IEC 62443 adds 51 System Requirements across 7 Foundational Requirements. Starting from scratch takes months. This library is that months-of-work already done.
+
+---
+
+## Coverage at a glance
+
+| Standard / Framework | Path | Controls / Requirements |
+|---------------------|------|------------------------|
+| **CIS RHEL 9 v2.0.0** | `benchmarks/cis/os/linux/rhel_9/` | **338/338 (100%)** ✅ |
+| CIS RHEL 8 | `benchmarks/cis/os/linux/rhel_8/` | Full |
+| CIS Ubuntu 22.04/24.04/20.04 | `benchmarks/cis/os/linux/ubuntu_*/` | Full |
+| CIS Windows Server 2019/2022 | `benchmarks/cis/os/windows/` | 9 sections |
+| CIS AWS / Azure / GCP | `benchmarks/cis/cloud/` | Foundations |
+| CIS Docker / Kubernetes / OpenShift | `benchmarks/cis/containers/` | Full |
+| DISA STIG RHEL 8/9, Ubuntu, Windows | `benchmarks/stig/` | Full |
+| NIST 800-53 rev5 | `frameworks/federal/nist_800_53/` | All control families |
+| NIST 800-82 (OT) | `frameworks/federal/nist_800_82/` | Full |
+| FISMA / FedRAMP / CMMC | `frameworks/federal/` | Full |
+| ISO 27001:2022 | `frameworks/management/iso27001/` | Full ISMS |
+| SOC 2 Type II | `frameworks/management/soc2/` | All TSCs |
+| PCI-DSS v4.0 | `frameworks/financial/pci_dss/` | All 12 requirements |
+| SOX ITGC | `frameworks/financial/sox/` | Full |
+| HIPAA | `frameworks/privacy/hipaa/` | Full |
+| GDPR | `frameworks/privacy/gdpr/` | Full |
+| NERC-CIP (CIP-002 – CIP-015) | `frameworks/critical_infrastructure/nerc_cip/` | 14 standards |
+| IEC 62443 (all parts) | `frameworks/critical_infrastructure/iec_62443/` | 51 SRs, SL 1–4 |
+| NIST IR 7628 (AMI / Smart Grid) | `frameworks/critical_infrastructure/ami/` | Full |
+| DORA / NIS2 | `frameworks/regulatory/` | Full |
+| NCSC CAF 4.0 | `frameworks/management/ncsc_caf/` | 23 Cyber Outcomes |
+| Digital Sovereignty | `frameworks/sovereignty/` | 7 domains |
 
 ---
 


### PR DESCRIPTION
## Summary

- **README**: Added \"Why this repo?\" section with problem statement and \"why not build your own\" framing; full framework coverage table (22+ rows); GitHub stars badge
- **CONTRIBUTING.md**: Complete guide covering taxonomy placement, required Rego v1 structure, PR checklist, `array.concat()` pitfall
- **Issue templates**: Framework request (YAML form) and bug report (YAML form)
- **opcr.io workflow**: GitHub Actions to build OPA bundle with `opa build` and push to `opcr.io` as OCI artifact on every main push and semver tag

## Setup required for opcr.io publishing

Add two repository secrets:
- `OPCR_USERNAME` — opcr.io username (ynotbhatc)
- `OPCR_TOKEN` — opcr.io API token from https://opcr.io

Once set, policies are available via:
```
opa pull opcr.io/ynotbhatc/rego_policy_libraries:latest
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)