### PR TITLE
feat: add 5 new compliance frameworks (396 → 444 policies)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rego Policy Libraries
 
-> **396 production-ready OPA policies** covering CIS Benchmarks, DISA STIGs, NIST, SOC 2, PCI-DSS, ISO 27001, NERC-CIP, IEC 62443, HIPAA, FedRAMP, and more — all in Rego v1 syntax, ready to load into any OPA instance.
+> **444 production-ready OPA policies** covering CIS Benchmarks, DISA STIGs, NIST, SOC 2, PCI-DSS, ISO 27001, NERC-CIP, IEC 62443, HIPAA, FedRAMP, CSA CCM, CCPA/CPRA, EU AI Act, and more — all in Rego v1 syntax, ready to load into any OPA instance.
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![OPA](https://img.shields.io/badge/OPA-v0.60%2B-blue)](https://www.openpolicyagent.org/)
@@ -51,6 +51,11 @@ This library gives you a **complete, working policy set on day one**, covering 2
 | DORA / NIS2 | `frameworks/regulatory/` | Full |
 | NCSC CAF 4.0 | `frameworks/management/ncsc_caf/` | 23 Cyber Outcomes |
 | Digital Sovereignty | `frameworks/sovereignty/` | 7 domains |
+| **CSA CCM v4.0** | `frameworks/management/csa_ccm/` | 16 domains, 197 controls |
+| **ISO/IEC 27701:2019** | `frameworks/privacy/iso27701/` | PIMS, PII Controller, PII Processor, DSR |
+| **NIST SP 800-171 Rev 3** | `frameworks/federal/nist/sp_800_171/` | 14 families, 110 CUI requirements |
+| **CCPA / CPRA** | `frameworks/privacy/ccpa/` | Consumer rights, sensitive PI, data practices |
+| **EU AI Act (2024/1689)** | `governance/eu_ai_act/` | Prohibited, High-Risk, Transparency, GPAI, Governance |
 
 ---
 
@@ -59,9 +64,9 @@ This library gives you a **complete, working policy set on day one**, covering 2
 | Domain | Policies | Coverage |
 |--------|----------|----------|
 | **CIS Benchmarks + DISA STIGs** | 238 | 22 platforms: Linux, Windows, Cloud, Containers, Databases, Network + RHEL 8/9 & Windows 2022 STIGs |
-| **Regulatory Frameworks** | 145 | ISO 27001, SOC 2, PCI-DSS, SOX, FISMA, FedRAMP, CMMC, GDPR, HIPAA, NERC-CIP, IEC 62443, DORA, NIS2, NY DFS, SEC Cyber, SWIFT CSP, HITRUST, TISAX, CFR Part 11, NCSC CAF, Digital Sovereignty |
+| **Regulatory Frameworks** | 186 | ISO 27001, SOC 2, PCI-DSS, SOX, FISMA, FedRAMP, CMMC, GDPR, HIPAA, NERC-CIP, IEC 62443, DORA, NIS2, NY DFS, SEC Cyber, SWIFT CSP, HITRUST, TISAX, CFR Part 11, NCSC CAF, Digital Sovereignty, **CSA CCM v4.0**, **ISO 27701**, **NIST SP 800-171 r3**, **CCPA/CPRA** |
 | **Enforcement** | 6 | Ansible, Terraform, Dockerfile, Kubernetes, Git |
-| **Governance** | 6 | AI agent authorization, MCP tool-call enforcement, GEISA |
+| **Governance** | 13 | AI agent authorization, MCP tool-call enforcement, GEISA, **EU AI Act (Regulation 2024/1689)** |
 | **Threat Detection** | 1 | Cryptocurrency miner detection |
 
 **Highlight:** CIS RHEL 9 v2.0.0 — **338/338 controls (100%)** across 14 modules.

--- a/frameworks/federal/nist/sp_800_171/audit_accountability/nist_800_171_au.rego
+++ b/frameworks/federal/nist/sp_800_171/audit_accountability/nist_800_171_au.rego
@@ -1,0 +1,164 @@
+package nist.sp800_171.audit_accountability
+
+import rego.v1
+
+# NIST SP 800-171 Rev 3 - Audit and Accountability (AU) Requirements
+# Family: 3.3 — Protecting Controlled Unclassified Information (CUI)
+
+# 3.3.1: Create and retain system audit logs and records to the extent needed to enable
+#         monitoring, analysis, investigation, and reporting of unlawful or unauthorized
+#         system activity
+default audit_logs_created_retained := false
+
+audit_logs_created_retained if {
+    input.nist_800_171.audit_accountability.audit_logs.logging_enabled == true
+    input.nist_800_171.audit_accountability.audit_logs.retention_period_days >= 90
+    input.nist_800_171.audit_accountability.audit_logs.covers_all_systems == true
+}
+
+# 3.3.2: Ensure that the actions of individual users can be uniquely traced to those users,
+#         so they can be held accountable for their actions
+default user_accountability := false
+
+user_accountability if {
+    input.nist_800_171.audit_accountability.user_tracing.unique_user_ids == true
+    input.nist_800_171.audit_accountability.user_tracing.shared_accounts_prohibited == true
+    input.nist_800_171.audit_accountability.user_tracing.audit_trail_complete == true
+}
+
+# 3.3.3: Review and update logged events
+default logged_events_reviewed := false
+
+logged_events_reviewed if {
+    input.nist_800_171.audit_accountability.event_review.events_defined == true
+    input.nist_800_171.audit_accountability.event_review.periodic_review_performed == true
+    input.nist_800_171.audit_accountability.event_review.updates_documented == true
+}
+
+# 3.3.4: Alert in the event of an audit logging process failure
+default audit_failure_alerting := false
+
+audit_failure_alerting if {
+    input.nist_800_171.audit_accountability.failure_alerting.alerts_configured == true
+    input.nist_800_171.audit_accountability.failure_alerting.responsible_personnel_notified == true
+    input.nist_800_171.audit_accountability.failure_alerting.response_procedures_documented == true
+}
+
+# 3.3.5: Correlate audit record review, analysis, and reporting processes for investigation
+#         and response to indications of unlawful, unauthorized, suspicious, or unusual activity
+default audit_correlation := false
+
+audit_correlation if {
+    input.nist_800_171.audit_accountability.correlation.correlation_capability == true
+    input.nist_800_171.audit_accountability.correlation.cross_system_analysis == true
+    input.nist_800_171.audit_accountability.correlation.reporting_integrated == true
+}
+
+# 3.3.6: Provide audit record reduction and report generation to support on-demand analysis
+#         and reporting
+default audit_reduction_reporting := false
+
+audit_reduction_reporting if {
+    input.nist_800_171.audit_accountability.reduction.reduction_capability == true
+    input.nist_800_171.audit_accountability.reduction.report_generation == true
+    input.nist_800_171.audit_accountability.reduction.on_demand_analysis == true
+}
+
+# 3.3.7: Provide a system capability that compares and synchronizes internal system clocks
+#         with an authoritative source to generate time stamps for audit records
+default time_synchronization := false
+
+time_synchronization if {
+    input.nist_800_171.audit_accountability.time_sync.ntp_configured == true
+    input.nist_800_171.audit_accountability.time_sync.authoritative_source == true
+    input.nist_800_171.audit_accountability.time_sync.all_systems_synchronized == true
+}
+
+# 3.3.8: Protect audit information and audit tools from unauthorized access, modification,
+#         and deletion
+default audit_protection := false
+
+audit_protection if {
+    input.nist_800_171.audit_accountability.audit_protection.access_restricted == true
+    input.nist_800_171.audit_accountability.audit_protection.integrity_protected == true
+    input.nist_800_171.audit_accountability.audit_protection.deletion_prevented == true
+}
+
+# 3.3.9: Limit management of audit logging to a subset of privileged users
+default audit_management_limited := false
+
+audit_management_limited if {
+    input.nist_800_171.audit_accountability.audit_management.restricted_to_privileged == true
+    input.nist_800_171.audit_accountability.audit_management.access_list_documented == true
+    input.nist_800_171.audit_accountability.audit_management.separation_of_duties == true
+}
+
+# Violations set
+violations contains msg if {
+    not audit_logs_created_retained
+    msg := "NIST 800-171 3.3.1: System audit logs must be created and retained (minimum 90 days) to support monitoring and investigation"
+}
+
+violations contains msg if {
+    not user_accountability
+    msg := "NIST 800-171 3.3.2: Individual user actions must be uniquely traceable; shared accounts must be prohibited"
+}
+
+violations contains msg if {
+    not logged_events_reviewed
+    msg := "NIST 800-171 3.3.3: Logged events must be defined, periodically reviewed, and updated as needed"
+}
+
+violations contains msg if {
+    not audit_failure_alerting
+    msg := "NIST 800-171 3.3.4: Alerts must be configured for audit logging process failures and responsible personnel must be notified"
+}
+
+violations contains msg if {
+    not audit_correlation
+    msg := "NIST 800-171 3.3.5: Audit records must be correlated across systems to support investigation of suspicious activity"
+}
+
+violations contains msg if {
+    not audit_reduction_reporting
+    msg := "NIST 800-171 3.3.6: Audit record reduction and report generation capability must be available for on-demand analysis"
+}
+
+violations contains msg if {
+    not time_synchronization
+    msg := "NIST 800-171 3.3.7: All system clocks must be synchronized with an authoritative NTP source for accurate audit timestamps"
+}
+
+violations contains msg if {
+    not audit_protection
+    msg := "NIST 800-171 3.3.8: Audit information and tools must be protected from unauthorized access, modification, and deletion"
+}
+
+violations contains msg if {
+    not audit_management_limited
+    msg := "NIST 800-171 3.3.9: Management of audit logging must be restricted to a subset of privileged users with documented access list"
+}
+
+# Compliance aggregation
+default compliant := false
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "family": "3.3 Audit and Accountability",
+    "standard": "NIST SP 800-171 Rev 3",
+    "total_controls": 9,
+    "violations": violations,
+    "compliant": compliant,
+    "controls": {
+        "3.3.1_audit_logs_created_retained": audit_logs_created_retained,
+        "3.3.2_user_accountability": user_accountability,
+        "3.3.3_logged_events_reviewed": logged_events_reviewed,
+        "3.3.4_audit_failure_alerting": audit_failure_alerting,
+        "3.3.5_audit_correlation": audit_correlation,
+        "3.3.6_audit_reduction_reporting": audit_reduction_reporting,
+        "3.3.7_time_synchronization": time_synchronization,
+        "3.3.8_audit_protection": audit_protection,
+        "3.3.9_audit_management_limited": audit_management_limited,
+    },
+}

--- a/frameworks/federal/nist/sp_800_171/awareness_training/nist_800_171_at.rego
+++ b/frameworks/federal/nist/sp_800_171/awareness_training/nist_800_171_at.rego
@@ -1,0 +1,72 @@
+package nist.sp800_171.awareness_training
+
+import rego.v1
+
+# NIST SP 800-171 Rev 3 - Awareness and Training (AT) Requirements
+# Family: 3.2 — Protecting Controlled Unclassified Information (CUI)
+
+# 3.2.1: Ensure personnel are aware of security risks associated with their activities and
+#         organizational systems, and ensure personnel are trained to carry out assigned
+#         information security responsibilities
+default security_awareness_program := false
+
+security_awareness_program if {
+    input.nist_800_171.awareness_training.awareness.program_established == true
+    input.nist_800_171.awareness_training.awareness.all_personnel_covered == true
+    input.nist_800_171.awareness_training.awareness.risk_topics_included == true
+    input.nist_800_171.awareness_training.awareness.periodic_refreshes == true
+}
+
+# 3.2.2: Ensure personnel are trained to carry out assigned information security responsibilities
+default role_based_training := false
+
+role_based_training if {
+    input.nist_800_171.awareness_training.role_training.role_specific_content == true
+    input.nist_800_171.awareness_training.role_training.completion_tracked == true
+    input.nist_800_171.awareness_training.role_training.before_access_granted == true
+}
+
+# 3.2.3: Provide security awareness training on recognizing and reporting threats including
+#         phishing, social engineering, and insider threats
+default threat_recognition_training := false
+
+threat_recognition_training if {
+    input.nist_800_171.awareness_training.threat_training.phishing_covered == true
+    input.nist_800_171.awareness_training.threat_training.social_engineering_covered == true
+    input.nist_800_171.awareness_training.threat_training.insider_threat_covered == true
+    input.nist_800_171.awareness_training.threat_training.reporting_procedures_covered == true
+}
+
+# Violations set
+violations contains msg if {
+    not security_awareness_program
+    msg := "NIST 800-171 3.2.1: A security awareness program covering CUI-related risks must be established for all personnel"
+}
+
+violations contains msg if {
+    not role_based_training
+    msg := "NIST 800-171 3.2.2: Role-based security training must be provided before granting access and tracked to completion"
+}
+
+violations contains msg if {
+    not threat_recognition_training
+    msg := "NIST 800-171 3.2.3: Security awareness training must cover phishing, social engineering, insider threats, and reporting procedures"
+}
+
+# Compliance aggregation
+default compliant := false
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "family": "3.2 Awareness and Training",
+    "standard": "NIST SP 800-171 Rev 3",
+    "total_controls": 3,
+    "violations": violations,
+    "compliant": compliant,
+    "controls": {
+        "3.2.1_security_awareness_program": security_awareness_program,
+        "3.2.2_role_based_training": role_based_training,
+        "3.2.3_threat_recognition_training": threat_recognition_training,
+    },
+}

--- a/frameworks/federal/nist/sp_800_171/configuration_management/nist_800_171_cm.rego
+++ b/frameworks/federal/nist/sp_800_171/configuration_management/nist_800_171_cm.rego
@@ -1,0 +1,166 @@
+package nist.sp800_171.configuration_management
+
+import rego.v1
+
+# NIST SP 800-171 Rev 3 - Configuration Management (CM) Requirements
+# Family: 3.4 — Protecting Controlled Unclassified Information (CUI)
+
+# 3.4.1: Establish and maintain baseline configurations and inventories of organizational
+#         systems throughout the respective system development life cycles
+default baseline_configurations := false
+
+baseline_configurations if {
+    input.nist_800_171.configuration_management.baselines.documented == true
+    input.nist_800_171.configuration_management.baselines.inventory_maintained == true
+    input.nist_800_171.configuration_management.baselines.includes_all_components == true
+    input.nist_800_171.configuration_management.baselines.reviewed_periodically == true
+}
+
+# 3.4.2: Establish and enforce security configuration settings for information technology
+#         products employed in organizational systems
+default security_configuration_settings := false
+
+security_configuration_settings if {
+    input.nist_800_171.configuration_management.security_settings.settings_defined == true
+    input.nist_800_171.configuration_management.security_settings.enforcement_automated == true
+    input.nist_800_171.configuration_management.security_settings.deviations_approved == true
+}
+
+# 3.4.3: Track, review, approve, and log changes to organizational systems
+default change_control := false
+
+change_control if {
+    input.nist_800_171.configuration_management.change_control.change_tracking == true
+    input.nist_800_171.configuration_management.change_control.review_process == true
+    input.nist_800_171.configuration_management.change_control.approval_required == true
+    input.nist_800_171.configuration_management.change_control.changes_logged == true
+}
+
+# 3.4.4: Analyze the security impact of changes prior to implementation
+default security_impact_analysis := false
+
+security_impact_analysis if {
+    input.nist_800_171.configuration_management.impact_analysis.performed_before_implementation == true
+    input.nist_800_171.configuration_management.impact_analysis.security_team_involved == true
+    input.nist_800_171.configuration_management.impact_analysis.results_documented == true
+}
+
+# 3.4.5: Define, document, approve, and enforce physical and logical access restrictions
+#         associated with changes to organizational systems
+default change_access_restrictions := false
+
+change_access_restrictions if {
+    input.nist_800_171.configuration_management.change_access.physical_restrictions_defined == true
+    input.nist_800_171.configuration_management.change_access.logical_restrictions_defined == true
+    input.nist_800_171.configuration_management.change_access.approval_documented == true
+    input.nist_800_171.configuration_management.change_access.enforcement_implemented == true
+}
+
+# 3.4.6: Employ the principle of least functionality by configuring organizational systems
+#         to provide only essential capabilities
+default least_functionality := false
+
+least_functionality if {
+    input.nist_800_171.configuration_management.least_functionality.unnecessary_functions_disabled == true
+    input.nist_800_171.configuration_management.least_functionality.reviewed_periodically == true
+    input.nist_800_171.configuration_management.least_functionality.documented_rationale == true
+}
+
+# 3.4.7: Restrict, disable, or prevent the use of nonessential programs, functions, ports,
+#         protocols, and services
+default nonessential_services_restricted := false
+
+nonessential_services_restricted if {
+    input.nist_800_171.configuration_management.nonessential.ports_restricted == true
+    input.nist_800_171.configuration_management.nonessential.protocols_restricted == true
+    input.nist_800_171.configuration_management.nonessential.services_restricted == true
+    input.nist_800_171.configuration_management.nonessential.programs_restricted == true
+}
+
+# 3.4.8: Apply deny-by-exception (blacklisting) policy to prevent use of unauthorized software
+default deny_by_exception_policy := false
+
+deny_by_exception_policy if {
+    input.nist_800_171.configuration_management.software_policy.deny_by_exception_implemented == true
+    input.nist_800_171.configuration_management.software_policy.authorized_software_list == true
+    input.nist_800_171.configuration_management.software_policy.enforcement_automated == true
+}
+
+# 3.4.9: Control and monitor user-installed software
+default user_installed_software_controlled := false
+
+user_installed_software_controlled if {
+    input.nist_800_171.configuration_management.user_software.installation_restricted == true
+    input.nist_800_171.configuration_management.user_software.monitoring_implemented == true
+    input.nist_800_171.configuration_management.user_software.policy_documented == true
+}
+
+# Violations set
+violations contains msg if {
+    not baseline_configurations
+    msg := "NIST 800-171 3.4.1: Baseline configurations and system inventories must be established, documented, and maintained"
+}
+
+violations contains msg if {
+    not security_configuration_settings
+    msg := "NIST 800-171 3.4.2: Security configuration settings must be established and enforced for all IT products"
+}
+
+violations contains msg if {
+    not change_control
+    msg := "NIST 800-171 3.4.3: Changes to organizational systems must be tracked, reviewed, approved, and logged"
+}
+
+violations contains msg if {
+    not security_impact_analysis
+    msg := "NIST 800-171 3.4.4: Security impact analysis must be performed and documented before implementing system changes"
+}
+
+violations contains msg if {
+    not change_access_restrictions
+    msg := "NIST 800-171 3.4.5: Physical and logical access restrictions for system changes must be defined, approved, and enforced"
+}
+
+violations contains msg if {
+    not least_functionality
+    msg := "NIST 800-171 3.4.6: Systems must be configured for least functionality with unnecessary functions disabled and reviewed periodically"
+}
+
+violations contains msg if {
+    not nonessential_services_restricted
+    msg := "NIST 800-171 3.4.7: Nonessential programs, ports, protocols, and services must be restricted, disabled, or prevented"
+}
+
+violations contains msg if {
+    not deny_by_exception_policy
+    msg := "NIST 800-171 3.4.8: A deny-by-exception policy must be implemented with an authorized software list and automated enforcement"
+}
+
+violations contains msg if {
+    not user_installed_software_controlled
+    msg := "NIST 800-171 3.4.9: User-installed software must be controlled with installation restrictions and active monitoring"
+}
+
+# Compliance aggregation
+default compliant := false
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "family": "3.4 Configuration Management",
+    "standard": "NIST SP 800-171 Rev 3",
+    "total_controls": 9,
+    "violations": violations,
+    "compliant": compliant,
+    "controls": {
+        "3.4.1_baseline_configurations": baseline_configurations,
+        "3.4.2_security_configuration_settings": security_configuration_settings,
+        "3.4.3_change_control": change_control,
+        "3.4.4_security_impact_analysis": security_impact_analysis,
+        "3.4.5_change_access_restrictions": change_access_restrictions,
+        "3.4.6_least_functionality": least_functionality,
+        "3.4.7_nonessential_services_restricted": nonessential_services_restricted,
+        "3.4.8_deny_by_exception_policy": deny_by_exception_policy,
+        "3.4.9_user_installed_software_controlled": user_installed_software_controlled,
+    },
+}

--- a/frameworks/federal/nist/sp_800_171/identification_authentication/nist_800_171_ia.rego
+++ b/frameworks/federal/nist/sp_800_171/identification_authentication/nist_800_171_ia.rego
@@ -1,0 +1,189 @@
+package nist.sp800_171.identification_authentication
+
+import rego.v1
+
+# NIST SP 800-171 Rev 3 - Identification and Authentication (IA) Requirements
+# Family: 3.5 — Protecting Controlled Unclassified Information (CUI)
+
+# 3.5.1: Identify system users, processes acting on behalf of users, and devices
+default system_identification := false
+
+system_identification if {
+    input.nist_800_171.identification_authentication.identification.users_identified == true
+    input.nist_800_171.identification_authentication.identification.processes_identified == true
+    input.nist_800_171.identification_authentication.identification.devices_identified == true
+}
+
+# 3.5.2: Authenticate (or verify) the identities of users, processes, or devices before
+#         allowing access to organizational systems
+default identity_authentication := false
+
+identity_authentication if {
+    input.nist_800_171.identification_authentication.authentication.required_before_access == true
+    input.nist_800_171.identification_authentication.authentication.all_entry_points_covered == true
+    input.nist_800_171.identification_authentication.authentication.mechanism_documented == true
+}
+
+# 3.5.3: Use multifactor authentication for local and network access to privileged accounts
+#         and for network access to non-privileged accounts
+default multifactor_authentication := false
+
+multifactor_authentication if {
+    input.nist_800_171.identification_authentication.mfa.privileged_local_mfa == true
+    input.nist_800_171.identification_authentication.mfa.privileged_network_mfa == true
+    input.nist_800_171.identification_authentication.mfa.non_privileged_network_mfa == true
+}
+
+# 3.5.4: Employ replay-resistant authentication mechanisms for network access to privileged
+#         and non-privileged accounts
+default replay_resistant_authentication := false
+
+replay_resistant_authentication if {
+    input.nist_800_171.identification_authentication.replay_resistant.mechanism_implemented == true
+    input.nist_800_171.identification_authentication.replay_resistant.covers_privileged == true
+    input.nist_800_171.identification_authentication.replay_resistant.covers_non_privileged == true
+}
+
+# 3.5.5: Employ identifier management including disabling identifiers after 35 days of inactivity
+default identifier_management := false
+
+identifier_management if {
+    input.nist_800_171.identification_authentication.identifier_mgmt.inactivity_period_days <= 35
+    input.nist_800_171.identification_authentication.identifier_mgmt.disable_on_inactivity == true
+    input.nist_800_171.identification_authentication.identifier_mgmt.unique_identifiers == true
+}
+
+# 3.5.6: Disable identifiers after a defined inactivity period
+default identifier_inactivity_disable := false
+
+identifier_inactivity_disable if {
+    input.nist_800_171.identification_authentication.inactivity_disable.policy_defined == true
+    input.nist_800_171.identification_authentication.inactivity_disable.automated_enforcement == true
+    input.nist_800_171.identification_authentication.inactivity_disable.period_documented == true
+}
+
+# 3.5.7: Enforce a minimum password complexity and change requirements for passwords
+default password_complexity := false
+
+password_complexity if {
+    input.nist_800_171.identification_authentication.password_complexity.minimum_length >= 12
+    input.nist_800_171.identification_authentication.password_complexity.complexity_enforced == true
+    input.nist_800_171.identification_authentication.password_complexity.change_requirements_defined == true
+}
+
+# 3.5.8: Prohibit password reuse for a specified number of generations (minimum 5)
+default password_reuse_prohibited := false
+
+password_reuse_prohibited if {
+    input.nist_800_171.identification_authentication.password_reuse.generations_remembered >= 5
+    input.nist_800_171.identification_authentication.password_reuse.enforcement_automated == true
+}
+
+# 3.5.9: Allow temporary password use with an immediate change requirement
+default temporary_password_control := false
+
+temporary_password_control if {
+    input.nist_800_171.identification_authentication.temp_password.immediate_change_required == true
+    input.nist_800_171.identification_authentication.temp_password.secure_delivery == true
+    input.nist_800_171.identification_authentication.temp_password.expiry_enforced == true
+}
+
+# 3.5.10: Store and transmit only cryptographically-protected passwords
+default password_cryptographic_protection := false
+
+password_cryptographic_protection if {
+    input.nist_800_171.identification_authentication.password_crypto.storage_hashed == true
+    input.nist_800_171.identification_authentication.password_crypto.transmission_encrypted == true
+    input.nist_800_171.identification_authentication.password_crypto.approved_algorithms == true
+}
+
+# 3.5.11: Obscure feedback of authentication information during the authentication process
+default authentication_feedback_obscured := false
+
+authentication_feedback_obscured if {
+    input.nist_800_171.identification_authentication.feedback.password_masked == true
+    input.nist_800_171.identification_authentication.feedback.no_hint_displayed == true
+    input.nist_800_171.identification_authentication.feedback.all_interfaces_covered == true
+}
+
+# Violations set
+violations contains msg if {
+    not system_identification
+    msg := "NIST 800-171 3.5.1: All system users, processes, and devices must be uniquely identified"
+}
+
+violations contains msg if {
+    not identity_authentication
+    msg := "NIST 800-171 3.5.2: Identity must be authenticated before granting access to organizational systems at all entry points"
+}
+
+violations contains msg if {
+    not multifactor_authentication
+    msg := "NIST 800-171 3.5.3: MFA must be used for local and network access to privileged accounts and network access to non-privileged accounts"
+}
+
+violations contains msg if {
+    not replay_resistant_authentication
+    msg := "NIST 800-171 3.5.4: Replay-resistant authentication mechanisms must be employed for network access to all account types"
+}
+
+violations contains msg if {
+    not identifier_management
+    msg := "NIST 800-171 3.5.5: Identifiers must be managed with unique IDs and disabled after a maximum of 35 days of inactivity"
+}
+
+violations contains msg if {
+    not identifier_inactivity_disable
+    msg := "NIST 800-171 3.5.6: Identifiers must be automatically disabled after a defined and documented inactivity period"
+}
+
+violations contains msg if {
+    not password_complexity
+    msg := "NIST 800-171 3.5.7: Password complexity must be enforced including minimum length of 12 characters and defined change requirements"
+}
+
+violations contains msg if {
+    not password_reuse_prohibited
+    msg := "NIST 800-171 3.5.8: Password reuse must be prohibited for a minimum of 5 previous generations with automated enforcement"
+}
+
+violations contains msg if {
+    not temporary_password_control
+    msg := "NIST 800-171 3.5.9: Temporary passwords must require immediate change upon use and must be securely delivered with expiry enforced"
+}
+
+violations contains msg if {
+    not password_cryptographic_protection
+    msg := "NIST 800-171 3.5.10: Passwords must be cryptographically hashed for storage and encrypted for transmission using approved algorithms"
+}
+
+violations contains msg if {
+    not authentication_feedback_obscured
+    msg := "NIST 800-171 3.5.11: Authentication feedback (passwords) must be obscured on all interfaces during the authentication process"
+}
+
+# Compliance aggregation
+default compliant := false
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "family": "3.5 Identification and Authentication",
+    "standard": "NIST SP 800-171 Rev 3",
+    "total_controls": 11,
+    "violations": violations,
+    "compliant": compliant,
+    "controls": {
+        "3.5.1_system_identification": system_identification,
+        "3.5.2_identity_authentication": identity_authentication,
+        "3.5.3_multifactor_authentication": multifactor_authentication,
+        "3.5.4_replay_resistant_authentication": replay_resistant_authentication,
+        "3.5.5_identifier_management": identifier_management,
+        "3.5.6_identifier_inactivity_disable": identifier_inactivity_disable,
+        "3.5.7_password_complexity": password_complexity,
+        "3.5.8_password_reuse_prohibited": password_reuse_prohibited,
+        "3.5.9_temporary_password_control": temporary_password_control,
+        "3.5.10_password_cryptographic_protection": password_cryptographic_protection,
+        "3.5.11_authentication_feedback_obscured": authentication_feedback_obscured,
+    },
+}

--- a/frameworks/federal/nist/sp_800_171/incident_response/nist_800_171_ir.rego
+++ b/frameworks/federal/nist/sp_800_171/incident_response/nist_800_171_ir.rego
@@ -1,0 +1,75 @@
+package nist.sp800_171.incident_response
+
+import rego.v1
+
+# NIST SP 800-171 Rev 3 - Incident Response (IR) Requirements
+# Family: 3.6 — Protecting Controlled Unclassified Information (CUI)
+
+# 3.6.1: Establish an operational incident-handling capability for organizational systems
+#         including preparation, detection, analysis, containment, recovery, and user response
+default incident_handling_capability := false
+
+incident_handling_capability if {
+    input.nist_800_171.incident_response.handling.plan_documented == true
+    input.nist_800_171.incident_response.handling.preparation_phase == true
+    input.nist_800_171.incident_response.handling.detection_procedures == true
+    input.nist_800_171.incident_response.handling.analysis_procedures == true
+    input.nist_800_171.incident_response.handling.containment_procedures == true
+    input.nist_800_171.incident_response.handling.recovery_procedures == true
+    input.nist_800_171.incident_response.handling.user_response_procedures == true
+}
+
+# 3.6.2: Track, document, and report incidents to appropriate officials and/or authorities
+default incident_tracking_reporting := false
+
+incident_tracking_reporting if {
+    input.nist_800_171.incident_response.tracking.incident_tracking_system == true
+    input.nist_800_171.incident_response.tracking.documentation_required == true
+    input.nist_800_171.incident_response.tracking.designated_officials_identified == true
+    input.nist_800_171.incident_response.tracking.reporting_timelines_defined == true
+}
+
+# 3.6.3: Test the organizational incident response capability (tabletop exercise or live drill)
+#         at least annually
+default incident_response_testing := false
+
+incident_response_testing if {
+    input.nist_800_171.incident_response.testing.tested_annually == true
+    input.nist_800_171.incident_response.testing.test_type_documented == true
+    input.nist_800_171.incident_response.testing.results_reviewed == true
+    input.nist_800_171.incident_response.testing.lessons_incorporated == true
+}
+
+# Violations set
+violations contains msg if {
+    not incident_handling_capability
+    msg := "NIST 800-171 3.6.1: An operational incident-handling capability must be established covering preparation, detection, analysis, containment, recovery, and user response"
+}
+
+violations contains msg if {
+    not incident_tracking_reporting
+    msg := "NIST 800-171 3.6.2: Incidents must be tracked, documented, and reported to designated officials with defined reporting timelines"
+}
+
+violations contains msg if {
+    not incident_response_testing
+    msg := "NIST 800-171 3.6.3: Incident response capability must be tested at least annually with results reviewed and lessons incorporated"
+}
+
+# Compliance aggregation
+default compliant := false
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "family": "3.6 Incident Response",
+    "standard": "NIST SP 800-171 Rev 3",
+    "total_controls": 3,
+    "violations": violations,
+    "compliant": compliant,
+    "controls": {
+        "3.6.1_incident_handling_capability": incident_handling_capability,
+        "3.6.2_incident_tracking_reporting": incident_tracking_reporting,
+        "3.6.3_incident_response_testing": incident_response_testing,
+    },
+}

--- a/frameworks/federal/nist/sp_800_171/maintenance/nist_800_171_ma.rego
+++ b/frameworks/federal/nist/sp_800_171/maintenance/nist_800_171_ma.rego
@@ -1,0 +1,116 @@
+package nist.sp800_171.maintenance
+
+import rego.v1
+
+# NIST SP 800-171 Rev 3 - Maintenance (MA) Requirements
+# Family: 3.7 — Protecting Controlled Unclassified Information (CUI)
+
+# 3.7.1: Perform maintenance on organizational systems
+default maintenance_performed := false
+
+maintenance_performed if {
+    input.nist_800_171.maintenance.maintenance_schedule.schedule_documented == true
+    input.nist_800_171.maintenance.maintenance_schedule.performed_regularly == true
+    input.nist_800_171.maintenance.maintenance_schedule.records_maintained == true
+}
+
+# 3.7.2: Provide controls on the tools, techniques, mechanisms, and personnel that perform
+#         maintenance on organizational systems
+default maintenance_controls := false
+
+maintenance_controls if {
+    input.nist_800_171.maintenance.controls.approved_tools == true
+    input.nist_800_171.maintenance.controls.approved_techniques == true
+    input.nist_800_171.maintenance.controls.authorized_personnel_only == true
+    input.nist_800_171.maintenance.controls.controls_documented == true
+}
+
+# 3.7.3: Ensure equipment removed for off-site maintenance is sanitized of any CUI
+default equipment_sanitization := false
+
+equipment_sanitization if {
+    input.nist_800_171.maintenance.sanitization.removed_equipment_sanitized == true
+    input.nist_800_171.maintenance.sanitization.sanitization_verified == true
+    input.nist_800_171.maintenance.sanitization.process_documented == true
+}
+
+# 3.7.4: Check media containing diagnostic programs for malicious code before use
+default diagnostic_media_checked := false
+
+diagnostic_media_checked if {
+    input.nist_800_171.maintenance.diagnostic_media.scanned_before_use == true
+    input.nist_800_171.maintenance.diagnostic_media.approved_scanning_tool == true
+    input.nist_800_171.maintenance.diagnostic_media.results_documented == true
+}
+
+# 3.7.5: Require MFA to establish nonlocal (remote) maintenance sessions via external
+#         networks and terminate such connections when nonlocal maintenance is complete
+default remote_maintenance_mfa := false
+
+remote_maintenance_mfa if {
+    input.nist_800_171.maintenance.remote_maintenance.mfa_required == true
+    input.nist_800_171.maintenance.remote_maintenance.session_terminated_after == true
+    input.nist_800_171.maintenance.remote_maintenance.connections_monitored == true
+}
+
+# 3.7.6: Supervise maintenance activities of maintenance personnel without required
+#         access authorization
+default maintenance_supervision := false
+
+maintenance_supervision if {
+    input.nist_800_171.maintenance.supervision.unauthorized_personnel_supervised == true
+    input.nist_800_171.maintenance.supervision.supervisor_has_required_access == true
+    input.nist_800_171.maintenance.supervision.supervision_documented == true
+}
+
+# Violations set
+violations contains msg if {
+    not maintenance_performed
+    msg := "NIST 800-171 3.7.1: System maintenance must be performed on a documented schedule with records maintained"
+}
+
+violations contains msg if {
+    not maintenance_controls
+    msg := "NIST 800-171 3.7.2: Controls must be established for maintenance tools, techniques, mechanisms, and authorized personnel"
+}
+
+violations contains msg if {
+    not equipment_sanitization
+    msg := "NIST 800-171 3.7.3: Equipment removed for off-site maintenance must be sanitized of CUI and sanitization must be verified"
+}
+
+violations contains msg if {
+    not diagnostic_media_checked
+    msg := "NIST 800-171 3.7.4: Media containing diagnostic programs must be scanned for malicious code before use in maintenance"
+}
+
+violations contains msg if {
+    not remote_maintenance_mfa
+    msg := "NIST 800-171 3.7.5: MFA must be required for remote maintenance sessions and connections must be terminated when complete"
+}
+
+violations contains msg if {
+    not maintenance_supervision
+    msg := "NIST 800-171 3.7.6: Maintenance personnel without required access authorization must be supervised by authorized individuals"
+}
+
+# Compliance aggregation
+default compliant := false
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "family": "3.7 Maintenance",
+    "standard": "NIST SP 800-171 Rev 3",
+    "total_controls": 6,
+    "violations": violations,
+    "compliant": compliant,
+    "controls": {
+        "3.7.1_maintenance_performed": maintenance_performed,
+        "3.7.2_maintenance_controls": maintenance_controls,
+        "3.7.3_equipment_sanitization": equipment_sanitization,
+        "3.7.4_diagnostic_media_checked": diagnostic_media_checked,
+        "3.7.5_remote_maintenance_mfa": remote_maintenance_mfa,
+        "3.7.6_maintenance_supervision": maintenance_supervision,
+    },
+}

--- a/frameworks/federal/nist/sp_800_171/media_protection/nist_800_171_mp.rego
+++ b/frameworks/federal/nist/sp_800_171/media_protection/nist_800_171_mp.rego
@@ -1,0 +1,162 @@
+package nist.sp800_171.media_protection
+
+import rego.v1
+
+# NIST SP 800-171 Rev 3 - Media Protection (MP) Requirements
+# Family: 3.8 — Protecting Controlled Unclassified Information (CUI)
+
+# 3.8.1: Protect (i.e., physically control and securely store) system media containing CUI,
+#         both paper and digital
+default media_physical_protection := false
+
+media_physical_protection if {
+    input.nist_800_171.media_protection.physical.paper_media_secured == true
+    input.nist_800_171.media_protection.physical.digital_media_secured == true
+    input.nist_800_171.media_protection.physical.access_controlled == true
+}
+
+# 3.8.2: Limit access to CUI on system media to authorized users
+default media_access_limited := false
+
+media_access_limited if {
+    input.nist_800_171.media_protection.access.authorized_users_only == true
+    input.nist_800_171.media_protection.access.access_list_documented == true
+    input.nist_800_171.media_protection.access.access_enforcement_implemented == true
+}
+
+# 3.8.3: Sanitize or destroy system media before disposal or reuse
+default media_sanitization_disposal := false
+
+media_sanitization_disposal if {
+    input.nist_800_171.media_protection.sanitization.sanitized_before_disposal == true
+    input.nist_800_171.media_protection.sanitization.sanitized_before_reuse == true
+    input.nist_800_171.media_protection.sanitization.method_documented == true
+    input.nist_800_171.media_protection.sanitization.verification_performed == true
+}
+
+# 3.8.4: Mark media with necessary CUI markings and distribution limitations
+default media_marking := false
+
+media_marking if {
+    input.nist_800_171.media_protection.marking.cui_markings_applied == true
+    input.nist_800_171.media_protection.marking.distribution_limitations_marked == true
+    input.nist_800_171.media_protection.marking.marking_policy_documented == true
+}
+
+# 3.8.5: Control access to media containing CUI and maintain accountability for media
+#         during transport
+default media_transport_control := false
+
+media_transport_control if {
+    input.nist_800_171.media_protection.transport.access_controlled_during_transport == true
+    input.nist_800_171.media_protection.transport.accountability_maintained == true
+    input.nist_800_171.media_protection.transport.chain_of_custody_documented == true
+}
+
+# 3.8.6: Implement cryptographic mechanisms to protect the confidentiality of CUI during
+#         transport unless otherwise protected by alternative physical safeguards
+default media_transport_encryption := false
+
+media_transport_encryption if {
+    input.nist_800_171.media_protection.transport_crypto.encryption_implemented == true
+    input.nist_800_171.media_protection.transport_crypto.approved_algorithms == true
+    input.nist_800_171.media_protection.transport_crypto.covers_all_cui_transport == true
+}
+
+# 3.8.7: Control the use of removable media on system components
+default removable_media_controlled := false
+
+removable_media_controlled if {
+    input.nist_800_171.media_protection.removable.usage_policy_defined == true
+    input.nist_800_171.media_protection.removable.technical_controls_implemented == true
+    input.nist_800_171.media_protection.removable.approval_required == true
+}
+
+# 3.8.8: Prohibit the use of portable storage devices when such devices have no identifiable
+#         owner
+default portable_storage_owner_required := false
+
+portable_storage_owner_required if {
+    input.nist_800_171.media_protection.portable_storage.owner_identification_required == true
+    input.nist_800_171.media_protection.portable_storage.unidentified_devices_prohibited == true
+    input.nist_800_171.media_protection.portable_storage.enforcement_implemented == true
+}
+
+# 3.8.9: Protect the confidentiality of backup CUI at storage locations
+default backup_cui_protected := false
+
+backup_cui_protected if {
+    input.nist_800_171.media_protection.backup.backups_encrypted == true
+    input.nist_800_171.media_protection.backup.storage_location_secured == true
+    input.nist_800_171.media_protection.backup.access_restricted == true
+}
+
+# Violations set
+violations contains msg if {
+    not media_physical_protection
+    msg := "NIST 800-171 3.8.1: System media containing CUI (paper and digital) must be physically controlled and securely stored"
+}
+
+violations contains msg if {
+    not media_access_limited
+    msg := "NIST 800-171 3.8.2: Access to CUI on system media must be limited to authorized users with a documented and enforced access list"
+}
+
+violations contains msg if {
+    not media_sanitization_disposal
+    msg := "NIST 800-171 3.8.3: System media must be sanitized using documented methods before disposal or reuse, with verification performed"
+}
+
+violations contains msg if {
+    not media_marking
+    msg := "NIST 800-171 3.8.4: Media must be marked with required CUI markings and distribution limitations per documented policy"
+}
+
+violations contains msg if {
+    not media_transport_control
+    msg := "NIST 800-171 3.8.5: Access to media containing CUI must be controlled during transport with chain-of-custody documentation"
+}
+
+violations contains msg if {
+    not media_transport_encryption
+    msg := "NIST 800-171 3.8.6: Cryptographic mechanisms using approved algorithms must protect CUI confidentiality during transport"
+}
+
+violations contains msg if {
+    not removable_media_controlled
+    msg := "NIST 800-171 3.8.7: Use of removable media on system components must be controlled with defined policy and technical enforcement"
+}
+
+violations contains msg if {
+    not portable_storage_owner_required
+    msg := "NIST 800-171 3.8.8: Portable storage devices without identifiable owners must be prohibited with technical enforcement"
+}
+
+violations contains msg if {
+    not backup_cui_protected
+    msg := "NIST 800-171 3.8.9: Backup CUI must be encrypted and stored in secured locations with restricted access"
+}
+
+# Compliance aggregation
+default compliant := false
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "family": "3.8 Media Protection",
+    "standard": "NIST SP 800-171 Rev 3",
+    "total_controls": 9,
+    "violations": violations,
+    "compliant": compliant,
+    "controls": {
+        "3.8.1_media_physical_protection": media_physical_protection,
+        "3.8.2_media_access_limited": media_access_limited,
+        "3.8.3_media_sanitization_disposal": media_sanitization_disposal,
+        "3.8.4_media_marking": media_marking,
+        "3.8.5_media_transport_control": media_transport_control,
+        "3.8.6_media_transport_encryption": media_transport_encryption,
+        "3.8.7_removable_media_controlled": removable_media_controlled,
+        "3.8.8_portable_storage_owner_required": portable_storage_owner_required,
+        "3.8.9_backup_cui_protected": backup_cui_protected,
+    },
+}

--- a/frameworks/federal/nist/sp_800_171/nist_800_171_main.rego
+++ b/frameworks/federal/nist/sp_800_171/nist_800_171_main.rego
@@ -1,0 +1,185 @@
+package nist.sp800_171.main
+
+import rego.v1
+
+# NIST SP 800-171 Rev 3 — Main Aggregator
+# Protecting Controlled Unclassified Information (CUI) in Nonfederal Systems and Organizations
+#
+# 110 total requirements across 14 families:
+#   3.1  Access Control (AC)               — 22 requirements
+#   3.2  Awareness and Training (AT)       —  3 requirements
+#   3.3  Audit and Accountability (AU)     —  9 requirements
+#   3.4  Configuration Management (CM)     —  9 requirements
+#   3.5  Identification and Authentication (IA) — 11 requirements
+#   3.6  Incident Response (IR)            —  3 requirements
+#   3.7  Maintenance (MA)                  —  6 requirements
+#   3.8  Media Protection (MP)             —  9 requirements
+#   3.9  Personnel Security (PS)           —  2 requirements
+#   3.10 Physical Protection (PE)          —  6 requirements
+#   3.11 Risk Assessment (RA)              —  3 requirements
+#   3.12 Security Assessment (CA)          —  4 requirements
+#   3.13 System and Communications Protection (SC) — 16 requirements
+#   3.14 System and Information Integrity (SI) —  7 requirements
+
+# ---------------------------------------------------------------------------
+# Per-family compliance status
+# ---------------------------------------------------------------------------
+
+# 3.1 Access Control — existing module uses nist_sp800_171_ac_compliant (not compliant).
+# The rule has no default so it may be undefined when input is absent; use false as fallback.
+ac_compliant := object.get(data.nist.sp800_171.access_control, "nist_sp800_171_ac_compliant", false)
+
+# 3.2 Awareness and Training
+at_compliant := data.nist.sp800_171.awareness_training.compliant
+
+# 3.3 Audit and Accountability
+au_compliant := data.nist.sp800_171.audit_accountability.compliant
+
+# 3.4 Configuration Management
+cm_compliant := data.nist.sp800_171.configuration_management.compliant
+
+# 3.5 Identification and Authentication
+ia_compliant := data.nist.sp800_171.identification_authentication.compliant
+
+# 3.6 Incident Response
+ir_compliant := data.nist.sp800_171.incident_response.compliant
+
+# 3.7 Maintenance
+ma_compliant := data.nist.sp800_171.maintenance.compliant
+
+# 3.8 Media Protection
+mp_compliant := data.nist.sp800_171.media_protection.compliant
+
+# 3.9 Personnel Security
+ps_compliant := data.nist.sp800_171.personnel_security.compliant
+
+# 3.10 Physical Protection
+pe_compliant := data.nist.sp800_171.physical_protection.compliant
+
+# 3.11 Risk Assessment
+ra_compliant := data.nist.sp800_171.risk_assessment.compliant
+
+# 3.12 Security Assessment
+ca_compliant := data.nist.sp800_171.security_assessment.compliant
+
+# 3.13 System and Communications Protection
+sc_compliant := data.nist.sp800_171.system_communications.compliant
+
+# 3.14 System and Information Integrity
+si_compliant := data.nist.sp800_171.system_information.compliant
+
+# ---------------------------------------------------------------------------
+# Overall compliance
+# ---------------------------------------------------------------------------
+
+default overall_compliant := false
+
+overall_compliant if {
+    ac_compliant
+    at_compliant
+    au_compliant
+    cm_compliant
+    ia_compliant
+    ir_compliant
+    ma_compliant
+    mp_compliant
+    ps_compliant
+    pe_compliant
+    ra_compliant
+    ca_compliant
+    sc_compliant
+    si_compliant
+}
+
+# ---------------------------------------------------------------------------
+# Families passing count
+# ---------------------------------------------------------------------------
+
+families_status := [
+    ac_compliant,
+    at_compliant,
+    au_compliant,
+    cm_compliant,
+    ia_compliant,
+    ir_compliant,
+    ma_compliant,
+    mp_compliant,
+    ps_compliant,
+    pe_compliant,
+    ra_compliant,
+    ca_compliant,
+    sc_compliant,
+    si_compliant,
+]
+
+families_passing := count([s | some s in families_status; s == true])
+
+# ---------------------------------------------------------------------------
+# Compliance report
+# ---------------------------------------------------------------------------
+
+compliance_report := {
+    "standard": "NIST SP 800-171 Rev 3 — Protecting Controlled Unclassified Information (CUI)",
+    "overall_compliant": overall_compliant,
+    "families_passing": families_passing,
+    "families_total": 14,
+    "families": {
+        "3.1_access_control": {
+            "compliant": ac_compliant,
+            "note": "Access control module uses nist_sp800_171_ac_compliant; see nist_sp800_171_ac_compliance for details",
+            "details": object.get(data.nist.sp800_171.access_control, "nist_sp800_171_ac_compliance", {}),
+        },
+        "3.2_awareness_training": {
+            "compliant": at_compliant,
+            "details": data.nist.sp800_171.awareness_training.compliance_report,
+        },
+        "3.3_audit_accountability": {
+            "compliant": au_compliant,
+            "details": data.nist.sp800_171.audit_accountability.compliance_report,
+        },
+        "3.4_configuration_management": {
+            "compliant": cm_compliant,
+            "details": data.nist.sp800_171.configuration_management.compliance_report,
+        },
+        "3.5_identification_authentication": {
+            "compliant": ia_compliant,
+            "details": data.nist.sp800_171.identification_authentication.compliance_report,
+        },
+        "3.6_incident_response": {
+            "compliant": ir_compliant,
+            "details": data.nist.sp800_171.incident_response.compliance_report,
+        },
+        "3.7_maintenance": {
+            "compliant": ma_compliant,
+            "details": data.nist.sp800_171.maintenance.compliance_report,
+        },
+        "3.8_media_protection": {
+            "compliant": mp_compliant,
+            "details": data.nist.sp800_171.media_protection.compliance_report,
+        },
+        "3.9_personnel_security": {
+            "compliant": ps_compliant,
+            "details": data.nist.sp800_171.personnel_security.compliance_report,
+        },
+        "3.10_physical_protection": {
+            "compliant": pe_compliant,
+            "details": data.nist.sp800_171.physical_protection.compliance_report,
+        },
+        "3.11_risk_assessment": {
+            "compliant": ra_compliant,
+            "details": data.nist.sp800_171.risk_assessment.compliance_report,
+        },
+        "3.12_security_assessment": {
+            "compliant": ca_compliant,
+            "details": data.nist.sp800_171.security_assessment.compliance_report,
+        },
+        "3.13_system_communications": {
+            "compliant": sc_compliant,
+            "details": data.nist.sp800_171.system_communications.compliance_report,
+        },
+        "3.14_system_information": {
+            "compliant": si_compliant,
+            "details": data.nist.sp800_171.system_information.compliance_report,
+        },
+    },
+}

--- a/frameworks/federal/nist/sp_800_171/personnel_security/nist_800_171_ps.rego
+++ b/frameworks/federal/nist/sp_800_171/personnel_security/nist_800_171_ps.rego
@@ -1,0 +1,53 @@
+package nist.sp800_171.personnel_security
+
+import rego.v1
+
+# NIST SP 800-171 Rev 3 - Personnel Security (PS) Requirements
+# Family: 3.9 — Protecting Controlled Unclassified Information (CUI)
+
+# 3.9.1: Screen individuals prior to authorizing access to organizational systems containing CUI
+default personnel_screening := false
+
+personnel_screening if {
+    input.nist_800_171.personnel_security.screening.background_checks_performed == true
+    input.nist_800_171.personnel_security.screening.criteria_documented == true
+    input.nist_800_171.personnel_security.screening.rescreening_policy == true
+}
+
+# 3.9.2: Ensure CUI is protected during and after personnel actions such as terminations and transfers
+default personnel_actions_protection := false
+
+personnel_actions_protection if {
+    input.nist_800_171.personnel_security.personnel_actions.termination_procedures == true
+    input.nist_800_171.personnel_security.personnel_actions.transfer_procedures == true
+    input.nist_800_171.personnel_security.personnel_actions.access_revocation_timely == true
+    input.nist_800_171.personnel_security.personnel_actions.property_return_required == true
+}
+
+# Violations set
+violations contains msg if {
+    not personnel_screening
+    msg := "NIST 800-171 3.9.1: Personnel screening must be performed prior to authorizing access to systems containing CUI"
+}
+
+violations contains msg if {
+    not personnel_actions_protection
+    msg := "NIST 800-171 3.9.2: CUI must be protected during and after personnel actions (terminations, transfers) with timely access revocation"
+}
+
+# Compliance aggregation
+default compliant := false
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "family": "3.9 Personnel Security",
+    "standard": "NIST SP 800-171 Rev 3",
+    "total_controls": 2,
+    "violations": violations,
+    "compliant": compliant,
+    "controls": {
+        "3.9.1_personnel_screening": personnel_screening,
+        "3.9.2_personnel_actions_protection": personnel_actions_protection,
+    },
+}

--- a/frameworks/federal/nist/sp_800_171/physical_protection/nist_800_171_pe.rego
+++ b/frameworks/federal/nist/sp_800_171/physical_protection/nist_800_171_pe.rego
@@ -1,0 +1,116 @@
+package nist.sp800_171.physical_protection
+
+import rego.v1
+
+# NIST SP 800-171 Rev 3 - Physical Protection (PE) Requirements
+# Family: 3.10 — Protecting Controlled Unclassified Information (CUI)
+
+# 3.10.1: Limit physical access to organizational systems to authorized individuals
+default physical_access_limited := false
+
+physical_access_limited if {
+    input.nist_800_171.physical_protection.access.authorized_individuals_only == true
+    input.nist_800_171.physical_protection.access.access_controls_implemented == true
+    input.nist_800_171.physical_protection.access.access_list_maintained == true
+}
+
+# 3.10.2: Protect and monitor the physical facility and support infrastructure for
+#          organizational systems
+default facility_monitoring := false
+
+facility_monitoring if {
+    input.nist_800_171.physical_protection.monitoring.facility_monitored == true
+    input.nist_800_171.physical_protection.monitoring.support_infrastructure_monitored == true
+    input.nist_800_171.physical_protection.monitoring.monitoring_continuous == true
+}
+
+# 3.10.3: Escort visitors and monitor visitor activity
+default visitor_escort := false
+
+visitor_escort if {
+    input.nist_800_171.physical_protection.visitors.escort_required == true
+    input.nist_800_171.physical_protection.visitors.activity_monitored == true
+    input.nist_800_171.physical_protection.visitors.visitor_log_maintained == true
+}
+
+# 3.10.4: Maintain audit logs of physical access
+default physical_access_logs := false
+
+physical_access_logs if {
+    input.nist_800_171.physical_protection.access_logs.logs_maintained == true
+    input.nist_800_171.physical_protection.access_logs.covers_all_entry_points == true
+    input.nist_800_171.physical_protection.access_logs.retention_period_days >= 90
+    input.nist_800_171.physical_protection.access_logs.reviewed_periodically == true
+}
+
+# 3.10.5: Control and manage physical access devices such as keys, locks, combinations,
+#          and card readers
+default physical_access_devices_managed := false
+
+physical_access_devices_managed if {
+    input.nist_800_171.physical_protection.access_devices.inventory_maintained == true
+    input.nist_800_171.physical_protection.access_devices.issuance_tracked == true
+    input.nist_800_171.physical_protection.access_devices.revocation_procedures == true
+    input.nist_800_171.physical_protection.access_devices.periodic_audit == true
+}
+
+# 3.10.6: Enforce safeguarding measures for CUI at alternate work sites
+default alternate_work_site_safeguards := false
+
+alternate_work_site_safeguards if {
+    input.nist_800_171.physical_protection.alternate_sites.safeguards_defined == true
+    input.nist_800_171.physical_protection.alternate_sites.safeguards_enforced == true
+    input.nist_800_171.physical_protection.alternate_sites.includes_remote_work == true
+}
+
+# Violations set
+violations contains msg if {
+    not physical_access_limited
+    msg := "NIST 800-171 3.10.1: Physical access to organizational systems must be limited to authorized individuals with maintained access lists"
+}
+
+violations contains msg if {
+    not facility_monitoring
+    msg := "NIST 800-171 3.10.2: Physical facilities and support infrastructure for organizational systems must be continuously protected and monitored"
+}
+
+violations contains msg if {
+    not visitor_escort
+    msg := "NIST 800-171 3.10.3: Visitors must be escorted and their activity monitored, with visitor logs maintained"
+}
+
+violations contains msg if {
+    not physical_access_logs
+    msg := "NIST 800-171 3.10.4: Audit logs of physical access must be maintained for all entry points, retained at least 90 days, and reviewed periodically"
+}
+
+violations contains msg if {
+    not physical_access_devices_managed
+    msg := "NIST 800-171 3.10.5: Physical access devices (keys, cards, PINs) must be inventoried, tracked, with revocation procedures and periodic audits"
+}
+
+violations contains msg if {
+    not alternate_work_site_safeguards
+    msg := "NIST 800-171 3.10.6: Safeguarding measures for CUI must be defined and enforced at alternate work sites including remote work locations"
+}
+
+# Compliance aggregation
+default compliant := false
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "family": "3.10 Physical Protection",
+    "standard": "NIST SP 800-171 Rev 3",
+    "total_controls": 6,
+    "violations": violations,
+    "compliant": compliant,
+    "controls": {
+        "3.10.1_physical_access_limited": physical_access_limited,
+        "3.10.2_facility_monitoring": facility_monitoring,
+        "3.10.3_visitor_escort": visitor_escort,
+        "3.10.4_physical_access_logs": physical_access_logs,
+        "3.10.5_physical_access_devices_managed": physical_access_devices_managed,
+        "3.10.6_alternate_work_site_safeguards": alternate_work_site_safeguards,
+    },
+}

--- a/frameworks/federal/nist/sp_800_171/risk_assessment/nist_800_171_ra.rego
+++ b/frameworks/federal/nist/sp_800_171/risk_assessment/nist_800_171_ra.rego
@@ -1,0 +1,75 @@
+package nist.sp800_171.risk_assessment
+
+import rego.v1
+
+# NIST SP 800-171 Rev 3 - Risk Assessment (RA) Requirements
+# Family: 3.11 — Protecting Controlled Unclassified Information (CUI)
+
+# 3.11.1: Periodically assess the risk to organizational operations, organizational assets,
+#          and individuals, resulting from the operation of organizational systems and the
+#          associated processing, storage, or transmission of CUI (at least annually)
+default risk_assessment_performed := false
+
+risk_assessment_performed if {
+    input.nist_800_171.risk_assessment.assessment.performed_annually == true
+    input.nist_800_171.risk_assessment.assessment.covers_operations == true
+    input.nist_800_171.risk_assessment.assessment.covers_assets == true
+    input.nist_800_171.risk_assessment.assessment.covers_individuals == true
+    input.nist_800_171.risk_assessment.assessment.results_documented == true
+}
+
+# 3.11.2: Scan for vulnerabilities in organizational systems and applications periodically
+#          and when new vulnerabilities affecting those systems are identified
+default vulnerability_scanning := false
+
+vulnerability_scanning if {
+    input.nist_800_171.risk_assessment.vulnerability_scanning.periodic_scans_performed == true
+    input.nist_800_171.risk_assessment.vulnerability_scanning.triggered_on_new_vulnerabilities == true
+    input.nist_800_171.risk_assessment.vulnerability_scanning.covers_all_systems == true
+    input.nist_800_171.risk_assessment.vulnerability_scanning.results_documented == true
+}
+
+# 3.11.3: Remediate vulnerabilities in accordance with risk assessments
+#          (critical vulnerabilities within 15 days, high within 30 days)
+default vulnerability_remediation := false
+
+vulnerability_remediation if {
+    input.nist_800_171.risk_assessment.remediation.risk_based_prioritization == true
+    input.nist_800_171.risk_assessment.remediation.critical_days <= 15
+    input.nist_800_171.risk_assessment.remediation.high_days <= 30
+    input.nist_800_171.risk_assessment.remediation.tracking_system == true
+}
+
+# Violations set
+violations contains msg if {
+    not risk_assessment_performed
+    msg := "NIST 800-171 3.11.1: Risk assessments must be performed at least annually covering operations, assets, individuals, and CUI handling"
+}
+
+violations contains msg if {
+    not vulnerability_scanning
+    msg := "NIST 800-171 3.11.2: Vulnerability scans must be performed periodically and triggered when new vulnerabilities affecting systems are identified"
+}
+
+violations contains msg if {
+    not vulnerability_remediation
+    msg := "NIST 800-171 3.11.3: Vulnerabilities must be remediated per risk assessment priority: critical within 15 days, high within 30 days"
+}
+
+# Compliance aggregation
+default compliant := false
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "family": "3.11 Risk Assessment",
+    "standard": "NIST SP 800-171 Rev 3",
+    "total_controls": 3,
+    "violations": violations,
+    "compliant": compliant,
+    "controls": {
+        "3.11.1_risk_assessment_performed": risk_assessment_performed,
+        "3.11.2_vulnerability_scanning": vulnerability_scanning,
+        "3.11.3_vulnerability_remediation": vulnerability_remediation,
+    },
+}

--- a/frameworks/federal/nist/sp_800_171/security_assessment/nist_800_171_ca.rego
+++ b/frameworks/federal/nist/sp_800_171/security_assessment/nist_800_171_ca.rego
@@ -1,0 +1,92 @@
+package nist.sp800_171.security_assessment
+
+import rego.v1
+
+# NIST SP 800-171 Rev 3 - Security Assessment (CA) Requirements
+# Family: 3.12 — Protecting Controlled Unclassified Information (CUI)
+
+# 3.12.1: Periodically assess the security controls in organizational systems to determine
+#          if the controls are effective in their application
+default security_controls_assessed := false
+
+security_controls_assessed if {
+    input.nist_800_171.security_assessment.controls_assessment.periodic_assessments == true
+    input.nist_800_171.security_assessment.controls_assessment.effectiveness_determined == true
+    input.nist_800_171.security_assessment.controls_assessment.results_documented == true
+    input.nist_800_171.security_assessment.controls_assessment.independent_assessor == true
+}
+
+# 3.12.2: Develop and implement plans of action designed to correct deficiencies and reduce
+#          or eliminate vulnerabilities in organizational systems
+default plans_of_action := false
+
+plans_of_action if {
+    input.nist_800_171.security_assessment.plans_of_action.poam_documented == true
+    input.nist_800_171.security_assessment.plans_of_action.deficiencies_tracked == true
+    input.nist_800_171.security_assessment.plans_of_action.milestones_defined == true
+    input.nist_800_171.security_assessment.plans_of_action.progress_monitored == true
+}
+
+# 3.12.3: Monitor security controls on an ongoing basis to ensure the continued effectiveness
+#          of the controls
+default continuous_monitoring := false
+
+continuous_monitoring if {
+    input.nist_800_171.security_assessment.continuous_monitoring.monitoring_implemented == true
+    input.nist_800_171.security_assessment.continuous_monitoring.ongoing_not_just_periodic == true
+    input.nist_800_171.security_assessment.continuous_monitoring.automated_where_possible == true
+}
+
+# 3.12.4: Develop, document, and periodically update system security plans that describe
+#          system boundaries, system environments, how security requirements are implemented,
+#          and the relationships with or connections to other systems
+default system_security_plan := false
+
+system_security_plan if {
+    input.nist_800_171.security_assessment.ssp.plan_documented == true
+    input.nist_800_171.security_assessment.ssp.system_boundary_defined == true
+    input.nist_800_171.security_assessment.ssp.environment_described == true
+    input.nist_800_171.security_assessment.ssp.requirements_implementation_described == true
+    input.nist_800_171.security_assessment.ssp.interconnections_documented == true
+    input.nist_800_171.security_assessment.ssp.updated_periodically == true
+}
+
+# Violations set
+violations contains msg if {
+    not security_controls_assessed
+    msg := "NIST 800-171 3.12.1: Security controls must be periodically assessed by an independent assessor to determine effectiveness"
+}
+
+violations contains msg if {
+    not plans_of_action
+    msg := "NIST 800-171 3.12.2: Plans of action (POA&M) must be developed and implemented to correct deficiencies with tracked milestones"
+}
+
+violations contains msg if {
+    not continuous_monitoring
+    msg := "NIST 800-171 3.12.3: Security controls must be continuously monitored on an ongoing basis with automated mechanisms where possible"
+}
+
+violations contains msg if {
+    not system_security_plan
+    msg := "NIST 800-171 3.12.4: System security plans must be documented, describing boundaries, environments, implementation, and interconnections, and updated periodically"
+}
+
+# Compliance aggregation
+default compliant := false
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "family": "3.12 Security Assessment",
+    "standard": "NIST SP 800-171 Rev 3",
+    "total_controls": 4,
+    "violations": violations,
+    "compliant": compliant,
+    "controls": {
+        "3.12.1_security_controls_assessed": security_controls_assessed,
+        "3.12.2_plans_of_action": plans_of_action,
+        "3.12.3_continuous_monitoring": continuous_monitoring,
+        "3.12.4_system_security_plan": system_security_plan,
+    },
+}

--- a/frameworks/federal/nist/sp_800_171/system_communications/nist_800_171_sc.rego
+++ b/frameworks/federal/nist/sp_800_171/system_communications/nist_800_171_sc.rego
@@ -1,0 +1,273 @@
+package nist.sp800_171.system_communications
+
+import rego.v1
+
+# NIST SP 800-171 Rev 3 - System and Communications Protection (SC) Requirements
+# Family: 3.13 — Protecting Controlled Unclassified Information (CUI)
+
+# 3.13.1: Monitor, control, and protect communications (transmissions) at the external
+#          boundaries and key internal boundaries of organizational systems
+default boundary_protection := false
+
+boundary_protection if {
+    input.nist_800_171.system_communications.boundary.external_boundaries_monitored == true
+    input.nist_800_171.system_communications.boundary.key_internal_boundaries_monitored == true
+    input.nist_800_171.system_communications.boundary.communications_controlled == true
+}
+
+# 3.13.2: Employ architectural designs, software development techniques, and systems
+#          engineering principles that promote effective information security
+default security_engineering_principles := false
+
+security_engineering_principles if {
+    input.nist_800_171.system_communications.engineering.security_by_design == true
+    input.nist_800_171.system_communications.engineering.secure_sdlc == true
+    input.nist_800_171.system_communications.engineering.principles_documented == true
+}
+
+# 3.13.3: Separate user functionality from system management functionality
+default functionality_separation := false
+
+functionality_separation if {
+    input.nist_800_171.system_communications.separation.user_mgmt_separated == true
+    input.nist_800_171.system_communications.separation.technical_controls_implemented == true
+    input.nist_800_171.system_communications.separation.admin_interfaces_distinct == true
+}
+
+# 3.13.4: Prevent unauthorized and unintended information transfer via shared system resources
+default shared_resource_control := false
+
+shared_resource_control if {
+    input.nist_800_171.system_communications.shared_resources.unauthorized_transfer_prevented == true
+    input.nist_800_171.system_communications.shared_resources.resource_isolation == true
+    input.nist_800_171.system_communications.shared_resources.controls_documented == true
+}
+
+# 3.13.5: Implement subnetworks for publicly accessible system components that are
+#          physically or logically separated from internal networks
+default dmz_implementation := false
+
+dmz_implementation if {
+    input.nist_800_171.system_communications.dmz.public_components_separated == true
+    input.nist_800_171.system_communications.dmz.physical_or_logical_separation == true
+    input.nist_800_171.system_communications.dmz.internal_network_protected == true
+}
+
+# 3.13.6: Deny network communications traffic by default and allow network communications
+#          traffic by exception (deny all, permit by exception)
+default deny_all_permit_exception := false
+
+deny_all_permit_exception if {
+    input.nist_800_171.system_communications.deny_all.default_deny_implemented == true
+    input.nist_800_171.system_communications.deny_all.permit_by_exception == true
+    input.nist_800_171.system_communications.deny_all.exceptions_documented == true
+}
+
+# 3.13.7: Prevent remote devices from simultaneously using non-remote access to
+#          organizational systems and using another connection to resources in other
+#          networks (split tunneling)
+default split_tunneling_prevention := false
+
+split_tunneling_prevention if {
+    input.nist_800_171.system_communications.split_tunneling.prevention_implemented == true
+    input.nist_800_171.system_communications.split_tunneling.vpn_configured_correctly == true
+    input.nist_800_171.system_communications.split_tunneling.policy_enforced == true
+}
+
+# 3.13.8: Implement cryptographic mechanisms to prevent unauthorized disclosure of CUI
+#          during transmission unless otherwise protected by alternative physical safeguards
+default transmission_encryption := false
+
+transmission_encryption if {
+    input.nist_800_171.system_communications.transmission.encryption_implemented == true
+    input.nist_800_171.system_communications.transmission.approved_algorithms == true
+    input.nist_800_171.system_communications.transmission.covers_all_cui_transmission == true
+}
+
+# 3.13.9: Terminate network connections associated with communications sessions after a
+#          defined period of inactivity
+default session_termination_inactivity := false
+
+session_termination_inactivity if {
+    input.nist_800_171.system_communications.session_timeout.inactivity_timeout_defined == true
+    input.nist_800_171.system_communications.session_timeout.automatic_termination == true
+    input.nist_800_171.system_communications.session_timeout.all_connection_types_covered == true
+}
+
+# 3.13.10: Establish and manage cryptographic keys for required cryptography employed in
+#           organizational systems
+default cryptographic_key_management := false
+
+cryptographic_key_management if {
+    input.nist_800_171.system_communications.key_management.key_generation_documented == true
+    input.nist_800_171.system_communications.key_management.key_distribution_secured == true
+    input.nist_800_171.system_communications.key_management.key_rotation_policy == true
+    input.nist_800_171.system_communications.key_management.key_destruction_procedures == true
+}
+
+# 3.13.11: Employ FIPS-validated cryptography when used to protect the confidentiality of CUI
+default fips_validated_cryptography := false
+
+fips_validated_cryptography if {
+    input.nist_800_171.system_communications.fips.fips_validated_modules == true
+    input.nist_800_171.system_communications.fips.covers_cui_protection == true
+    input.nist_800_171.system_communications.fips.inventory_maintained == true
+}
+
+# 3.13.12: Prohibit remote activation of collaborative computing devices and provide
+#           indication of use to users physically present
+default collaborative_device_control := false
+
+collaborative_device_control if {
+    input.nist_800_171.system_communications.collaborative_devices.remote_activation_prohibited == true
+    input.nist_800_171.system_communications.collaborative_devices.presence_indicator == true
+    input.nist_800_171.system_communications.collaborative_devices.policy_documented == true
+}
+
+# 3.13.13: Control and monitor the use of mobile code
+default mobile_code_control := false
+
+mobile_code_control if {
+    input.nist_800_171.system_communications.mobile_code.usage_policy_defined == true
+    input.nist_800_171.system_communications.mobile_code.technical_controls == true
+    input.nist_800_171.system_communications.mobile_code.monitoring_implemented == true
+}
+
+# 3.13.14: Control and monitor the use of Voice over Internet Protocol (VoIP) technologies
+default voip_control := false
+
+voip_control if {
+    input.nist_800_171.system_communications.voip.usage_policy_defined == true
+    input.nist_800_171.system_communications.voip.technical_controls == true
+    input.nist_800_171.system_communications.voip.monitoring_implemented == true
+}
+
+# 3.13.15: Protect the authenticity of communications sessions
+default session_authenticity := false
+
+session_authenticity if {
+    input.nist_800_171.system_communications.authenticity.session_authentication == true
+    input.nist_800_171.system_communications.authenticity.replay_protection == true
+    input.nist_800_171.system_communications.authenticity.mechanisms_documented == true
+}
+
+# 3.13.16: Protect the confidentiality of CUI at rest
+default cui_at_rest_protection := false
+
+cui_at_rest_protection if {
+    input.nist_800_171.system_communications.data_at_rest.encryption_implemented == true
+    input.nist_800_171.system_communications.data_at_rest.approved_algorithms == true
+    input.nist_800_171.system_communications.data_at_rest.covers_all_cui_storage == true
+}
+
+# Violations set
+violations contains msg if {
+    not boundary_protection
+    msg := "NIST 800-171 3.13.1: Communications must be monitored, controlled, and protected at external boundaries and key internal boundaries"
+}
+
+violations contains msg if {
+    not security_engineering_principles
+    msg := "NIST 800-171 3.13.2: Security engineering principles including security by design and secure SDLC must be employed and documented"
+}
+
+violations contains msg if {
+    not functionality_separation
+    msg := "NIST 800-171 3.13.3: User functionality must be technically separated from system management functionality with distinct admin interfaces"
+}
+
+violations contains msg if {
+    not shared_resource_control
+    msg := "NIST 800-171 3.13.4: Unauthorized and unintended information transfer via shared system resources must be prevented through resource isolation"
+}
+
+violations contains msg if {
+    not dmz_implementation
+    msg := "NIST 800-171 3.13.5: Publicly accessible system components must be in subnetworks physically or logically separated from internal networks"
+}
+
+violations contains msg if {
+    not deny_all_permit_exception
+    msg := "NIST 800-171 3.13.6: Network communications must default to deny-all with permit-by-exception; all exceptions must be documented"
+}
+
+violations contains msg if {
+    not split_tunneling_prevention
+    msg := "NIST 800-171 3.13.7: Split tunneling must be prevented to stop remote devices from simultaneously accessing organizational and external networks"
+}
+
+violations contains msg if {
+    not transmission_encryption
+    msg := "NIST 800-171 3.13.8: FIPS-approved cryptographic mechanisms must protect CUI confidentiality during all transmission"
+}
+
+violations contains msg if {
+    not session_termination_inactivity
+    msg := "NIST 800-171 3.13.9: Network connections must be automatically terminated after a defined period of inactivity across all connection types"
+}
+
+violations contains msg if {
+    not cryptographic_key_management
+    msg := "NIST 800-171 3.13.10: Cryptographic keys must be managed with documented generation, secured distribution, rotation policy, and destruction procedures"
+}
+
+violations contains msg if {
+    not fips_validated_cryptography
+    msg := "NIST 800-171 3.13.11: FIPS-validated cryptographic modules must be employed for protecting CUI with an inventory maintained"
+}
+
+violations contains msg if {
+    not collaborative_device_control
+    msg := "NIST 800-171 3.13.12: Remote activation of collaborative computing devices must be prohibited with presence indicators for users"
+}
+
+violations contains msg if {
+    not mobile_code_control
+    msg := "NIST 800-171 3.13.13: Mobile code use must be controlled with defined policy, technical controls, and active monitoring"
+}
+
+violations contains msg if {
+    not voip_control
+    msg := "NIST 800-171 3.13.14: VoIP technology use must be controlled with defined policy, technical controls, and active monitoring"
+}
+
+violations contains msg if {
+    not session_authenticity
+    msg := "NIST 800-171 3.13.15: The authenticity of communications sessions must be protected with session authentication and replay protection"
+}
+
+violations contains msg if {
+    not cui_at_rest_protection
+    msg := "NIST 800-171 3.13.16: CUI at rest must be protected with FIPS-approved encryption across all CUI storage locations"
+}
+
+# Compliance aggregation
+default compliant := false
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "family": "3.13 System and Communications Protection",
+    "standard": "NIST SP 800-171 Rev 3",
+    "total_controls": 16,
+    "violations": violations,
+    "compliant": compliant,
+    "controls": {
+        "3.13.1_boundary_protection": boundary_protection,
+        "3.13.2_security_engineering_principles": security_engineering_principles,
+        "3.13.3_functionality_separation": functionality_separation,
+        "3.13.4_shared_resource_control": shared_resource_control,
+        "3.13.5_dmz_implementation": dmz_implementation,
+        "3.13.6_deny_all_permit_exception": deny_all_permit_exception,
+        "3.13.7_split_tunneling_prevention": split_tunneling_prevention,
+        "3.13.8_transmission_encryption": transmission_encryption,
+        "3.13.9_session_termination_inactivity": session_termination_inactivity,
+        "3.13.10_cryptographic_key_management": cryptographic_key_management,
+        "3.13.11_fips_validated_cryptography": fips_validated_cryptography,
+        "3.13.12_collaborative_device_control": collaborative_device_control,
+        "3.13.13_mobile_code_control": mobile_code_control,
+        "3.13.14_voip_control": voip_control,
+        "3.13.15_session_authenticity": session_authenticity,
+        "3.13.16_cui_at_rest_protection": cui_at_rest_protection,
+    },
+}

--- a/frameworks/federal/nist/sp_800_171/system_information/nist_800_171_si.rego
+++ b/frameworks/federal/nist/sp_800_171/system_information/nist_800_171_si.rego
@@ -1,0 +1,137 @@
+package nist.sp800_171.system_information
+
+import rego.v1
+
+# NIST SP 800-171 Rev 3 - System and Information Integrity (SI) Requirements
+# Family: 3.14 — Protecting Controlled Unclassified Information (CUI)
+
+# 3.14.1: Identify, report, and correct information and system flaws in a timely manner
+default flaw_remediation := false
+
+flaw_remediation if {
+    input.nist_800_171.system_information.flaws.identification_process == true
+    input.nist_800_171.system_information.flaws.reporting_process == true
+    input.nist_800_171.system_information.flaws.timely_correction == true
+    input.nist_800_171.system_information.flaws.tracking_system == true
+}
+
+# 3.14.2: Provide protection from malicious code at appropriate locations within
+#          organizational systems
+default malicious_code_protection := false
+
+malicious_code_protection if {
+    input.nist_800_171.system_information.malicious_code.protection_at_entry_exit == true
+    input.nist_800_171.system_information.malicious_code.workstation_protection == true
+    input.nist_800_171.system_information.malicious_code.server_protection == true
+    input.nist_800_171.system_information.malicious_code.approved_solution == true
+}
+
+# 3.14.3: Monitor system security alerts and advisories and take appropriate actions
+#          in response
+default security_alerts_monitored := false
+
+security_alerts_monitored if {
+    input.nist_800_171.system_information.alerts.monitoring_implemented == true
+    input.nist_800_171.system_information.alerts.advisories_tracked == true
+    input.nist_800_171.system_information.alerts.response_procedures_defined == true
+    input.nist_800_171.system_information.alerts.subscribed_to_threat_feeds == true
+}
+
+# 3.14.4: Update malicious code protection mechanisms when new releases are available
+default malicious_code_updated := false
+
+malicious_code_updated if {
+    input.nist_800_171.system_information.malicious_code_updates.automatic_updates == true
+    input.nist_800_171.system_information.malicious_code_updates.update_frequency_defined == true
+    input.nist_800_171.system_information.malicious_code_updates.all_systems_covered == true
+}
+
+# 3.14.5: Perform periodic scans of organizational systems and real-time scans of files
+#          from external sources as files are downloaded, opened, or executed
+default system_scanning := false
+
+system_scanning if {
+    input.nist_800_171.system_information.scanning.periodic_scans_performed == true
+    input.nist_800_171.system_information.scanning.real_time_scanning == true
+    input.nist_800_171.system_information.scanning.external_source_files_scanned == true
+    input.nist_800_171.system_information.scanning.scan_schedule_defined == true
+}
+
+# 3.14.6: Monitor organizational systems, including inbound and outbound communications
+#          traffic, to detect attacks and indicators of potential attacks
+default attack_detection_monitoring := false
+
+attack_detection_monitoring if {
+    input.nist_800_171.system_information.attack_detection.system_monitoring == true
+    input.nist_800_171.system_information.attack_detection.inbound_traffic_monitored == true
+    input.nist_800_171.system_information.attack_detection.outbound_traffic_monitored == true
+    input.nist_800_171.system_information.attack_detection.ioc_detection == true
+}
+
+# 3.14.7: Identify unauthorized use of organizational systems
+default unauthorized_use_detection := false
+
+unauthorized_use_detection if {
+    input.nist_800_171.system_information.unauthorized_use.detection_mechanisms == true
+    input.nist_800_171.system_information.unauthorized_use.baseline_established == true
+    input.nist_800_171.system_information.unauthorized_use.anomaly_detection == true
+    input.nist_800_171.system_information.unauthorized_use.response_procedures == true
+}
+
+# Violations set
+violations contains msg if {
+    not flaw_remediation
+    msg := "NIST 800-171 3.14.1: System flaws must be identified, reported, and corrected in a timely manner with a tracking system"
+}
+
+violations contains msg if {
+    not malicious_code_protection
+    msg := "NIST 800-171 3.14.2: Malicious code protection must be deployed at entry/exit points, workstations, and servers using approved solutions"
+}
+
+violations contains msg if {
+    not security_alerts_monitored
+    msg := "NIST 800-171 3.14.3: Security alerts and advisories must be monitored with subscriptions to threat feeds and defined response procedures"
+}
+
+violations contains msg if {
+    not malicious_code_updated
+    msg := "NIST 800-171 3.14.4: Malicious code protection mechanisms must be automatically updated on a defined schedule for all systems"
+}
+
+violations contains msg if {
+    not system_scanning
+    msg := "NIST 800-171 3.14.5: Periodic system scans and real-time scanning of files from external sources must be performed per defined schedule"
+}
+
+violations contains msg if {
+    not attack_detection_monitoring
+    msg := "NIST 800-171 3.14.6: Systems and inbound/outbound communications traffic must be monitored to detect attacks and indicators of compromise"
+}
+
+violations contains msg if {
+    not unauthorized_use_detection
+    msg := "NIST 800-171 3.14.7: Unauthorized use of organizational systems must be detected through baseline monitoring, anomaly detection, and response procedures"
+}
+
+# Compliance aggregation
+default compliant := false
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "family": "3.14 System and Information Integrity",
+    "standard": "NIST SP 800-171 Rev 3",
+    "total_controls": 7,
+    "violations": violations,
+    "compliant": compliant,
+    "controls": {
+        "3.14.1_flaw_remediation": flaw_remediation,
+        "3.14.2_malicious_code_protection": malicious_code_protection,
+        "3.14.3_security_alerts_monitored": security_alerts_monitored,
+        "3.14.4_malicious_code_updated": malicious_code_updated,
+        "3.14.5_system_scanning": system_scanning,
+        "3.14.6_attack_detection_monitoring": attack_detection_monitoring,
+        "3.14.7_unauthorized_use_detection": unauthorized_use_detection,
+    },
+}

--- a/frameworks/management/csa_ccm/csa_ccm_application_security.rego
+++ b/frameworks/management/csa_ccm/csa_ccm_application_security.rego
@@ -1,0 +1,169 @@
+package csa_ccm.application_security
+
+import rego.v1
+
+default compliant := false
+
+violations contains msg if {
+    not input.csa_ccm.application_security.appsec_policy.policy_established
+    msg := "AIS-01: Application security policies and procedures not formally established"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.appsec_policy.policy_reviewed_annually
+    msg := "AIS-01: Application security policy not reviewed at least annually"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.appsec_policy.developer_acknowledgement
+    msg := "AIS-01: Developers have not formally acknowledged application security policies"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.appsec_policy.cloud_app_scope_included
+    msg := "AIS-01: Cloud-hosted applications not explicitly included in application security policy scope"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.sdlc.lifecycle_implemented
+    msg := "AIS-02: Secure development lifecycle (SDLC) not implemented — security must be integrated into all SDLC phases"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.sdlc.security_requirements_defined
+    msg := "AIS-02: Security requirements not defined during application design phase"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.sdlc.threat_modeling_performed
+    msg := "AIS-02: Threat modeling not performed for new and significantly changed applications"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.sdlc.security_training_for_developers
+    msg := "AIS-02: Developers have not completed secure coding training"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.sdlc.security_gates_in_cicd
+    msg := "AIS-02: Security gates not integrated into CI/CD pipeline"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.testing.sast_conducted
+    msg := "AIS-03: Static application security testing (SAST) not conducted on application code"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.testing.dast_conducted
+    msg := "AIS-03: Dynamic application security testing (DAST) not conducted against running applications"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.testing.pentest_conducted
+    msg := "AIS-03: Penetration testing not conducted at defined intervals for production applications"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.testing.findings_remediated
+    msg := "AIS-03: Security testing findings not tracked to remediation with defined SLAs"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.testing.pre_release_testing_required
+    msg := "AIS-03: Security testing not required before releasing new or significantly changed application versions"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.input_validation.input_validation_implemented
+    msg := "AIS-04: Input validation not implemented — all user-supplied input must be validated"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.input_validation.output_encoding_implemented
+    msg := "AIS-04: Output encoding not implemented — output to clients must be encoded to prevent injection attacks"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.input_validation.sql_injection_prevented
+    msg := "AIS-04: SQL injection prevention controls (parameterized queries or ORM) not verified as implemented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.input_validation.xss_prevented
+    msg := "AIS-04: Cross-site scripting (XSS) prevention controls not verified as implemented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.api_security.authentication_required
+    msg := "AIS-05: API authentication not required — all API endpoints must enforce authentication"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.api_security.authorization_enforced
+    msg := "AIS-05: API authorization not enforced — access to API resources must be validated per request"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.api_security.rate_limiting_implemented
+    msg := "AIS-05: API rate limiting not implemented — APIs must be protected against abuse and denial of service"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.api_security.api_inventory_maintained
+    msg := "AIS-05: API inventory not maintained — all internal and external APIs must be catalogued"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.api_security.transport_encryption_enforced
+    msg := "AIS-05: API transport encryption not enforced — all API communication must use TLS"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.dependencies.inventory_maintained
+    msg := "AIS-06: Third-party dependency inventory not maintained — all libraries and components must be tracked"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.dependencies.vulnerability_scanning
+    msg := "AIS-06: Third-party dependencies not scanned for known vulnerabilities"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.dependencies.sca_tool_in_use
+    msg := "AIS-06: Software composition analysis (SCA) tool not integrated into development pipeline"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.dependencies.outdated_components_remediated
+    msg := "AIS-06: Outdated or vulnerable third-party components not remediated within defined SLAs"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.code_review.review_process_established
+    msg := "AIS-07: Application code review process not established"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.code_review.peer_review_required
+    msg := "AIS-07: Peer code review not required before merging code into production branches"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.code_review.security_focused_review
+    msg := "AIS-07: Code review process does not include explicit security-focused review criteria"
+}
+
+violations contains msg if {
+    not input.csa_ccm.application_security.code_review.automated_review_integrated
+    msg := "AIS-07: Automated code analysis not integrated to supplement manual review processes"
+}
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "domain": "AIS — Application & Interface Security",
+    "compliant": compliant,
+    "violation_count": count(violations),
+    "violations": violations,
+}

--- a/frameworks/management/csa_ccm/csa_ccm_audit_assurance.rego
+++ b/frameworks/management/csa_ccm/csa_ccm_audit_assurance.rego
@@ -1,0 +1,148 @@
+package csa_ccm.audit_assurance
+
+import rego.v1
+
+default compliant := false
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.independent_audit.program_established
+    msg := "A&A-01: Independent audit and assurance program not formally established"
+}
+
+violations contains msg if {
+    input.csa_ccm.audit_assurance.independent_audit.program_established
+    not input.csa_ccm.audit_assurance.independent_audit.auditor_independence_confirmed
+    msg := "A&A-01: Auditor independence not confirmed — internal auditors must have organizational independence"
+}
+
+violations contains msg if {
+    input.csa_ccm.audit_assurance.independent_audit.program_established
+    not input.csa_ccm.audit_assurance.independent_audit.cloud_scope_included
+    msg := "A&A-01: Cloud services not included in the audit and assurance program scope"
+}
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.audit_scope.scope_documented
+    msg := "A&A-02: Audit scope not documented — scope, objectives, and boundaries must be formally defined"
+}
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.audit_scope.frequency_defined
+    msg := "A&A-02: Audit frequency not defined — schedule and cadence must be documented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.audit_scope.methodology_documented
+    msg := "A&A-02: Audit methodology not documented — assessment approach and standards must be specified"
+}
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.audit_scope.risk_based_approach
+    msg := "A&A-02: Audit scope does not use a risk-based approach for prioritizing coverage"
+}
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.findings_tracking.remediation_tracked
+    msg := "A&A-03: Audit findings not tracked to remediation — findings must be assigned, tracked, and closed"
+}
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.findings_tracking.owners_assigned
+    msg := "A&A-03: Audit findings lack assigned owners responsible for remediation"
+}
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.findings_tracking.due_dates_set
+    msg := "A&A-03: Audit findings lack remediation due dates — timelines must be established and monitored"
+}
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.findings_tracking.overdue_escalation_process
+    msg := "A&A-03: No escalation process for overdue audit findings — escalation path must be defined"
+}
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.reporting.reports_communicated
+    msg := "A&A-04: Audit reports not communicated to management and relevant stakeholders"
+}
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.reporting.executive_distribution
+    msg := "A&A-04: Audit results not distributed to executive leadership for awareness and accountability"
+}
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.reporting.board_notification
+    msg := "A&A-04: Board or audit committee not notified of significant audit findings"
+}
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.reporting.timely_issuance
+    msg := "A&A-04: Audit reports not issued within required timeframe after audit completion"
+}
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.internal_audit.function_exists
+    msg := "A&A-05: Internal audit function does not exist — a formal internal audit capability must be established"
+}
+
+violations contains msg if {
+    input.csa_ccm.audit_assurance.internal_audit.function_exists
+    not input.csa_ccm.audit_assurance.internal_audit.charter_documented
+    msg := "A&A-05: Internal audit function lacks a formal charter defining scope, authority, and responsibilities"
+}
+
+violations contains msg if {
+    input.csa_ccm.audit_assurance.internal_audit.function_exists
+    not input.csa_ccm.audit_assurance.internal_audit.independence_maintained
+    msg := "A&A-05: Internal audit function independence not maintained — must report outside of audited functions"
+}
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.evidence_retention.retention_policy_defined
+    msg := "A&A-06: Audit evidence retention policy not defined — retention periods must align with regulatory requirements"
+}
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.evidence_retention.evidence_stored_securely
+    msg := "A&A-06: Audit evidence not stored securely — integrity and confidentiality must be protected"
+}
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.evidence_retention.retention_period_met
+    msg := "A&A-06: Audit evidence not retained for the required minimum retention period"
+}
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.evidence_retention.disposal_process_defined
+    msg := "A&A-06: Secure disposal process for expired audit evidence not defined"
+}
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.continuous_monitoring.monitoring_program_exists
+    msg := "A&A-07: Continuous compliance monitoring program not established"
+}
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.continuous_monitoring.automated_controls_monitored
+    msg := "A&A-07: Automated controls not continuously monitored — technical controls require ongoing validation"
+}
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.continuous_monitoring.alerts_configured
+    msg := "A&A-07: Compliance drift alerts not configured — deviations must trigger timely notification"
+}
+
+violations contains msg if {
+    not input.csa_ccm.audit_assurance.continuous_monitoring.results_reviewed_regularly
+    msg := "A&A-07: Continuous monitoring results not reviewed at defined intervals by responsible parties"
+}
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "domain": "A&A — Audit and Assurance",
+    "compliant": compliant,
+    "violation_count": count(violations),
+    "violations": violations,
+}

--- a/frameworks/management/csa_ccm/csa_ccm_business_continuity.rego
+++ b/frameworks/management/csa_ccm/csa_ccm_business_continuity.rego
@@ -1,0 +1,229 @@
+package csa_ccm.business_continuity
+
+import rego.v1
+
+default compliant := false
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.bcm_policy.policy_established
+    msg := "BCR-01: Business continuity management policy not formally established"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.bcm_policy.executive_approved
+    msg := "BCR-01: Business continuity policy not approved by executive leadership"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.bcm_policy.cloud_services_included
+    msg := "BCR-01: Cloud services and dependencies not included in business continuity policy scope"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.bcm_policy.reviewed_annually
+    msg := "BCR-01: Business continuity policy not reviewed and updated at least annually"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.bia.bia_conducted
+    msg := "BCR-02: Business impact analysis (BIA) not conducted — critical processes and dependencies must be identified"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.bia.critical_processes_identified
+    msg := "BCR-02: Critical business processes not identified and prioritized through BIA"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.bia.cloud_dependency_mapped
+    msg := "BCR-02: Cloud service dependencies not mapped as part of business impact analysis"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.bia.reviewed_after_significant_change
+    msg := "BCR-02: BIA not reviewed after significant changes to business operations or technology"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.bcp.plans_documented
+    msg := "BCR-03: Business continuity plans (BCPs) not documented for critical business functions"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.bcp.plans_maintained
+    msg := "BCR-03: Business continuity plans not maintained and updated to reflect current operations"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.bcp.roles_assigned
+    msg := "BCR-03: Roles and responsibilities in BCPs not assigned to named individuals or teams"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.bcp.contact_lists_current
+    msg := "BCR-03: Contact lists in BCPs not maintained with current information"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.bcp.activation_criteria_defined
+    msg := "BCR-03: BCP activation criteria and thresholds not clearly defined"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.bcp_testing.plans_tested
+    msg := "BCR-04: Business continuity plans not tested at defined intervals"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.bcp_testing.test_frequency_met
+    msg := "BCR-04: BCP testing frequency does not meet defined schedule requirements"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.bcp_testing.test_results_documented
+    msg := "BCR-04: BCP test results not documented including gaps and lessons learned"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.bcp_testing.deficiencies_remediated
+    msg := "BCR-04: Deficiencies identified during BCP testing not tracked to remediation"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.drp.plans_documented
+    msg := "BCR-05: Disaster recovery plans (DRPs) not documented for critical IT systems"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.drp.recovery_procedures_defined
+    msg := "BCR-05: Step-by-step recovery procedures not defined in disaster recovery plans"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.drp.alternate_site_defined
+    msg := "BCR-05: Alternate processing site or cloud failover target not defined in DRP"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.drp.data_recovery_procedures_included
+    msg := "BCR-05: Data recovery procedures not included in disaster recovery plans"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.drp_testing.drp_tested_annually
+    msg := "BCR-06: Disaster recovery plans not tested at least annually"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.drp_testing.failover_tested
+    msg := "BCR-06: Failover to alternate processing site or cloud region not tested"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.drp_testing.test_results_documented
+    msg := "BCR-06: DRP test results not documented with outcomes, gaps, and corrective actions"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.dependencies.critical_dependencies_identified
+    msg := "BCR-07: Critical technology and business dependencies not identified and managed"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.dependencies.third_party_dependencies_mapped
+    msg := "BCR-07: Third-party and cloud provider dependencies not mapped for continuity planning"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.dependencies.single_points_of_failure_addressed
+    msg := "BCR-07: Single points of failure in critical dependencies not identified and mitigated"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.rto_rpo.rto_defined
+    msg := "BCR-08: Recovery time objectives (RTO) not defined for critical business functions and systems"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.rto_rpo.rpo_defined
+    msg := "BCR-08: Recovery point objectives (RPO) not defined — acceptable data loss thresholds must be established"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.rto_rpo.rto_rpo_validated
+    msg := "BCR-08: RTO and RPO targets not validated through testing to confirm achievability"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.rto_rpo.business_approved
+    msg := "BCR-08: RTO and RPO targets not formally approved by business stakeholders"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.backup.procedures_implemented
+    msg := "BCR-09: Backup procedures not implemented for critical systems and data"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.backup.backup_frequency_meets_rpo
+    msg := "BCR-09: Backup frequency does not meet defined recovery point objectives (RPO)"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.backup.backups_tested
+    msg := "BCR-09: Backup restoration not tested at defined intervals to verify recoverability"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.backup.offsite_or_cloud_storage
+    msg := "BCR-09: Backups not stored offsite or in a separate cloud region from primary systems"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.backup.encryption_applied
+    msg := "BCR-09: Backup data not encrypted — backup storage must enforce encryption at rest"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.crisis_communication.plan_established
+    msg := "BCR-10: Crisis communication plan not established"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.crisis_communication.stakeholder_notifications_defined
+    msg := "BCR-10: Stakeholder notification procedures not defined in crisis communication plan"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.crisis_communication.media_response_defined
+    msg := "BCR-10: Media and public communications response procedures not defined for crisis events"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.crisis_communication.regulatory_notification_included
+    msg := "BCR-10: Regulatory notification requirements not included in crisis communication plan"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.lessons_learned.process_defined
+    msg := "BCR-11: Lessons learned process for incidents and BC/DR tests not formally defined"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.lessons_learned.findings_incorporated_into_plans
+    msg := "BCR-11: Lessons learned findings not incorporated into updated business continuity and DR plans"
+}
+
+violations contains msg if {
+    not input.csa_ccm.business_continuity.lessons_learned.review_conducted_after_events
+    msg := "BCR-11: Post-incident or post-test review not conducted within required timeframe"
+}
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "domain": "BCR — Business Continuity Management & Operational Resilience",
+    "compliant": compliant,
+    "violation_count": count(violations),
+    "violations": violations,
+}

--- a/frameworks/management/csa_ccm/csa_ccm_change_control.rego
+++ b/frameworks/management/csa_ccm/csa_ccm_change_control.rego
@@ -1,0 +1,184 @@
+package csa_ccm.change_control
+
+import rego.v1
+
+default compliant := false
+
+violations contains msg if {
+    not input.csa_ccm.change_control.change_policy.policy_established
+    msg := "CCC-01: Change management policy not formally established"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.change_policy.cloud_changes_in_scope
+    msg := "CCC-01: Cloud environment changes not included in change management policy scope"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.change_policy.policy_reviewed_annually
+    msg := "CCC-01: Change management policy not reviewed and updated at least annually"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.change_policy.roles_defined
+    msg := "CCC-01: Roles and responsibilities for change management not defined in policy"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.change_approval.documentation_required
+    msg := "CCC-02: Change documentation not required before implementation — all changes must be formally documented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.change_approval.review_required
+    msg := "CCC-02: Change review not required — changes must be reviewed by qualified personnel before approval"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.change_approval.approval_required
+    msg := "CCC-02: Formal change approval not required before implementation"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.change_approval.change_records_maintained
+    msg := "CCC-02: Change records not maintained — history of all changes must be retained for audit purposes"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.change_approval.impact_assessment_required
+    msg := "CCC-02: Impact assessment not required as part of change documentation and approval process"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.emergency_change.procedure_defined
+    msg := "CCC-03: Emergency change procedure not defined — expedited path for urgent changes must be documented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.emergency_change.post_approval_required
+    msg := "CCC-03: Post-implementation approval not required for emergency changes implemented without prior approval"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.emergency_change.emergency_changes_tracked
+    msg := "CCC-03: Emergency changes not tracked separately for trend analysis and review"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.emergency_change.retrospective_review_conducted
+    msg := "CCC-03: Retrospective review not conducted for emergency changes to identify root cause and prevention"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.config_baseline.baseline_established
+    msg := "CCC-04: Configuration management baseline not established for cloud and on-premises systems"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.config_baseline.baseline_documented
+    msg := "CCC-04: Configuration baseline not documented — approved configuration state must be formally recorded"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.config_baseline.baseline_reviewed_regularly
+    msg := "CCC-04: Configuration baseline not reviewed regularly to ensure accuracy and relevance"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.config_baseline.security_hardening_included
+    msg := "CCC-04: Security hardening standards not included in configuration management baseline"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.config_tracking.changes_tracked
+    msg := "CCC-05: Configuration changes not tracked — all changes to baseline configurations must be recorded"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.config_tracking.audit_trail_maintained
+    msg := "CCC-05: Audit trail not maintained for configuration changes — who, what, when must be captured"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.config_tracking.version_control_used
+    msg := "CCC-05: Version control not used for configuration management artifacts"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.unauthorized_change_detection.detection_controls_exist
+    msg := "CCC-06: Unauthorized configuration change detection controls not implemented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.unauthorized_change_detection.alerts_configured
+    msg := "CCC-06: Alerts not configured to notify security personnel of unauthorized configuration changes"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.unauthorized_change_detection.drift_detection_automated
+    msg := "CCC-06: Configuration drift detection not automated — manual-only detection is insufficient"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.unauthorized_change_detection.response_procedure_defined
+    msg := "CCC-06: Response procedure for unauthorized changes not defined — actions upon detection must be documented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.rollback.rollback_procedure_defined
+    msg := "CCC-07: Rollback procedures not defined — method to reverse changes must be documented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.rollback.success_criteria_defined
+    msg := "CCC-07: Change success criteria not defined — go/no-go decision points must be established before implementation"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.rollback.rollback_tested
+    msg := "CCC-07: Rollback procedures not tested to verify they can be executed successfully"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.separation_of_duties.sod_enforced
+    msg := "CCC-08: Separation of duties not enforced in change process — requester and approver must be different individuals"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.separation_of_duties.developer_prod_access_restricted
+    msg := "CCC-08: Developer access to production environment not restricted to prevent unauthorized changes"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.separation_of_duties.approvals_auditable
+    msg := "CCC-08: Change approvals not auditable — approval actions must be logged with identity and timestamp"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.post_implementation_review.review_conducted
+    msg := "CCC-09: Post-implementation review not conducted for significant changes"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.post_implementation_review.objectives_validated
+    msg := "CCC-09: Post-implementation review does not validate that change met its stated objectives"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.post_implementation_review.unintended_effects_assessed
+    msg := "CCC-09: Post-implementation review does not assess unintended effects or side effects of the change"
+}
+
+violations contains msg if {
+    not input.csa_ccm.change_control.post_implementation_review.lessons_captured
+    msg := "CCC-09: Lessons learned not captured from post-implementation reviews to improve future changes"
+}
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "domain": "CCC — Change Control & Configuration Management",
+    "compliant": compliant,
+    "violation_count": count(violations),
+    "violations": violations,
+}

--- a/frameworks/management/csa_ccm/csa_ccm_cryptography.rego
+++ b/frameworks/management/csa_ccm/csa_ccm_cryptography.rego
@@ -1,0 +1,185 @@
+package csa_ccm.cryptography
+
+import rego.v1
+
+default compliant := false
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.crypto_policy.policy_established
+    msg := "CEK-01: Cryptography and key management policy not formally established"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.crypto_policy.approved_algorithms_listed
+    msg := "CEK-01: Approved cryptographic algorithms not listed in policy — permitted algorithms must be enumerated"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.crypto_policy.key_management_procedures_defined
+    msg := "CEK-01: Key management procedures not defined within the cryptography policy"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.crypto_policy.policy_reviewed_annually
+    msg := "CEK-01: Cryptography policy not reviewed at least annually or when cryptographic standards change"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.encryption_at_rest.sensitive_data_encrypted
+    msg := "CEK-02: Sensitive data not encrypted at rest — data classification must drive encryption requirements"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.encryption_at_rest.database_encryption_enabled
+    msg := "CEK-02: Database encryption at rest not enabled for databases containing sensitive or regulated data"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.encryption_at_rest.storage_encryption_enabled
+    msg := "CEK-02: Storage-level encryption not enabled for cloud storage containing sensitive data"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.encryption_at_rest.backup_encryption_enabled
+    msg := "CEK-02: Backup data not encrypted — backup storage must enforce encryption at rest"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.encryption_in_transit.tls_enforced
+    msg := "CEK-03: TLS not enforced for data in transit — all network communications must use TLS 1.2 or higher"
+}
+
+violations contains msg if {
+    input.csa_ccm.cryptography.encryption_in_transit.tls_enforced
+    not input.csa_ccm.cryptography.encryption_in_transit.minimum_tls_version_met
+    msg := "CEK-03: TLS version below minimum required — TLS 1.2 is the minimum; TLS 1.3 is preferred"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.encryption_in_transit.weak_ciphers_disabled
+    msg := "CEK-03: Weak cipher suites not disabled — RC4, DES, 3DES, and export ciphers must be disabled"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.encryption_in_transit.certificate_validity_enforced
+    msg := "CEK-03: Certificate validity not enforced — expired or self-signed certificates must be rejected"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.key_generation.approved_algorithms_used
+    msg := "CEK-04: Key generation does not use approved algorithms — AES-256, RSA-2048+, or ECC-256+ required"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.key_generation.key_length_meets_standard
+    msg := "CEK-04: Cryptographic key length does not meet minimum standards for the algorithm in use"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.key_generation.random_number_generator_validated
+    msg := "CEK-04: Random number generator used for key generation not validated as cryptographically secure"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.key_generation.weak_keys_prohibited
+    msg := "CEK-04: Weak or deprecated key types (MD5, SHA-1 for signing, DSA-1024) not explicitly prohibited"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.key_storage.hsm_or_equivalent_used
+    msg := "CEK-05: Cryptographic keys not protected using HSM or equivalent key management service"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.key_storage.keys_never_stored_in_plaintext
+    msg := "CEK-05: Cryptographic keys stored in plaintext — keys must be encrypted when stored"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.key_storage.key_access_restricted
+    msg := "CEK-05: Access to cryptographic keys not restricted — least-privilege access to keys must be enforced"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.key_storage.key_access_logged
+    msg := "CEK-05: Access to cryptographic keys not logged — all key access must generate an audit record"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.key_rotation.rotation_schedule_defined
+    msg := "CEK-06: Key rotation schedule not defined — rotation frequency must be specified per key type"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.key_rotation.rotation_enforced
+    msg := "CEK-06: Key rotation not enforced per defined schedule — keys must be rotated automatically or with documented process"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.key_rotation.emergency_rotation_procedure
+    msg := "CEK-06: Emergency key rotation procedure not defined for use when compromise is suspected"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.key_rotation.rotation_logged
+    msg := "CEK-06: Key rotation events not logged — rotation history must be maintained for audit"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.key_destruction.destruction_procedure_defined
+    msg := "CEK-07: Key destruction and revocation procedures not defined"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.key_destruction.destroyed_keys_irrecoverable
+    msg := "CEK-07: Key destruction process does not guarantee keys are cryptographically irrecoverable"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.key_destruction.revocation_timely
+    msg := "CEK-07: Key revocation does not occur within defined timeframe upon suspected compromise or employee departure"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.certificate_management.lifecycle_management_implemented
+    msg := "CEK-08: Certificate lifecycle management not implemented — issuance, renewal, and revocation must be managed"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.certificate_management.expiry_monitoring_enabled
+    msg := "CEK-08: Certificate expiry monitoring not enabled — alerts must fire before certificate expiration"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.certificate_management.certificate_inventory_maintained
+    msg := "CEK-08: Certificate inventory not maintained — all issued certificates must be catalogued"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.certificate_management.crl_or_ocsp_implemented
+    msg := "CEK-08: Certificate revocation (CRL or OCSP) not implemented and checked by relying parties"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.crypto_review.standards_review_process
+    msg := "CEK-09: Process not defined for reviewing cryptographic controls when industry standards change"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.crypto_review.deprecated_crypto_identified
+    msg := "CEK-09: Deprecated or weak cryptographic implementations not proactively identified across the environment"
+}
+
+violations contains msg if {
+    not input.csa_ccm.cryptography.crypto_review.migration_plan_when_deprecated
+    msg := "CEK-09: Migration plan not defined for transitioning away from deprecated cryptographic algorithms"
+}
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "domain": "CEK — Cryptography, Encryption & Key Management",
+    "compliant": compliant,
+    "violation_count": count(violations),
+    "violations": violations,
+}

--- a/frameworks/management/csa_ccm/csa_ccm_data_security.rego
+++ b/frameworks/management/csa_ccm/csa_ccm_data_security.rego
@@ -1,0 +1,189 @@
+package csa_ccm.data_security
+
+import rego.v1
+
+default compliant := false
+
+violations contains msg if {
+    not input.csa_ccm.data_security.classification.policy_established
+    msg := "DSP-01: Data security and privacy lifecycle management policy not formally established"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.classification.classification_scheme_defined
+    msg := "DSP-01: Data classification scheme not defined — categories and handling requirements must be documented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.classification.cloud_data_in_scope
+    msg := "DSP-01: Cloud-stored and cloud-processed data not included in data security policy scope"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.classification.policy_reviewed_annually
+    msg := "DSP-01: Data security policy not reviewed and updated at least annually"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.labeling.labeling_implemented
+    msg := "DSP-02: Data labeling not implemented — data must be labeled according to classification scheme"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.labeling.sensitive_data_labeled
+    msg := "DSP-02: Sensitive and regulated data not consistently labeled across all storage and processing systems"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.labeling.labeling_enforced_at_creation
+    msg := "DSP-02: Data labeling not enforced at the time of data creation or ingestion"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.retention.retention_policy_defined
+    msg := "DSP-03: Data retention policy not defined — retention periods must align with legal and regulatory requirements"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.retention.retention_schedules_documented
+    msg := "DSP-03: Data retention schedules not documented per data classification category"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.retention.retention_enforced_technically
+    msg := "DSP-03: Data retention not enforced through technical controls — automated retention mechanisms must be implemented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.retention.legal_hold_process_defined
+    msg := "DSP-03: Legal hold process not defined to preserve data beyond normal retention periods when required"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.disposal.disposal_procedures_defined
+    msg := "DSP-04: Data disposal procedures not defined — secure deletion methods must be documented per data type"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.disposal.secure_deletion_used
+    msg := "DSP-04: Secure deletion techniques not used — data must be rendered unrecoverable upon disposal"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.disposal.cloud_data_deletion_verified
+    msg := "DSP-04: Deletion of data from cloud provider systems not verified — confirmation of deletion must be obtained"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.disposal.disposal_records_maintained
+    msg := "DSP-04: Records of data disposal not maintained for audit and compliance purposes"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.dlp.dlp_controls_implemented
+    msg := "DSP-05: Data loss prevention (DLP) controls not implemented for sensitive data"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.dlp.egress_monitoring_enabled
+    msg := "DSP-05: Data egress monitoring not enabled — unauthorized data exfiltration must be detected"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.dlp.dlp_policies_cover_cloud
+    msg := "DSP-05: DLP policies do not cover cloud storage and SaaS applications"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.dlp.dlp_alerts_reviewed
+    msg := "DSP-05: DLP alerts not reviewed by security personnel within defined response timeframe"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.privacy.privacy_notice_provided
+    msg := "DSP-06: Privacy notice not provided to data subjects informing them of data collection and use"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.privacy.consent_mechanism_implemented
+    msg := "DSP-06: Consent mechanism not implemented where required by applicable privacy regulations"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.privacy.data_subject_rights_honored
+    msg := "DSP-06: Data subject rights (access, erasure, portability, correction) not honored within required timeframes"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.privacy.privacy_impact_assessments_conducted
+    msg := "DSP-06: Privacy impact assessments not conducted for new processing activities involving personal data"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.data_flows.data_flows_mapped
+    msg := "DSP-07: Data flows not mapped — movement of sensitive data across systems and boundaries must be documented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.data_flows.data_flow_diagrams_maintained
+    msg := "DSP-07: Data flow diagrams not maintained and updated when systems or processes change"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.data_flows.unauthorized_flows_detected
+    msg := "DSP-07: Controls not implemented to detect unauthorized data flows or unexpected data movement"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.cross_border.transfer_restrictions_assessed
+    msg := "DSP-08: Cross-border data transfer restrictions not assessed for applicable jurisdictions"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.cross_border.transfer_mechanisms_documented
+    msg := "DSP-08: Legal mechanisms for cross-border data transfers (SCCs, BCRs, adequacy decisions) not documented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.cross_border.cloud_region_data_residency_enforced
+    msg := "DSP-08: Data residency requirements not enforced in cloud provider configuration"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.data_inventory.inventory_maintained
+    msg := "DSP-09: Data inventory not maintained — all sensitive and regulated data assets must be catalogued"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.data_inventory.data_owners_assigned
+    msg := "DSP-09: Data owners not assigned for sensitive and regulated data assets"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.data_inventory.inventory_reviewed_regularly
+    msg := "DSP-09: Data inventory not reviewed and updated regularly to reflect changes in data holdings"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.access_to_data.access_based_on_classification
+    msg := "DSP-10: Access to sensitive data not restricted based on data classification level"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.access_to_data.least_privilege_enforced
+    msg := "DSP-10: Least-privilege access not enforced for systems and users accessing sensitive data"
+}
+
+violations contains msg if {
+    not input.csa_ccm.data_security.access_to_data.privileged_data_access_logged
+    msg := "DSP-10: Access to sensitive and regulated data not logged for audit and anomaly detection purposes"
+}
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "domain": "DSP — Data Security & Privacy Lifecycle Management",
+    "compliant": compliant,
+    "violation_count": count(violations),
+    "violations": violations,
+}

--- a/frameworks/management/csa_ccm/csa_ccm_endpoint_management.rego
+++ b/frameworks/management/csa_ccm/csa_ccm_endpoint_management.rego
@@ -1,0 +1,209 @@
+package csa_ccm.endpoint_management
+
+import rego.v1
+
+default compliant := false
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.uem_policy.policy_established
+    msg := "UEM-01: Endpoint management policy not formally established for all device types accessing cloud services"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.uem_policy.byod_policy_defined
+    msg := "UEM-01: BYOD (bring your own device) policy not defined — personal device access to corporate data must be governed"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.uem_policy.policy_reviewed_annually
+    msg := "UEM-01: Endpoint management policy not reviewed and updated at least annually"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.uem_policy.all_device_types_in_scope
+    msg := "UEM-01: All device types (laptops, mobile, tablets, IoT) not included in endpoint management policy scope"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.mdm_deployment.mdm_uem_solution_deployed
+    msg := "UEM-02: MDM/UEM solution not deployed — endpoint management must be centralized for all managed devices"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.mdm_deployment.all_managed_devices_enrolled
+    msg := "UEM-02: All managed devices not enrolled in MDM/UEM platform — unenrolled devices must be blocked from corporate resources"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.mdm_deployment.compliance_policies_enforced
+    msg := "UEM-02: Device compliance policies not enforced via MDM/UEM — non-compliant devices must be blocked or quarantined"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.mdm_deployment.device_inventory_maintained
+    msg := "UEM-02: Device inventory not maintained through MDM/UEM — all managed endpoints must be catalogued"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.device_encryption.encryption_enforced
+    msg := "UEM-03: Device encryption not enforced on all managed endpoints — full-disk encryption must be enabled"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.device_encryption.encryption_compliance_monitored
+    msg := "UEM-03: Endpoint encryption compliance not monitored — devices without encryption must be identified and remediated"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.device_encryption.mobile_device_encryption_enforced
+    msg := "UEM-03: Mobile device encryption not enforced — smartphones and tablets accessing corporate data must encrypt storage"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.remote_wipe.remote_wipe_capability_enabled
+    msg := "UEM-04: Remote wipe capability not enabled for managed devices — lost or stolen devices must be remotely wiped"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.remote_wipe.remote_wipe_procedure_defined
+    msg := "UEM-04: Remote wipe procedure not defined — process for initiating wipe upon device loss or employee termination must be documented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.remote_wipe.selective_wipe_for_byod
+    msg := "UEM-04: Selective wipe capability not implemented for BYOD — corporate data must be removable without wiping personal data"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.byod.byod_policy_enforced
+    msg := "UEM-05: BYOD policy not enforced — personal devices accessing corporate resources must meet minimum security requirements"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.byod.containerization_or_mam_implemented
+    msg := "UEM-05: Containerization or mobile application management (MAM) not implemented to isolate corporate data on BYOD devices"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.byod.jailbroken_rooted_devices_blocked
+    msg := "UEM-05: Jailbroken or rooted devices not blocked from accessing corporate applications and data"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.byod.minimum_os_version_enforced
+    msg := "UEM-05: Minimum OS version not enforced for BYOD devices — outdated OS versions must be blocked"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.edr.edr_solution_deployed
+    msg := "UEM-06: Endpoint detection and response (EDR) solution not deployed on managed endpoints"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.edr.edr_coverage_complete
+    msg := "UEM-06: EDR coverage not complete — all managed servers and workstations must have EDR agent installed and reporting"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.edr.edr_alerts_monitored
+    msg := "UEM-06: EDR alerts not actively monitored — threat detections must be reviewed and responded to within defined SLA"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.edr.automated_response_enabled
+    msg := "UEM-06: EDR automated response not enabled — high-confidence threat detections should trigger automated containment"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.endpoint_patching.patch_management_implemented
+    msg := "UEM-07: Endpoint patch management not implemented — all managed devices must receive security patches"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.endpoint_patching.critical_patches_applied_timely
+    msg := "UEM-07: Critical endpoint patches not applied within defined SLA — critical OS and application patches must be deployed promptly"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.endpoint_patching.patch_compliance_monitored
+    msg := "UEM-07: Endpoint patch compliance not monitored — unpatched devices must be identified and reported"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.endpoint_patching.patch_testing_before_deployment
+    msg := "UEM-07: Patches not tested before broad deployment — pilot deployment must verify patch stability"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.removable_media.removable_media_policy_defined
+    msg := "UEM-08: Removable media (USB, external drives) policy not defined — use must be governed and restricted"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.removable_media.unauthorized_media_blocked
+    msg := "UEM-08: Unauthorized removable media not blocked — only approved and encrypted media must be permitted"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.removable_media.media_scanning_enforced
+    msg := "UEM-08: Removable media not scanned for malware upon connection — automatic scanning must be enforced"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.screen_lock.screen_lock_enforced
+    msg := "UEM-09: Screen lock not enforced on managed endpoints — automatic lock after defined idle period must be configured"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.screen_lock.screen_lock_timeout_appropriate
+    msg := "UEM-09: Screen lock timeout not appropriate — maximum idle time before lock must not exceed 15 minutes"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.application_control.application_allowlisting_implemented
+    msg := "UEM-10: Application allowlisting or application control not implemented — unauthorized applications must be prevented from executing"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.application_control.unauthorized_apps_blocked
+    msg := "UEM-10: Unauthorized application execution not blocked — software installation without approval must be prevented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.configuration_baseline.endpoint_hardening_standards_applied
+    msg := "UEM-11: Endpoint hardening standards not applied — managed endpoints must be configured per security baseline (CIS Benchmark)"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.configuration_baseline.baseline_drift_detected
+    msg := "UEM-11: Configuration drift from endpoint hardening baseline not detected — deviation from standard must trigger remediation"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.configuration_baseline.new_devices_hardened_before_deployment
+    msg := "UEM-11: New endpoints not hardened before deployment — security configuration must be applied prior to production use"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.network_access_control.nac_implemented
+    msg := "UEM-12: Network access control (NAC) not implemented — device compliance must be verified before granting network access"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.network_access_control.non_compliant_devices_quarantined
+    msg := "UEM-12: Non-compliant devices not quarantined — devices failing compliance checks must be isolated from corporate networks"
+}
+
+violations contains msg if {
+    not input.csa_ccm.endpoint_management.network_access_control.guest_network_segregated
+    msg := "UEM-12: Guest and BYOD network not segregated from corporate network — untrusted devices must access only segregated network segments"
+}
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "domain": "UEM — Universal Endpoint Management",
+    "compliant": compliant,
+    "violation_count": count(violations),
+    "violations": violations,
+}

--- a/frameworks/management/csa_ccm/csa_ccm_governance.rego
+++ b/frameworks/management/csa_ccm/csa_ccm_governance.rego
@@ -1,0 +1,144 @@
+package csa_ccm.governance
+
+import rego.v1
+
+default compliant := false
+
+violations contains msg if {
+    not input.csa_ccm.governance.security_framework.framework_established
+    msg := "GRC-01: Information security governance framework not formally established"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.security_framework.cloud_governance_included
+    msg := "GRC-01: Cloud computing governance not explicitly included in the security governance framework"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.security_framework.framework_aligned_to_standard
+    msg := "GRC-01: Governance framework not aligned to a recognized standard (ISO 27001, NIST CSF, CSA CCM)"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.security_framework.framework_documented
+    msg := "GRC-01: Information security governance framework not formally documented and published"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.security_framework.reviewed_annually
+    msg := "GRC-01: Information security governance framework not reviewed at least annually"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.roles_responsibilities.ciso_or_equivalent_defined
+    msg := "GRC-02: CISO or equivalent cloud security leadership role not formally defined"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.roles_responsibilities.cloud_security_roles_documented
+    msg := "GRC-02: Roles and responsibilities for cloud security not documented and communicated"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.roles_responsibilities.accountability_assigned
+    msg := "GRC-02: Accountability for cloud security outcomes not assigned to named individuals or roles"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.roles_responsibilities.raci_or_equivalent_defined
+    msg := "GRC-02: RACI or equivalent responsibility matrix not defined for cloud security functions"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.risk_management.risk_program_exists
+    msg := "GRC-03: Risk management program not established for cloud and information security"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.risk_management.risk_register_maintained
+    msg := "GRC-03: Risk register not maintained — identified risks must be documented with likelihood and impact"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.risk_management.risk_treatment_plans_defined
+    msg := "GRC-03: Risk treatment plans not defined for accepted or mitigated risks"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.risk_management.risk_review_cadence
+    msg := "GRC-03: Risk reviews not conducted at defined intervals — risk posture must be regularly reassessed"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.risk_management.risk_aligned_to_business_objectives
+    msg := "GRC-03: Risk management program not aligned to organizational business objectives and risk appetite"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.compliance_obligations.obligations_inventoried
+    msg := "GRC-04: Compliance obligations not inventoried — all applicable legal, regulatory, and contractual requirements must be catalogued"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.compliance_obligations.obligations_tracked
+    msg := "GRC-04: Compliance obligation status not tracked — adherence to each obligation must be monitored"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.compliance_obligations.gaps_identified_and_remediated
+    msg := "GRC-04: Compliance gaps not identified and tracked to remediation"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.compliance_obligations.regulatory_change_monitoring
+    msg := "GRC-04: Process not established to monitor for changes in applicable regulatory requirements"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.executive_approval.policies_executive_approved
+    msg := "GRC-05: Cloud security policies not formally approved by executive leadership"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.executive_approval.cloud_strategy_approved
+    msg := "GRC-05: Cloud strategy not formally approved by executive leadership"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.executive_approval.security_budget_allocated
+    msg := "GRC-05: Security budget not allocated by executive leadership as part of approved strategy"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.executive_approval.board_oversight_exists
+    msg := "GRC-05: Board-level oversight of cloud security and risk management not established"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.metrics.metrics_defined
+    msg := "GRC-06: Security metrics and KPIs not defined for the cloud security program"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.metrics.metrics_reported_to_leadership
+    msg := "GRC-06: Security metrics not regularly reported to executive leadership and board"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.metrics.metrics_actionable
+    msg := "GRC-06: Security metrics not actionable — metrics must drive decisions and program improvements"
+}
+
+violations contains msg if {
+    not input.csa_ccm.governance.metrics.metrics_reviewed_regularly
+    msg := "GRC-06: Security metrics and KPIs not reviewed regularly to assess relevance and effectiveness"
+}
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "domain": "GRC — Governance, Risk & Compliance",
+    "compliant": compliant,
+    "violation_count": count(violations),
+    "violations": violations,
+}

--- a/frameworks/management/csa_ccm/csa_ccm_human_resources.rego
+++ b/frameworks/management/csa_ccm/csa_ccm_human_resources.rego
@@ -1,0 +1,194 @@
+package csa_ccm.human_resources
+
+import rego.v1
+
+default compliant := false
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.background_checks.policy_established
+    msg := "HRS-01: Background check policy for personnel with access to sensitive systems not established"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.background_checks.checks_conducted_pre_hire
+    msg := "HRS-01: Background checks not conducted before granting access to sensitive cloud environments"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.background_checks.checks_commensurate_with_access
+    msg := "HRS-01: Background check depth not commensurate with the sensitivity of access being granted"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.background_checks.contractors_included
+    msg := "HRS-01: Background check requirements not applied to contractors and third-party personnel with system access"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.security_awareness.training_program_established
+    msg := "HRS-02: Security awareness training program not established for all personnel"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.security_awareness.training_conducted_at_hire
+    msg := "HRS-02: Security awareness training not completed by new employees before granting system access"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.security_awareness.annual_training_required
+    msg := "HRS-02: Annual security awareness training not required for all personnel"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.security_awareness.cloud_security_topics_included
+    msg := "HRS-02: Cloud security topics not included in security awareness training curriculum"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.security_awareness.completion_tracked
+    msg := "HRS-02: Training completion not tracked to ensure all personnel have completed required training"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.acceptable_use.policy_established
+    msg := "HRS-03: Acceptable use policy for information systems and cloud resources not established"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.acceptable_use.employees_acknowledged
+    msg := "HRS-03: Employees have not formally acknowledged and signed the acceptable use policy"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.acceptable_use.policy_reviewed_annually
+    msg := "HRS-03: Acceptable use policy not reviewed and updated at least annually"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.acceptable_use.violations_enforced
+    msg := "HRS-03: Disciplinary process for acceptable use policy violations not defined and communicated"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.nda.nda_required
+    msg := "HRS-04: Non-disclosure agreements not required for personnel with access to sensitive or proprietary information"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.nda.nda_signed_before_access
+    msg := "HRS-04: NDAs not signed before granting access to sensitive information or cloud environments"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.nda.nda_covers_cloud_data
+    msg := "HRS-04: NDAs do not explicitly cover cloud-hosted data and third-party cloud environments"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.nda.nda_records_maintained
+    msg := "HRS-04: NDA signing records not maintained for audit and legal purposes"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.termination.termination_procedure_defined
+    msg := "HRS-05: Employee and contractor termination procedure not formally defined"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.termination.access_revoked_timely
+    msg := "HRS-05: System and cloud access not revoked within defined timeframe upon termination"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.termination.privileged_access_revoked_immediately
+    msg := "HRS-05: Privileged access not revoked immediately upon termination — elevated access must be removed without delay"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.termination.asset_return_verified
+    msg := "HRS-05: Return of company-issued assets and credentials not verified upon termination"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.termination.exit_process_documented
+    msg := "HRS-05: Exit process not documented with checklist of security-relevant steps to complete upon separation"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.role_based_access_removal.access_tied_to_role
+    msg := "HRS-06: Access privileges not tied to job roles — access must be granted based on defined roles and responsibilities"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.role_based_access_removal.access_updated_on_role_change
+    msg := "HRS-06: Access not updated when personnel change roles — access must reflect current job responsibilities"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.role_based_access_removal.periodic_access_reviews_conducted
+    msg := "HRS-06: Periodic access reviews not conducted to verify access remains appropriate for current roles"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.role_based_access_removal.orphaned_accounts_removed
+    msg := "HRS-06: Orphaned accounts (accounts without active owners) not identified and removed"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.insider_threat.program_exists
+    msg := "HRS-07: Insider threat program not established — behavioral monitoring and detection controls must be implemented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.insider_threat.monitoring_implemented
+    msg := "HRS-07: User behavior monitoring not implemented to detect potential insider threat indicators"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.insider_threat.reporting_mechanism_exists
+    msg := "HRS-07: Mechanism for reporting suspected insider threat activity not established and communicated to personnel"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.insider_threat.high_risk_personnel_controls
+    msg := "HRS-07: Enhanced monitoring controls not applied to personnel with high-privilege access or elevated risk"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.security_roles.specialized_training_provided
+    msg := "HRS-08: Specialized security training not provided to personnel in security-relevant roles (admins, developers, security team)"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.security_roles.certifications_encouraged
+    msg := "HRS-08: Security certifications not encouraged or required for personnel in cloud security roles"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.security_roles.security_responsibilities_documented
+    msg := "HRS-08: Security responsibilities not formally documented in job descriptions for roles with security functions"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.third_party_personnel.security_requirements_communicated
+    msg := "HRS-09: Security requirements not formally communicated to third-party personnel before granting access"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.third_party_personnel.access_limited_to_required
+    msg := "HRS-09: Third-party personnel access not limited to only what is required for contracted services"
+}
+
+violations contains msg if {
+    not input.csa_ccm.human_resources.third_party_personnel.access_reviewed_regularly
+    msg := "HRS-09: Third-party personnel access not reviewed regularly to confirm continued business need"
+}
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "domain": "HRS — Human Resources",
+    "compliant": compliant,
+    "violation_count": count(violations),
+    "violations": violations,
+}

--- a/frameworks/management/csa_ccm/csa_ccm_identity_access.rego
+++ b/frameworks/management/csa_ccm/csa_ccm_identity_access.rego
@@ -1,0 +1,255 @@
+package csa_ccm.identity_access
+
+import rego.v1
+
+default compliant := false
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.iam_policy.policy_established
+    msg := "IAM-01: Identity and access management policy not formally established"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.iam_policy.cloud_identities_in_scope
+    msg := "IAM-01: Cloud identity management not included in IAM policy scope"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.iam_policy.policy_reviewed_annually
+    msg := "IAM-01: IAM policy not reviewed and updated at least annually"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.iam_policy.least_privilege_principle_adopted
+    msg := "IAM-01: Least-privilege access principle not formally adopted in IAM policy"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.identity_lifecycle.provisioning_process_defined
+    msg := "IAM-02: Identity provisioning process not defined — formal procedure for creating and managing accounts required"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.identity_lifecycle.deprovisioning_process_defined
+    msg := "IAM-02: Identity deprovisioning process not defined — accounts must be removed or disabled promptly when no longer needed"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.identity_lifecycle.unique_identities_enforced
+    msg := "IAM-02: Unique identities not enforced — shared accounts must be prohibited except where technically required"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.identity_lifecycle.identity_verified_before_provisioning
+    msg := "IAM-02: Identity verification not performed before provisioning accounts with access to sensitive systems"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.mfa.mfa_enforced
+    msg := "IAM-03: Multi-factor authentication (MFA) not enforced for access to cloud management consoles and sensitive systems"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.mfa.mfa_on_privileged_accounts
+    msg := "IAM-03: MFA not enforced for all privileged accounts — administrative access requires MFA without exception"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.mfa.mfa_on_remote_access
+    msg := "IAM-03: MFA not enforced for remote access connections (VPN, remote desktop, SSH with key-only insufficient)"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.mfa.phishing_resistant_mfa_for_admins
+    msg := "IAM-03: Phishing-resistant MFA not used for administrative accounts — FIDO2/hardware keys required for high-privilege access"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.privileged_access.pam_solution_deployed
+    msg := "IAM-04: Privileged access management (PAM) solution not deployed to control and audit privileged account usage"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.privileged_access.privileged_accounts_inventoried
+    msg := "IAM-04: Privileged accounts not inventoried — all accounts with elevated access must be catalogued"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.privileged_access.privileged_sessions_recorded
+    msg := "IAM-04: Privileged sessions not recorded — administrative sessions must be captured for audit and forensic purposes"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.privileged_access.standing_privilege_minimized
+    msg := "IAM-04: Standing privileged access not minimized — just-in-time access must be implemented where feasible"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.privileged_access.break_glass_procedure_defined
+    msg := "IAM-04: Break-glass emergency access procedure not defined for privileged accounts"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.sso.sso_implemented
+    msg := "IAM-05: Single sign-on (SSO) not implemented for cloud applications to centralize access management"
+}
+
+violations contains msg if {
+    input.csa_ccm.identity_access.sso.sso_implemented
+    not input.csa_ccm.identity_access.sso.sso_uses_federated_identity
+    msg := "IAM-05: SSO not federated with enterprise identity provider — applications must authenticate through central IdP"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.sso.sso_session_timeout_configured
+    msg := "IAM-05: SSO session timeout not configured — idle sessions must expire after defined period of inactivity"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.service_accounts.service_accounts_inventoried
+    msg := "IAM-06: Service accounts not inventoried — all non-human identities must be catalogued with their purpose and owner"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.service_accounts.service_account_credentials_rotated
+    msg := "IAM-06: Service account credentials not rotated on defined schedule — static credentials create persistent risk"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.service_accounts.service_account_permissions_minimal
+    msg := "IAM-06: Service account permissions not minimized — accounts must have only the access required for their function"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.service_accounts.managed_identities_preferred
+    msg := "IAM-06: Managed identities or workload identity federation not preferred over static service account credentials"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.access_reviews.reviews_conducted
+    msg := "IAM-07: Access reviews not conducted at defined intervals to verify access remains appropriate"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.access_reviews.privileged_access_reviewed_frequently
+    msg := "IAM-07: Privileged access not reviewed more frequently than standard user access"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.access_reviews.inappropriate_access_revoked
+    msg := "IAM-07: Inappropriate access identified during reviews not revoked within defined timeframe"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.access_reviews.review_results_documented
+    msg := "IAM-07: Access review results not documented and retained for audit purposes"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.jit_access.jit_implemented_for_privileged
+    msg := "IAM-08: Just-in-time (JIT) access not implemented for privileged cloud management access"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.jit_access.access_requests_approved
+    msg := "IAM-08: JIT access requests not subject to approval before access is granted"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.jit_access.jit_access_time_limited
+    msg := "IAM-08: JIT access not time-limited — elevated access must automatically expire after defined duration"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.rbac.rbac_implemented
+    msg := "IAM-09: Role-based access control (RBAC) not implemented — access must be granted based on defined roles"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.rbac.roles_defined_per_job_function
+    msg := "IAM-09: RBAC roles not defined per job function — access groups must align to business role requirements"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.rbac.excessive_role_assignments_detected
+    msg := "IAM-09: Excessive role assignments not detected and remediated — personnel must not accumulate unnecessary roles"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.zero_trust.network_implicit_trust_eliminated
+    msg := "IAM-10: Implicit network trust not eliminated — zero trust principles require verification of every access request"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.zero_trust.continuous_verification_implemented
+    msg := "IAM-10: Continuous identity and device verification not implemented — trust must be continuously validated"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.zero_trust.microsegmentation_applied
+    msg := "IAM-10: Microsegmentation not applied to limit lateral movement within cloud environments"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.password_policy.password_policy_enforced
+    msg := "IAM-11: Password policy not enforced for user accounts — minimum complexity and length requirements must be configured"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.password_policy.minimum_length_enforced
+    msg := "IAM-11: Password minimum length not enforced — passwords must meet minimum length requirements (14+ characters)"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.password_policy.breached_password_detection
+    msg := "IAM-11: Breached password detection not implemented — compromised passwords must be blocked or flagged"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.account_lockout.lockout_policy_configured
+    msg := "IAM-12: Account lockout policy not configured — repeated failed authentication attempts must lock accounts"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.account_lockout.lockout_threshold_appropriate
+    msg := "IAM-12: Account lockout threshold too high — maximum failed attempts before lockout must be set to 10 or fewer"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.federated_identity.federation_implemented
+    msg := "IAM-13: Federated identity not implemented — cloud access must authenticate through enterprise directory"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.federated_identity.directory_sync_operational
+    msg := "IAM-13: Directory synchronization not operational — cloud identity must reflect current enterprise directory state"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.federated_identity.terminated_users_deprovisioned_automatically
+    msg := "IAM-13: Terminated users not automatically deprovisioned from cloud systems via directory synchronization"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.privileged_identity.privileged_identity_governance_defined
+    msg := "IAM-14: Privileged identity governance not defined — lifecycle of privileged accounts must be formally managed"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.privileged_identity.admin_accounts_separate_from_user_accounts
+    msg := "IAM-14: Administrative accounts not separate from standard user accounts — separate identities required for privileged tasks"
+}
+
+violations contains msg if {
+    not input.csa_ccm.identity_access.privileged_identity.global_admin_accounts_minimized
+    msg := "IAM-14: Number of global administrator accounts not minimized — highest-privilege roles must have the fewest holders"
+}
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "domain": "IAM — Identity & Access Management",
+    "compliant": compliant,
+    "violation_count": count(violations),
+    "violations": violations,
+}

--- a/frameworks/management/csa_ccm/csa_ccm_incident_management.rego
+++ b/frameworks/management/csa_ccm/csa_ccm_incident_management.rego
@@ -1,0 +1,179 @@
+package csa_ccm.incident_management
+
+import rego.v1
+
+default compliant := false
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.ir_policy.policy_established
+    msg := "SEF-01: Security incident response policy not formally established"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.ir_policy.cloud_incidents_in_scope
+    msg := "SEF-01: Cloud security incidents not explicitly included in incident response policy scope"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.ir_policy.roles_defined
+    msg := "SEF-01: Incident response roles and responsibilities not defined in policy"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.ir_policy.policy_reviewed_annually
+    msg := "SEF-01: Incident response policy not reviewed and updated at least annually"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.ir_policy.ir_plan_exists
+    msg := "SEF-01: Incident response plan not documented — detailed procedures for responding to security incidents required"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.classification.classification_scheme_defined
+    msg := "SEF-02: Incident classification and severity scheme not defined"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.classification.severity_levels_documented
+    msg := "SEF-02: Incident severity levels (critical, high, medium, low) not documented with clear criteria"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.classification.triage_procedure_defined
+    msg := "SEF-02: Incident triage procedure not defined — method for assessing and classifying incoming incidents required"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.classification.cloud_specific_classification_included
+    msg := "SEF-02: Cloud-specific incident types not included in classification scheme (account compromise, misconfiguration, data exposure)"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.escalation.escalation_procedures_defined
+    msg := "SEF-03: Incident escalation procedures not defined — criteria and path for escalating incidents must be documented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.escalation.escalation_contacts_maintained
+    msg := "SEF-03: Escalation contact list not maintained with current information for all response roles"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.escalation.management_notification_thresholds
+    msg := "SEF-03: Management notification thresholds not defined — criteria for when to notify leadership must be specified"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.escalation.on_call_rotation_established
+    msg := "SEF-03: On-call rotation not established — 24/7 incident response coverage must be maintained"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.notification.customer_notification_procedure
+    msg := "SEF-04: Customer notification procedure not defined for incidents affecting customer data or services"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.notification.regulatory_notification_timeframes
+    msg := "SEF-04: Regulatory notification timeframes not documented — breach notification deadlines (e.g., GDPR 72 hours) must be tracked"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.notification.notification_templates_prepared
+    msg := "SEF-04: Notification templates not prepared — pre-approved communications for stakeholders and regulators required"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.notification.notifications_sent_within_sla
+    msg := "SEF-04: Incident notifications not sent within defined SLA timeframes for the incident severity level"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.forensic_readiness.forensic_readiness_plan_exists
+    msg := "SEF-05: Forensic readiness plan not established — capability to collect and preserve evidence must be pre-planned"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.forensic_readiness.cloud_forensics_capability
+    msg := "SEF-05: Cloud forensics capability not established — tools and procedures for cloud evidence collection must be ready"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.forensic_readiness.evidence_preservation_procedure
+    msg := "SEF-05: Evidence preservation procedure not defined — chain of custody and evidence integrity must be maintained"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.forensic_readiness.legal_hold_integrated_with_ir
+    msg := "SEF-05: Legal hold process not integrated with incident response — legal requirements during incidents must be addressed"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.forensic_readiness.log_retention_sufficient_for_forensics
+    msg := "SEF-05: Log retention period not sufficient for forensic investigation — at least 12 months of logs must be available"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.post_incident_review.review_conducted
+    msg := "SEF-06: Post-incident review not conducted after significant security incidents"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.post_incident_review.root_cause_analysis_performed
+    msg := "SEF-06: Root cause analysis not performed for security incidents to prevent recurrence"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.post_incident_review.lessons_learned_documented
+    msg := "SEF-06: Lessons learned not documented and shared from post-incident reviews"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.post_incident_review.process_improvements_tracked
+    msg := "SEF-06: Process improvements identified in post-incident reviews not tracked to completion"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.ir_testing.ir_plan_tested
+    msg := "SEF-06: Incident response plan not tested through exercises — tabletop or simulation exercises must be conducted"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.ediscovery.ediscovery_capability_defined
+    msg := "SEF-07: E-discovery capability not defined — ability to identify and collect electronically stored information for legal proceedings required"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.ediscovery.cloud_data_searchable
+    msg := "SEF-07: Cloud-stored data not searchable and exportable for e-discovery and legal proceedings"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.ediscovery.legal_team_engaged_in_planning
+    msg := "SEF-07: Legal team not engaged in e-discovery capability planning — legal requirements must inform technical implementation"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.metrics.incident_metrics_tracked
+    msg := "SEF-08: Security incident metrics not tracked — mean time to detect (MTTD) and mean time to respond (MTTR) must be measured"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.metrics.metrics_reported_to_management
+    msg := "SEF-08: Incident metrics not regularly reported to management — leadership must have visibility into incident trends"
+}
+
+violations contains msg if {
+    not input.csa_ccm.incident_management.metrics.trend_analysis_conducted
+    msg := "SEF-08: Incident trend analysis not conducted to identify systemic issues or patterns"
+}
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "domain": "SEF — Security Incident Management, E-Discovery & Cloud Forensics",
+    "compliant": compliant,
+    "violation_count": count(violations),
+    "violations": violations,
+}

--- a/frameworks/management/csa_ccm/csa_ccm_infrastructure.rego
+++ b/frameworks/management/csa_ccm/csa_ccm_infrastructure.rego
@@ -1,0 +1,204 @@
+package csa_ccm.infrastructure
+
+import rego.v1
+
+default compliant := false
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.network_segmentation.segmentation_implemented
+    msg := "IVS-01: Network segmentation not implemented — production, development, and sensitive workloads must be isolated"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.network_segmentation.micro_segmentation_applied
+    msg := "IVS-01: Micro-segmentation not applied to cloud virtual networks — workloads must be isolated at the subnet or security group level"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.network_segmentation.dmz_implemented
+    msg := "IVS-01: DMZ or equivalent perimeter isolation not implemented for internet-facing cloud services"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.network_segmentation.segmentation_validated
+    msg := "IVS-01: Network segmentation effectiveness not validated through testing or verification"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.hypervisor.hypervisor_hardened
+    msg := "IVS-02: Hypervisor not hardened — virtualization layer must be configured per security hardening standards"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.hypervisor.hypervisor_patched_regularly
+    msg := "IVS-02: Hypervisor and virtualization platform not patched on defined schedule to address known vulnerabilities"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.hypervisor.hypervisor_access_restricted
+    msg := "IVS-02: Administrative access to hypervisor not restricted to authorized personnel only"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.vm_isolation.vm_isolation_enforced
+    msg := "IVS-03: Virtual machine isolation not enforced — guest VMs must be prevented from accessing other VMs or host resources"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.vm_isolation.vm_breakout_controls_implemented
+    msg := "IVS-03: VM escape/breakout controls not implemented — hypervisor-level protections must prevent VM escapes"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.vm_isolation.multi_tenant_isolation_verified
+    msg := "IVS-03: Multi-tenant isolation not verified — cloud provider tenant isolation controls must be validated"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.network_security_groups.security_groups_configured
+    msg := "IVS-04: Cloud network security groups not configured — all cloud resources must have explicit ingress and egress rules"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.network_security_groups.default_deny_implemented
+    msg := "IVS-04: Default-deny posture not implemented — network security groups must deny all traffic not explicitly permitted"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.network_security_groups.overly_permissive_rules_detected
+    msg := "IVS-04: Overly permissive security group rules (0.0.0.0/0 on sensitive ports) not detected and remediated"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.network_security_groups.security_group_review_conducted
+    msg := "IVS-04: Security group rules not reviewed regularly for necessity and least-privilege compliance"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.container_security.container_images_scanned
+    msg := "IVS-05: Container images not scanned for vulnerabilities before deployment"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.container_security.trusted_registries_enforced
+    msg := "IVS-05: Container images not restricted to trusted registries — image pull from public untrusted sources must be blocked"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.container_security.containers_run_as_non_root
+    msg := "IVS-05: Containers not enforced to run as non-root user — privileged container execution must be prevented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.container_security.runtime_security_monitoring
+    msg := "IVS-05: Container runtime security monitoring not implemented — anomalous container behavior must be detected"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.container_security.image_signing_enforced
+    msg := "IVS-05: Container image signing not enforced — only signed images from authorized sources should be deployed"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.workload_protection.workload_protection_deployed
+    msg := "IVS-06: Workload protection solution not deployed — cloud workloads must be protected against malware and threats"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.workload_protection.cloud_security_posture_managed
+    msg := "IVS-06: Cloud security posture management (CSPM) not implemented to detect cloud misconfiguration"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.workload_protection.cloud_workload_protection_active
+    msg := "IVS-06: Cloud workload protection platform (CWPP) not active on production cloud workloads"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.vulnerability_scanning.infrastructure_scanned
+    msg := "IVS-07: Infrastructure vulnerability scanning not performed on cloud hosts and network components"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.vulnerability_scanning.scan_frequency_defined
+    msg := "IVS-07: Infrastructure scanning frequency not defined — scan cadence must be documented and enforced"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.vulnerability_scanning.findings_tracked_to_remediation
+    msg := "IVS-07: Infrastructure vulnerability scan findings not tracked to remediation with defined SLAs"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.vulnerability_scanning.authenticated_scans_used
+    msg := "IVS-07: Authenticated vulnerability scans not used — unauthenticated scans miss significant vulnerability classes"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.host_hardening.hardening_standards_applied
+    msg := "IVS-08: Host hardening standards not applied to cloud virtual machine instances"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.host_hardening.cis_benchmark_or_stig_followed
+    msg := "IVS-08: CIS Benchmark or DISA STIG not followed for cloud host hardening configuration"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.host_hardening.hardening_compliance_verified
+    msg := "IVS-08: Hardening compliance not verified after provisioning — drift from baseline must be detected"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.network_monitoring.network_traffic_monitored
+    msg := "IVS-09: Cloud network traffic not monitored for anomalous or malicious activity"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.network_monitoring.flow_logs_enabled
+    msg := "IVS-09: Cloud network flow logs not enabled — VPC/VNet flow logs must be collected for security analysis"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.network_monitoring.ids_ips_deployed
+    msg := "IVS-09: Intrusion detection or prevention system not deployed to monitor cloud network traffic"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.patch_management.infrastructure_patches_applied
+    msg := "IVS-10: Infrastructure patching not enforced — cloud hosts and network components must be patched on defined schedule"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.patch_management.critical_patches_applied_timely
+    msg := "IVS-10: Critical infrastructure patches not applied within required timeframe (≤15 days for critical severity)"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.patch_management.patch_compliance_monitored
+    msg := "IVS-10: Infrastructure patch compliance not monitored — unpatched systems must be identified and reported"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.resource_management.unused_resources_identified
+    msg := "IVS-11: Unused cloud resources not identified — orphaned instances, storage, and access keys create unnecessary attack surface"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.resource_management.resource_inventory_maintained
+    msg := "IVS-11: Cloud resource inventory not maintained — all provisioned cloud assets must be catalogued"
+}
+
+violations contains msg if {
+    not input.csa_ccm.infrastructure.resource_management.resource_tagging_enforced
+    msg := "IVS-11: Resource tagging not enforced — cloud resources must be tagged with owner, environment, and classification"
+}
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "domain": "IVS — Infrastructure & Virtualization Security",
+    "compliant": compliant,
+    "violation_count": count(violations),
+    "violations": violations,
+}

--- a/frameworks/management/csa_ccm/csa_ccm_interoperability.rego
+++ b/frameworks/management/csa_ccm/csa_ccm_interoperability.rego
@@ -1,0 +1,109 @@
+package csa_ccm.interoperability
+
+import rego.v1
+
+default compliant := false
+
+violations contains msg if {
+    not input.csa_ccm.interoperability.data_portability.requirements_documented
+    msg := "IPY-01: Data portability requirements not documented — ability to export and migrate data must be formally assessed"
+}
+
+violations contains msg if {
+    not input.csa_ccm.interoperability.data_portability.export_capability_verified
+    msg := "IPY-01: Data export capability not verified — ability to retrieve all data from the cloud provider must be tested"
+}
+
+violations contains msg if {
+    not input.csa_ccm.interoperability.data_portability.portability_sla_in_contracts
+    msg := "IPY-01: Data portability provisions not included in cloud provider contracts or service agreements"
+}
+
+violations contains msg if {
+    not input.csa_ccm.interoperability.data_portability.data_formats_documented
+    msg := "IPY-01: Data formats used by cloud provider not documented — format dependencies must be understood for portability planning"
+}
+
+violations contains msg if {
+    not input.csa_ccm.interoperability.api_standards.apis_documented
+    msg := "IPY-02: APIs not documented — all interfaces used for cloud service integration must be formally documented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.interoperability.api_standards.standard_protocols_used
+    msg := "IPY-02: Non-standard or proprietary protocols not assessed for interoperability risk — standard APIs (REST, OpenAPI) must be preferred"
+}
+
+violations contains msg if {
+    not input.csa_ccm.interoperability.api_standards.api_versioning_managed
+    msg := "IPY-02: API versioning not managed — deprecated API versions must have defined sunset timelines"
+}
+
+violations contains msg if {
+    not input.csa_ccm.interoperability.api_standards.api_dependency_inventory
+    msg := "IPY-02: Inventory of third-party API dependencies not maintained for interoperability and continuity assessment"
+}
+
+violations contains msg if {
+    not input.csa_ccm.interoperability.exit_plan.exit_plan_established
+    msg := "IPY-03: Exit and transition plan not established for cloud provider changes or service termination"
+}
+
+violations contains msg if {
+    not input.csa_ccm.interoperability.exit_plan.data_migration_procedure_defined
+    msg := "IPY-03: Data migration procedure not defined as part of exit planning — method for moving data must be documented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.interoperability.exit_plan.business_continuity_during_migration
+    msg := "IPY-03: Business continuity requirements during provider migration not addressed in exit plan"
+}
+
+violations contains msg if {
+    not input.csa_ccm.interoperability.exit_plan.exit_plan_reviewed_regularly
+    msg := "IPY-03: Exit plan not reviewed regularly — plan must remain current with evolving architecture and provider landscape"
+}
+
+violations contains msg if {
+    not input.csa_ccm.interoperability.exit_plan.transition_timelines_defined
+    msg := "IPY-03: Transition timelines and dependencies not defined in exit plan"
+}
+
+violations contains msg if {
+    not input.csa_ccm.interoperability.data_format_standards.open_standards_preferred
+    msg := "IPY-04: Open data format standards not preferred — proprietary formats must be assessed for lock-in risk"
+}
+
+violations contains msg if {
+    not input.csa_ccm.interoperability.data_format_standards.vendor_lock_in_assessed
+    msg := "IPY-04: Vendor lock-in risk not formally assessed for each cloud service used"
+}
+
+violations contains msg if {
+    not input.csa_ccm.interoperability.data_format_standards.format_standards_documented
+    msg := "IPY-04: Data format standards not documented for data at rest and in transit with cloud services"
+}
+
+violations contains msg if {
+    not input.csa_ccm.interoperability.portability_testing.portability_tested
+    msg := "IPY-05: Portability not tested at defined intervals — ability to migrate must be periodically validated"
+}
+
+violations contains msg if {
+    not input.csa_ccm.interoperability.portability_testing.test_results_documented
+    msg := "IPY-05: Portability test results not documented — outcomes, gaps, and remediation steps must be recorded"
+}
+
+violations contains msg if {
+    not input.csa_ccm.interoperability.portability_testing.deficiencies_remediated
+    msg := "IPY-05: Portability deficiencies identified during testing not tracked to remediation"
+}
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "domain": "IPY — Interoperability & Portability",
+    "compliant": compliant,
+    "violation_count": count(violations),
+    "violations": violations,
+}

--- a/frameworks/management/csa_ccm/csa_ccm_logging_monitoring.rego
+++ b/frameworks/management/csa_ccm/csa_ccm_logging_monitoring.rego
@@ -1,0 +1,214 @@
+package csa_ccm.logging_monitoring
+
+import rego.v1
+
+default compliant := false
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.audit_logging.logging_policy_established
+    msg := "LOG-01: Audit logging policy not established — requirements for what must be logged must be formally defined"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.audit_logging.audit_logging_enabled
+    msg := "LOG-01: Audit logging not enabled across cloud management planes and application layers"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.audit_logging.cloud_api_logging_enabled
+    msg := "LOG-01: Cloud control plane API logging not enabled — all API calls to cloud management APIs must be logged"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.audit_logging.log_coverage_verified
+    msg := "LOG-01: Audit log coverage not verified — gaps in logging across systems must be identified and addressed"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.log_retention.retention_policy_defined
+    msg := "LOG-02: Log retention policy not defined — minimum retention periods must be documented per log type and regulatory requirement"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.log_retention.retention_period_enforced
+    msg := "LOG-02: Log retention period not technically enforced — automated retention and deletion controls must be configured"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.log_retention.minimum_retention_met
+    msg := "LOG-02: Log retention does not meet minimum period required by applicable regulations (typically 1 year or more)"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.log_retention.archived_logs_protected
+    msg := "LOG-02: Archived logs not protected from unauthorized modification or deletion"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.centralized_logging.siem_deployed
+    msg := "LOG-03: SIEM or centralized logging platform not deployed — logs must be aggregated for correlation and analysis"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.centralized_logging.cloud_logs_forwarded
+    msg := "LOG-03: Cloud service logs not forwarded to centralized logging platform"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.centralized_logging.all_critical_sources_onboarded
+    msg := "LOG-03: All critical log sources not onboarded to centralized SIEM or logging platform"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.centralized_logging.log_parsing_configured
+    msg := "LOG-03: Log parsing and normalization not configured — raw logs must be structured for effective analysis"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.real_time_alerting.alerting_configured
+    msg := "LOG-04: Real-time security alerting not configured — critical events must trigger immediate notifications"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.real_time_alerting.alert_rules_defined
+    msg := "LOG-04: Alert rules not defined for security-relevant events — specific conditions requiring alerts must be documented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.real_time_alerting.alert_response_times_defined
+    msg := "LOG-04: Response time requirements for security alerts not defined by severity level"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.real_time_alerting.alerts_reviewed_and_actioned
+    msg := "LOG-04: Security alerts not reviewed and actioned within defined response time requirements"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.anomaly_detection.anomaly_detection_implemented
+    msg := "LOG-05: Anomaly detection not implemented — baseline behavior must be established and deviations detected"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.anomaly_detection.ueba_or_equivalent
+    msg := "LOG-05: User and entity behavior analytics (UEBA) or equivalent not implemented for threat detection"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.anomaly_detection.cloud_anomalies_detected
+    msg := "LOG-05: Cloud-specific anomalies (unusual API calls, impossible travel, credential abuse) not detected"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.privileged_access_logging.privileged_actions_logged
+    msg := "LOG-06: Privileged user actions not logged — all administrative activities must generate audit records"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.privileged_access_logging.privileged_session_content_captured
+    msg := "LOG-06: Privileged session content not captured — commands and actions during elevated sessions must be recorded"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.privileged_access_logging.privileged_log_tampering_prevented
+    msg := "LOG-06: Privileged users not prevented from modifying or deleting their own audit logs"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.ntp.time_synchronization_configured
+    msg := "LOG-07: Network time synchronization (NTP) not configured on cloud systems — accurate timestamps required for log correlation"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.ntp.single_time_source_used
+    msg := "LOG-07: Consistent time source not enforced across all systems — divergent clocks undermine log correlation"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.ntp.time_drift_monitored
+    msg := "LOG-07: Time drift not monitored and alerted — clock skew must be detected and corrected"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.log_integrity.logs_protected_from_tampering
+    msg := "LOG-08: Log integrity protection not implemented — logs must be protected from unauthorized modification"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.log_integrity.immutable_log_storage_used
+    msg := "LOG-08: Immutable log storage not used — write-once storage or cryptographic verification must protect log integrity"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.log_integrity.log_integrity_verified
+    msg := "LOG-08: Log integrity not periodically verified — mechanisms to detect log tampering must be operational"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.log_integrity.log_access_controlled
+    msg := "LOG-08: Log access not restricted — only authorized security personnel must be able to read or manage audit logs"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.monitoring_coverage.all_environments_monitored
+    msg := "LOG-09: All cloud environments (production, development, staging) not covered by security monitoring"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.monitoring_coverage.network_monitoring_active
+    msg := "LOG-09: Cloud network traffic monitoring not active — network-level visibility required alongside host-level logging"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.monitoring_coverage.application_logging_enabled
+    msg := "LOG-09: Application-level logging not enabled — application events must be captured alongside infrastructure logs"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.incident_detection.detection_use_cases_defined
+    msg := "LOG-10: Threat detection use cases not defined — specific attack patterns and behaviors to detect must be documented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.incident_detection.detection_rules_tuned
+    msg := "LOG-10: Detection rules not regularly tuned — false positive rates must be managed to maintain alert quality"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.monitoring_program.program_reviewed_annually
+    msg := "LOG-11: Logging and monitoring program not reviewed at least annually for completeness and effectiveness"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.monitoring_program.coverage_gaps_identified
+    msg := "LOG-11: Logging coverage gaps not systematically identified and remediated"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.data_access_logging.sensitive_data_access_logged
+    msg := "LOG-12: Access to sensitive and regulated data not logged — all reads and writes to sensitive data must generate audit records"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.data_access_logging.bulk_data_access_alerted
+    msg := "LOG-12: Bulk data access not alerted — large-volume data reads may indicate exfiltration and must trigger review"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.metrics_dashboards.security_dashboards_operational
+    msg := "LOG-13: Security monitoring dashboards not operational — real-time visibility into security posture must be maintained"
+}
+
+violations contains msg if {
+    not input.csa_ccm.logging_monitoring.metrics_dashboards.kpi_metrics_tracked
+    msg := "LOG-13: Key security monitoring KPIs not tracked and reported to management regularly"
+}
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "domain": "LOG — Logging & Monitoring",
+    "compliant": compliant,
+    "violation_count": count(violations),
+    "violations": violations,
+}

--- a/frameworks/management/csa_ccm/csa_ccm_main.rego
+++ b/frameworks/management/csa_ccm/csa_ccm_main.rego
@@ -1,0 +1,121 @@
+package csa_ccm.main
+
+import rego.v1
+
+import data.csa_ccm.audit_assurance
+import data.csa_ccm.application_security
+import data.csa_ccm.business_continuity
+import data.csa_ccm.change_control
+import data.csa_ccm.cryptography
+import data.csa_ccm.data_security
+import data.csa_ccm.governance
+import data.csa_ccm.human_resources
+import data.csa_ccm.identity_access
+import data.csa_ccm.interoperability
+import data.csa_ccm.infrastructure
+import data.csa_ccm.logging_monitoring
+import data.csa_ccm.incident_management
+import data.csa_ccm.supply_chain
+import data.csa_ccm.threat_vulnerability
+import data.csa_ccm.endpoint_management
+
+default overall_compliant := false
+
+domain_reports := {
+    "audit_assurance": {
+        "compliant": audit_assurance.compliant,
+        "details": audit_assurance.compliance_report,
+    },
+    "application_security": {
+        "compliant": application_security.compliant,
+        "details": application_security.compliance_report,
+    },
+    "business_continuity": {
+        "compliant": business_continuity.compliant,
+        "details": business_continuity.compliance_report,
+    },
+    "change_control": {
+        "compliant": change_control.compliant,
+        "details": change_control.compliance_report,
+    },
+    "cryptography": {
+        "compliant": cryptography.compliant,
+        "details": cryptography.compliance_report,
+    },
+    "data_security": {
+        "compliant": data_security.compliant,
+        "details": data_security.compliance_report,
+    },
+    "governance": {
+        "compliant": governance.compliant,
+        "details": governance.compliance_report,
+    },
+    "human_resources": {
+        "compliant": human_resources.compliant,
+        "details": human_resources.compliance_report,
+    },
+    "identity_access": {
+        "compliant": identity_access.compliant,
+        "details": identity_access.compliance_report,
+    },
+    "interoperability": {
+        "compliant": interoperability.compliant,
+        "details": interoperability.compliance_report,
+    },
+    "infrastructure": {
+        "compliant": infrastructure.compliant,
+        "details": infrastructure.compliance_report,
+    },
+    "logging_monitoring": {
+        "compliant": logging_monitoring.compliant,
+        "details": logging_monitoring.compliance_report,
+    },
+    "incident_management": {
+        "compliant": incident_management.compliant,
+        "details": incident_management.compliance_report,
+    },
+    "supply_chain": {
+        "compliant": supply_chain.compliant,
+        "details": supply_chain.compliance_report,
+    },
+    "threat_vulnerability": {
+        "compliant": threat_vulnerability.compliant,
+        "details": threat_vulnerability.compliance_report,
+    },
+    "endpoint_management": {
+        "compliant": endpoint_management.compliant,
+        "details": endpoint_management.compliance_report,
+    },
+}
+
+domains_passing := count([domain |
+    some domain, report in domain_reports
+    report.compliant == true
+])
+
+overall_compliant if {
+    audit_assurance.compliant
+    application_security.compliant
+    business_continuity.compliant
+    change_control.compliant
+    cryptography.compliant
+    data_security.compliant
+    governance.compliant
+    human_resources.compliant
+    identity_access.compliant
+    interoperability.compliant
+    infrastructure.compliant
+    logging_monitoring.compliant
+    incident_management.compliant
+    supply_chain.compliant
+    threat_vulnerability.compliant
+    endpoint_management.compliant
+}
+
+compliance_report := {
+    "standard": "CSA Cloud Controls Matrix (CCM) v4.0",
+    "overall_compliant": overall_compliant,
+    "domains_passing": domains_passing,
+    "domains_total": 16,
+    "domains": domain_reports,
+}

--- a/frameworks/management/csa_ccm/csa_ccm_supply_chain.rego
+++ b/frameworks/management/csa_ccm/csa_ccm_supply_chain.rego
@@ -1,0 +1,174 @@
+package csa_ccm.supply_chain
+
+import rego.v1
+
+default compliant := false
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.supplier_policy.policy_established
+    msg := "STA-01: Supply chain security and third-party risk management policy not formally established"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.supplier_policy.cloud_suppliers_in_scope
+    msg := "STA-01: Cloud service providers and SaaS vendors not included in supply chain security policy scope"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.supplier_policy.policy_reviewed_annually
+    msg := "STA-01: Supply chain security policy not reviewed and updated at least annually"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.supplier_assessments.assessments_conducted
+    msg := "STA-02: Supplier security assessments not conducted before onboarding new cloud or technology vendors"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.supplier_assessments.risk_tiering_applied
+    msg := "STA-02: Risk tiering not applied to suppliers — assessment depth must be commensurate with the risk level of access granted"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.supplier_assessments.reassessments_conducted_periodically
+    msg := "STA-02: Supplier security reassessments not conducted periodically — third-party risk must be reviewed regularly"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.supplier_assessments.questionnaires_or_audits_used
+    msg := "STA-02: Standardized security questionnaires (CAIQ, SIG) or audits not used for supplier assessments"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.supplier_assessments.certifications_reviewed
+    msg := "STA-02: Supplier security certifications (ISO 27001, SOC 2, FedRAMP) not reviewed as part of assessment"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.third_party_risk.risk_management_program_exists
+    msg := "STA-03: Third-party risk management program not established — structured approach to managing vendor risk required"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.third_party_risk.risk_register_includes_vendors
+    msg := "STA-03: Third-party and vendor risks not included in enterprise risk register"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.third_party_risk.critical_vendors_identified
+    msg := "STA-03: Critical vendors and dependencies not identified — concentration risk and single-vendor dependency must be assessed"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.third_party_risk.vendor_risk_monitoring_ongoing
+    msg := "STA-03: Ongoing vendor risk monitoring not implemented — continuous monitoring for changes in vendor risk posture required"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.subprocessor_inventory.inventory_maintained
+    msg := "STA-04: Subprocessor inventory not maintained — all third parties that process data on behalf of the organization must be catalogued"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.subprocessor_inventory.data_sharing_documented
+    msg := "STA-04: Data sharing with subprocessors not documented — what data is shared, why, and under what terms must be recorded"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.subprocessor_inventory.subprocessor_changes_managed
+    msg := "STA-04: Process not defined for managing changes to the subprocessor inventory — customers must be notified where required"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.subprocessor_inventory.subprocessors_assessed
+    msg := "STA-04: Subprocessors not assessed for security controls — downstream data processors must meet equivalent security standards"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.contract_requirements.security_requirements_in_contracts
+    msg := "STA-05: Security requirements not included in supplier and cloud provider contracts"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.contract_requirements.right_to_audit_included
+    msg := "STA-05: Right to audit or audit report provision not included in supplier contracts"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.contract_requirements.incident_notification_sla_included
+    msg := "STA-05: Incident notification SLA not included in supplier contracts — vendors must notify of breaches within required timeframe"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.contract_requirements.data_handling_requirements_specified
+    msg := "STA-05: Data handling, protection, and deletion requirements not specified in supplier contracts"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.contract_requirements.termination_provisions_included
+    msg := "STA-05: Contract termination provisions not included — data return and deletion upon contract end must be addressed"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.transparency.csp_transparency_report_reviewed
+    msg := "STA-06: Cloud service provider transparency reports not reviewed — government access requests and security disclosures must be assessed"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.transparency.csp_shared_responsibility_understood
+    msg := "STA-06: Cloud shared responsibility model not formally documented and understood for each cloud service used"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.transparency.csp_security_posture_reviewed
+    msg := "STA-06: CSP security posture reports (SOC 2, ISO 27001 certificates) not reviewed at least annually"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.software_supply_chain.sbom_maintained
+    msg := "STA-07: Software bill of materials (SBOM) not maintained — software components and their origins must be tracked"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.software_supply_chain.build_pipeline_integrity
+    msg := "STA-07: Build pipeline integrity not verified — CI/CD pipelines must be secured against supply chain compromise"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.software_supply_chain.third_party_code_reviewed
+    msg := "STA-07: Third-party code and libraries not reviewed for security risks before use in production"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.offboarding.vendor_offboarding_procedure_defined
+    msg := "STA-08: Vendor offboarding procedure not defined — structured process for terminating supplier relationships required"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.offboarding.data_retrieved_or_deleted_on_exit
+    msg := "STA-08: Data retrieval or deletion from outgoing vendors not verified — all organizational data must be accounted for at contract end"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.offboarding.access_revoked_on_termination
+    msg := "STA-08: Supplier access revoked promptly upon contract termination — all credentials and access paths must be removed"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.incident_response.vendor_ir_coordination_defined
+    msg := "STA-09: Vendor incident response coordination not defined — process for coordinating response with suppliers during shared incidents required"
+}
+
+violations contains msg if {
+    not input.csa_ccm.supply_chain.incident_response.vendor_notification_requirements_enforced
+    msg := "STA-09: Vendor security incident notification requirements not enforced through contracts and monitoring"
+}
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "domain": "STA — Supply Chain Management, Transparency & Accountability",
+    "compliant": compliant,
+    "violation_count": count(violations),
+    "violations": violations,
+}

--- a/frameworks/management/csa_ccm/csa_ccm_threat_vulnerability.rego
+++ b/frameworks/management/csa_ccm/csa_ccm_threat_vulnerability.rego
@@ -1,0 +1,189 @@
+package csa_ccm.threat_vulnerability
+
+import rego.v1
+
+default compliant := false
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.tvm_policy.policy_established
+    msg := "TVM-01: Threat and vulnerability management policy not formally established"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.tvm_policy.cloud_assets_in_scope
+    msg := "TVM-01: Cloud assets and workloads not included in threat and vulnerability management policy scope"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.tvm_policy.remediation_slas_defined
+    msg := "TVM-01: Vulnerability remediation SLAs not defined in policy — timelines for remediation by severity must be documented"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.tvm_policy.policy_reviewed_annually
+    msg := "TVM-01: Threat and vulnerability management policy not reviewed and updated at least annually"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.internal_scanning.internal_scans_conducted
+    msg := "TVM-02: Internal vulnerability scanning not conducted on cloud and on-premises systems"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.internal_scanning.scan_frequency_defined
+    msg := "TVM-02: Internal scan frequency not defined — cadence must be documented (at minimum quarterly for all assets)"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.internal_scanning.authenticated_scans_used
+    msg := "TVM-02: Authenticated internal scans not used — credential-based scanning required for complete vulnerability discovery"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.internal_scanning.all_assets_covered
+    msg := "TVM-02: All cloud and on-premises assets not covered by internal vulnerability scanning"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.external_scanning.external_scans_conducted
+    msg := "TVM-03: External vulnerability scanning not conducted — internet-facing assets must be scanned from an external perspective"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.external_scanning.external_scan_frequency_defined
+    msg := "TVM-03: External scan frequency not defined — external-facing assets must be scanned at least monthly"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.external_scanning.external_attack_surface_inventoried
+    msg := "TVM-03: External attack surface not inventoried — all internet-facing services and endpoints must be catalogued"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.patch_critical.critical_patches_applied_within_sla
+    msg := "TVM-04: Critical severity vulnerabilities not patched within required SLA (≤15 days for CVSS 9.0+)"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.patch_critical.zero_day_response_process_defined
+    msg := "TVM-04: Zero-day vulnerability response process not defined — procedure for handling actively exploited vulnerabilities required"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.patch_critical.patch_exemption_process_defined
+    msg := "TVM-04: Patch exemption process not defined — risk acceptance for vulnerabilities that cannot be immediately patched must be formalized"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.patch_high.high_patches_applied_within_sla
+    msg := "TVM-05: High severity vulnerabilities not patched within required SLA (≤30 days for CVSS 7.0-8.9)"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.patch_high.patch_compliance_rate_monitored
+    msg := "TVM-05: Patch compliance rate not monitored and reported — percentage of systems patched within SLA must be tracked"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.penetration_testing.pentest_conducted
+    msg := "TVM-06: Penetration testing not conducted — formal adversarial testing of cloud and application security must be performed"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.penetration_testing.pentest_frequency_met
+    msg := "TVM-06: Penetration testing not conducted at required frequency — at least annual testing for production environments"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.penetration_testing.cloud_specific_testing_performed
+    msg := "TVM-06: Cloud-specific penetration testing not performed — cloud configuration and IAM must be included in test scope"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.penetration_testing.findings_remediated
+    msg := "TVM-06: Penetration testing findings not tracked to remediation — all critical and high findings must be addressed"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.penetration_testing.qualified_testers_used
+    msg := "TVM-06: Penetration testing not performed by qualified internal or third-party testers"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.threat_intelligence.threat_intel_feeds_subscribed
+    msg := "TVM-07: Threat intelligence feeds not subscribed to — organization must consume current threat data relevant to its industry and technology stack"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.threat_intel.threat_intel_operationalized
+    msg := "TVM-07: Threat intelligence not operationalized — intelligence must inform detection rules, defenses, and patch prioritization"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.threat_intel.cloud_specific_threat_intel_consumed
+    msg := "TVM-07: Cloud-specific threat intelligence not consumed — CSP security advisories and cloud threat reports must be monitored"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.cvss_scoring.cvss_scoring_used
+    msg := "TVM-08: CVSS scoring not used to prioritize vulnerability remediation"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.cvss_scoring.exploitability_considered
+    msg := "TVM-08: Exploitability not considered in vulnerability prioritization — CVSS base score alone is insufficient; exploited-in-wild status must be factored"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.cvss_scoring.business_context_applied
+    msg := "TVM-08: Business context not applied to vulnerability prioritization — asset criticality must influence remediation priority"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.remediation_tracking.all_findings_tracked
+    msg := "TVM-09: Not all vulnerability findings tracked to remediation — all identified vulnerabilities must have an assigned remediation owner and timeline"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.remediation_tracking.overdue_vulns_escalated
+    msg := "TVM-09: Overdue vulnerability remediations not escalated — vulnerabilities exceeding SLA must trigger escalation"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.remediation_tracking.remediation_effectiveness_verified
+    msg := "TVM-09: Remediation effectiveness not verified — rescans must confirm vulnerabilities are resolved after patching"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.remediation_tracking.metrics_reported_to_management
+    msg := "TVM-09: Vulnerability management metrics not reported to management — exposure trends and SLA compliance must be visible to leadership"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.zero_day_response.process_defined
+    msg := "TVM-10: Zero-day and critical vulnerability response process not formally defined"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.zero_day_response.emergency_patching_capability
+    msg := "TVM-10: Emergency patching capability not established — organization must be able to deploy critical patches outside normal change windows"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.zero_day_response.workarounds_applied_when_patch_unavailable
+    msg := "TVM-10: Compensating controls and workarounds not applied when patches are unavailable for critical vulnerabilities"
+}
+
+violations contains msg if {
+    not input.csa_ccm.threat_vulnerability.zero_day_response.csp_advisories_monitored
+    msg := "TVM-10: Cloud service provider security advisories not actively monitored for critical zero-day disclosures"
+}
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "domain": "TVM — Threat & Vulnerability Management",
+    "compliant": compliant,
+    "violation_count": count(violations),
+    "violations": violations,
+}

--- a/frameworks/privacy/ccpa/ccpa_business_obligations.rego
+++ b/frameworks/privacy/ccpa/ccpa_business_obligations.rego
@@ -1,0 +1,108 @@
+package ccpa.business_obligations
+
+import rego.v1
+
+violations contains msg if {
+	not input.ccpa.business_obligations.privacy_policy.published_and_updated_annually
+	msg := "CCPA §1798.130: Comprehensive privacy policy not published or not updated annually"
+}
+
+violations contains msg if {
+	not input.ccpa.business_obligations.privacy_policy.lists_categories_collected
+	msg := "CCPA §1798.130: Privacy policy does not list categories of personal information collected in prior 12 months"
+}
+
+violations contains msg if {
+	not input.ccpa.business_obligations.privacy_policy.lists_collection_purposes
+	msg := "CCPA §1798.130: Privacy policy does not list purposes for which personal information is collected"
+}
+
+violations contains msg if {
+	not input.ccpa.business_obligations.privacy_policy.lists_third_party_categories
+	msg := "CCPA §1798.130: Privacy policy does not list categories of third parties personal information is shared with"
+}
+
+violations contains msg if {
+	not input.ccpa.business_obligations.privacy_policy.contact_information_included
+	msg := "CCPA §1798.130: Privacy policy does not include contact information for privacy requests"
+}
+
+violations contains msg if {
+	not input.ccpa.business_obligations.privacy_policy.ccpa_rights_disclosure_included
+	msg := "CCPA §1798.130: Privacy policy does not include disclosure of CCPA consumer rights"
+}
+
+violations contains msg if {
+	not input.ccpa.business_obligations.notice_at_collection.provided_at_or_before_collection
+	msg := "CCPA §1798.100(b): Notice not provided at or before point of personal information collection"
+}
+
+violations contains msg if {
+	not input.ccpa.business_obligations.notice_at_collection.categories_and_purposes_disclosed
+	msg := "CCPA §1798.100(b): Categories of personal information and purposes not disclosed in notice at collection"
+}
+
+violations contains msg if {
+	not input.ccpa.business_obligations.notice_at_collection.sale_sharing_disclosed_with_opt_out
+	msg := "CCPA §1798.100(b): Sale or sharing of personal information not disclosed with opt-out link where applicable"
+}
+
+violations contains msg if {
+	not input.ccpa.business_obligations.notice_at_collection.retention_periods_disclosed
+	msg := "CCPA §1798.100(b): Retention periods or criteria for determination not disclosed in notice at collection"
+}
+
+violations contains msg if {
+	not input.ccpa.business_obligations.training.personnel_trained
+	msg := "CCPA §1798.135(b): Personnel handling privacy requests not trained on CCPA requirements"
+}
+
+violations contains msg if {
+	not input.ccpa.business_obligations.training.training_documented_and_refreshed
+	msg := "CCPA §1798.135(b): Privacy training not documented or not refreshed annually"
+}
+
+violations contains msg if {
+	not input.ccpa.business_obligations.record_keeping.requests_retained_24_months
+	msg := "CPRA §1798.185(a)(3): Records of privacy requests and responses not retained for 24 months"
+}
+
+violations contains msg if {
+	not input.ccpa.business_obligations.record_keeping.annual_metrics_reported
+	msg := "CPRA §1798.185(a)(3): Annual metrics on rights requests not reported (required for large businesses)"
+}
+
+violations contains msg if {
+	not input.ccpa.business_obligations.service_provider_contracts.written_contracts_limiting_use
+	msg := "CCPA §1798.140: Written contracts with service providers not in place limiting use of personal information"
+}
+
+violations contains msg if {
+	not input.ccpa.business_obligations.service_provider_contracts.prohibition_on_selling
+	msg := "CCPA §1798.140: Service provider contracts do not prohibit selling of personal information"
+}
+
+violations contains msg if {
+	not input.ccpa.business_obligations.service_provider_contracts.subprocessor_restrictions
+	msg := "CCPA §1798.140: Subprocessor restrictions not included in service provider contracts"
+}
+
+violations contains msg if {
+	input.ccpa.business_obligations.data_broker.applicable
+	not input.ccpa.business_obligations.data_broker.registered_with_cppa
+	msg := "CPRA §1798.99.80: Business qualifies as data broker but is not registered with the California Privacy Protection Agency"
+}
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+compliance_report := {
+	"standard": "CCPA/CPRA",
+	"domain": "Business Obligations (§1798.130–§1798.185)",
+	"compliant": compliant,
+	"violation_count": count(violations),
+	"violations": violations,
+}

--- a/frameworks/privacy/ccpa/ccpa_consumer_rights.rego
+++ b/frameworks/privacy/ccpa/ccpa_consumer_rights.rego
@@ -1,0 +1,122 @@
+package ccpa.consumer_rights
+
+import rego.v1
+
+violations contains msg if {
+	not input.ccpa.consumer_rights.right_to_know.categories_disclosed
+	msg := "CCPA §1798.110: Categories of personal information collected, purposes, and third parties not disclosed"
+}
+
+violations contains msg if {
+	not input.ccpa.consumer_rights.right_to_know.specific_pieces_provided
+	msg := "CCPA §1798.115: Specific pieces of personal information not provided to consumer upon request"
+}
+
+violations contains msg if {
+	not input.ccpa.consumer_rights.right_to_know.response_within_45_days
+	msg := "CCPA §1798.100: Response to right-to-know request not fulfilled within 45 days"
+}
+
+violations contains msg if {
+	not input.ccpa.consumer_rights.right_to_know.two_requests_per_year_honored
+	msg := "CCPA §1798.100: Two disclosure requests per 12-month period not honored"
+}
+
+violations contains msg if {
+	not input.ccpa.consumer_rights.right_to_know.identity_verification_established
+	msg := "CCPA §1798.100: Identity verification process for right-to-know requests not established"
+}
+
+violations contains msg if {
+	not input.ccpa.consumer_rights.right_to_delete.deletion_process_established
+	msg := "CCPA §1798.105: Deletion process for personal information not established"
+}
+
+violations contains msg if {
+	not input.ccpa.consumer_rights.right_to_delete.deletion_propagated
+	msg := "CCPA §1798.105: Deletion not propagated to service providers and contractors"
+}
+
+violations contains msg if {
+	not input.ccpa.consumer_rights.right_to_delete.exceptions_documented
+	msg := "CCPA §1798.105: Exceptions to deletion (legal obligation, security) not documented"
+}
+
+violations contains msg if {
+	not input.ccpa.consumer_rights.right_to_delete.confirmation_provided
+	msg := "CCPA §1798.105: Confirmation of deletion not provided to consumer"
+}
+
+violations contains msg if {
+	not input.ccpa.consumer_rights.right_to_opt_out.do_not_sell_link_on_homepage
+	msg := "CCPA §1798.135: 'Do Not Sell or Share My Personal Information' link not present on homepage"
+}
+
+violations contains msg if {
+	not input.ccpa.consumer_rights.right_to_opt_out.honored_within_15_business_days
+	msg := "CCPA §1798.120: Opt-out of sale or sharing not honored within 15 business days"
+}
+
+violations contains msg if {
+	not input.ccpa.consumer_rights.right_to_opt_out.no_reenrollment_within_12_months
+	msg := "CCPA §1798.120: Opted-out consumers re-enrolled for sale or sharing within 12 months without consent"
+}
+
+violations contains msg if {
+	not input.ccpa.consumer_rights.right_to_opt_out.gpc_signal_honored
+	msg := "CCPA §1798.135: Global Privacy Control (GPC) signal not honored"
+}
+
+violations contains msg if {
+	not input.ccpa.consumer_rights.right_to_correct.correction_process_defined
+	msg := "CPRA §1798.106: Process for consumers to correct inaccurate personal information not defined"
+}
+
+violations contains msg if {
+	not input.ccpa.consumer_rights.right_to_correct.correction_propagated
+	msg := "CPRA §1798.106: Correction not propagated to third parties"
+}
+
+violations contains msg if {
+	not input.ccpa.consumer_rights.right_to_correct.response_within_45_days
+	msg := "CPRA §1798.106: Response to right-to-correct request not fulfilled within 45 days"
+}
+
+violations contains msg if {
+	not input.ccpa.consumer_rights.right_to_limit_sensitive.limit_sensitive_pi_link_available
+	msg := "CPRA §1798.121: 'Limit the Use of My Sensitive Personal Information' link not available"
+}
+
+violations contains msg if {
+	not input.ccpa.consumer_rights.right_to_limit_sensitive.use_limited_when_requested
+	msg := "CPRA §1798.121: Sensitive personal information use not limited to specified purposes when consumer requests"
+}
+
+violations contains msg if {
+	not input.ccpa.consumer_rights.right_to_limit_sensitive.honored_within_15_business_days
+	msg := "CPRA §1798.121: Request to limit sensitive personal information use not honored within 15 business days"
+}
+
+violations contains msg if {
+	not input.ccpa.consumer_rights.non_discrimination.no_penalty_for_rights_exercise
+	msg := "CCPA §1798.125: Consumers penalized for exercising privacy rights"
+}
+
+violations contains msg if {
+	not input.ccpa.consumer_rights.non_discrimination.no_different_pricing_for_opt_out
+	msg := "CCPA §1798.125: Consumers denied goods, services, or charged different prices for opting out"
+}
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+compliance_report := {
+	"standard": "CCPA/CPRA",
+	"domain": "Consumer Rights (§1798.100–§1798.125)",
+	"compliant": compliant,
+	"violation_count": count(violations),
+	"violations": violations,
+}

--- a/frameworks/privacy/ccpa/ccpa_data_practices.rego
+++ b/frameworks/privacy/ccpa/ccpa_data_practices.rego
@@ -1,0 +1,87 @@
+package ccpa.data_practices
+
+import rego.v1
+
+violations contains msg if {
+	not input.ccpa.data_practices.data_minimization.collected_only_for_disclosed_purposes
+	msg := "CPRA §1798.100(a)(3): Personal information collected for purposes not disclosed to consumer"
+}
+
+violations contains msg if {
+	not input.ccpa.data_practices.data_minimization.collection_limited_to_necessary
+	msg := "CPRA §1798.100(a)(3): Personal information collection not limited to what is reasonably necessary"
+}
+
+violations contains msg if {
+	not input.ccpa.data_practices.data_minimization.not_used_incompatibly
+	msg := "CPRA §1798.100(a)(3): Personal information used in manner incompatible with disclosed purpose"
+}
+
+violations contains msg if {
+	not input.ccpa.data_practices.purpose_limitation.not_used_beyond_disclosed_purposes
+	msg := "CPRA §1798.100(a)(3): Personal information used for purposes materially different from those disclosed"
+}
+
+violations contains msg if {
+	not input.ccpa.data_practices.purpose_limitation.not_sold_beyond_disclosed_categories
+	msg := "CPRA §1798.100(a)(3): Personal information sold or shared beyond disclosed categories"
+}
+
+violations contains msg if {
+	not input.ccpa.data_practices.retention_limitation.schedule_established_and_documented
+	msg := "CPRA §1798.100(a)(3): Retention schedule for personal information not established or not documented"
+}
+
+violations contains msg if {
+	not input.ccpa.data_practices.retention_limitation.not_retained_longer_than_necessary
+	msg := "CPRA §1798.100(a)(3): Personal information retained longer than necessary for disclosed purpose"
+}
+
+violations contains msg if {
+	not input.ccpa.data_practices.retention_limitation.automated_deletion_enforced
+	msg := "CPRA §1798.100(a)(3): Retention schedule not technically enforced with automated deletion"
+}
+
+violations contains msg if {
+	not input.ccpa.data_practices.security.reasonable_security_implemented
+	msg := "CCPA §1798.150: Reasonable security measures not implemented for personal information"
+}
+
+violations contains msg if {
+	not input.ccpa.data_practices.security.breach_notification_within_72_hours
+	msg := "CCPA §1798.150: Security incidents not reported to CPPA within 72 hours"
+}
+
+violations contains msg if {
+	not input.ccpa.data_practices.security.consumer_notification_without_unreasonable_delay
+	msg := "CCPA §1798.150: Consumer notification after breach delayed unreasonably"
+}
+
+violations contains msg if {
+	not input.ccpa.data_practices.data_protection_assessments.conducted_for_high_risk
+	msg := "CPRA §1798.185(a)(15): Data Protection Assessments not conducted for high-risk processing (profiling, sensitive PI, sharing)"
+}
+
+violations contains msg if {
+	not input.ccpa.data_practices.data_protection_assessments.submitted_to_cppa_on_request
+	msg := "CPRA §1798.185(a)(15): Data Protection Assessments not available for submission to CPPA upon request"
+}
+
+violations contains msg if {
+	not input.ccpa.data_practices.data_protection_assessments.reviewed_annually
+	msg := "CPRA §1798.185(a)(15): Data Protection Assessments not reviewed annually"
+}
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+compliance_report := {
+	"standard": "CCPA/CPRA",
+	"domain": "Data Practices (§1798.100, §1798.150, §1798.185)",
+	"compliant": compliant,
+	"violation_count": count(violations),
+	"violations": violations,
+}

--- a/frameworks/privacy/ccpa/ccpa_main.rego
+++ b/frameworks/privacy/ccpa/ccpa_main.rego
@@ -1,0 +1,52 @@
+package ccpa.main
+
+import rego.v1
+
+import data.ccpa.business_obligations
+import data.ccpa.consumer_rights
+import data.ccpa.data_practices
+import data.ccpa.sensitive_data
+
+default overall_compliant := false
+
+overall_compliant if {
+	consumer_rights.compliant
+	business_obligations.compliant
+	sensitive_data.compliant
+	data_practices.compliant
+}
+
+modules_passing := count([m |
+	some m in [
+		consumer_rights.compliant,
+		business_obligations.compliant,
+		sensitive_data.compliant,
+		data_practices.compliant,
+	]
+	m == true
+])
+
+compliance_report := {
+	"standard": "CCPA/CPRA — California Consumer Privacy Act (as amended by CPRA 2023)",
+	"overall_compliant": overall_compliant,
+	"modules_passing": modules_passing,
+	"modules_total": 4,
+	"modules": {
+		"consumer_rights": {
+			"compliant": consumer_rights.compliant,
+			"details": consumer_rights.compliance_report,
+		},
+		"business_obligations": {
+			"compliant": business_obligations.compliant,
+			"details": business_obligations.compliance_report,
+		},
+		"sensitive_data": {
+			"compliant": sensitive_data.compliant,
+			"details": sensitive_data.compliance_report,
+		},
+		"data_practices": {
+			"compliant": data_practices.compliant,
+			"details": data_practices.compliance_report,
+		},
+	},
+}

--- a/frameworks/privacy/ccpa/ccpa_sensitive_data.rego
+++ b/frameworks/privacy/ccpa/ccpa_sensitive_data.rego
@@ -1,0 +1,92 @@
+package ccpa.sensitive_data
+
+import rego.v1
+
+violations contains msg if {
+	not input.ccpa.sensitive_data.government_ids.access_limited_and_encrypted
+	msg := "CPRA §1798.140(ae): SSN and government ID data not access-limited and not encrypted"
+}
+
+violations contains msg if {
+	not input.ccpa.sensitive_data.account_credentials.not_stored_in_plaintext
+	msg := "CPRA §1798.140(ae): Account credentials stored in plaintext"
+}
+
+violations contains msg if {
+	not input.ccpa.sensitive_data.precise_geolocation.explicit_purpose_limitation
+	msg := "CPRA §1798.140(ae): Precise geolocation data (within 1,852m) collected without explicit purpose limitation"
+}
+
+violations contains msg if {
+	not input.ccpa.sensitive_data.racial_ethnic_origin.dpias_conducted
+	msg := "CPRA §1798.140(ae): Data Protection Impact Assessments not conducted for processing racial or ethnic origin data"
+}
+
+violations contains msg if {
+	not input.ccpa.sensitive_data.religious_beliefs.collection_minimized
+	msg := "CPRA §1798.140(ae): Collection of religious or philosophical beliefs data not minimized"
+}
+
+violations contains msg if {
+	not input.ccpa.sensitive_data.union_membership.collection_minimized
+	msg := "CPRA §1798.140(ae): Collection of union membership data not minimized"
+}
+
+violations contains msg if {
+	not input.ccpa.sensitive_data.mail_email_text.not_accessed_except_for_delivery
+	msg := "CPRA §1798.140(ae): Mail, email, or text message content accessed for purposes other than delivery"
+}
+
+violations contains msg if {
+	not input.ccpa.sensitive_data.genetic_data.access_controls_implemented
+	msg := "CPRA §1798.140(ae): Access controls for genetic data not implemented"
+}
+
+violations contains msg if {
+	not input.ccpa.sensitive_data.genetic_data.not_sold
+	msg := "CPRA §1798.140(ae): Genetic data sold or shared without restriction"
+}
+
+violations contains msg if {
+	not input.ccpa.sensitive_data.biometric_data.consent_obtained
+	msg := "CPRA §1798.140(ae): Consent not obtained for collection of biometric data"
+}
+
+violations contains msg if {
+	not input.ccpa.sensitive_data.biometric_data.retention_limited
+	msg := "CPRA §1798.140(ae): Retention of biometric data not limited to stated purpose"
+}
+
+violations contains msg if {
+	not input.ccpa.sensitive_data.health_information.hipaa_aligned_controls
+	msg := "CPRA §1798.140(ae): HIPAA-aligned controls not applied to health information where applicable"
+}
+
+violations contains msg if {
+	not input.ccpa.sensitive_data.sex_life_orientation.not_collected_unless_necessary
+	msg := "CPRA §1798.140(ae): Sex life or sexual orientation data collected without demonstrated necessity"
+}
+
+violations contains msg if {
+	not input.ccpa.sensitive_data.automated_decisions.opt_out_available
+	msg := "CPRA §1798.185(a)(21): Consumers cannot opt out of automated decisions affecting them significantly"
+}
+
+violations contains msg if {
+	not input.ccpa.sensitive_data.automated_decisions.logic_explanation_available
+	msg := "CPRA §1798.185(a)(21): Explanation of automated decision-making logic not available upon request"
+}
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+compliance_report := {
+	"standard": "CCPA/CPRA",
+	"domain": "Sensitive Personal Information (§1798.140(ae), §1798.185(a)(21))",
+	"compliant": compliant,
+	"violation_count": count(violations),
+	"violations": violations,
+}

--- a/frameworks/privacy/iso27701/iso27701_data_subject_rights.rego
+++ b/frameworks/privacy/iso27701/iso27701_data_subject_rights.rego
@@ -1,0 +1,77 @@
+package iso27701.data_subject_rights
+
+import rego.v1
+
+violations contains msg if {
+	not input.iso27701.data_subject_rights.access.process_defined
+	msg := "ISO 27701 Annex B / GDPR Art. 15: Right of access process not defined"
+}
+
+violations contains msg if {
+	not input.iso27701.data_subject_rights.access.thirty_day_sla
+	msg := "ISO 27701 Annex B / GDPR Art. 15: Right of access response SLA of 30 days not established"
+}
+
+violations contains msg if {
+	not input.iso27701.data_subject_rights.rectification.process_defined
+	msg := "ISO 27701 Annex B / GDPR Art. 16: Right to rectification process not defined"
+}
+
+violations contains msg if {
+	not input.iso27701.data_subject_rights.rectification.propagated_to_processors
+	msg := "ISO 27701 Annex B / GDPR Art. 16: Rectification not propagated to processors and third parties"
+}
+
+violations contains msg if {
+	not input.iso27701.data_subject_rights.erasure.technical_deletion_capability
+	msg := "ISO 27701 Annex B / GDPR Art. 17: Technical capability for deletion of PII not implemented"
+}
+
+violations contains msg if {
+	not input.iso27701.data_subject_rights.erasure.backups_addressed
+	msg := "ISO 27701 Annex B / GDPR Art. 17: Right to erasure process does not address backup copies"
+}
+
+violations contains msg if {
+	not input.iso27701.data_subject_rights.restriction.flag_based_mechanism
+	msg := "ISO 27701 Annex B / GDPR Art. 18: Flag-based processing restriction mechanism not implemented"
+}
+
+violations contains msg if {
+	not input.iso27701.data_subject_rights.portability.machine_readable_format
+	msg := "ISO 27701 Annex B / GDPR Art. 20: Data portability in machine-readable format not available"
+}
+
+violations contains msg if {
+	not input.iso27701.data_subject_rights.portability.direct_transfer_supported
+	msg := "ISO 27701 Annex B / GDPR Art. 20: Direct transfer of PII to another controller not supported"
+}
+
+violations contains msg if {
+	not input.iso27701.data_subject_rights.objection.opt_out_mechanism
+	msg := "ISO 27701 Annex B / GDPR Art. 21: Opt-out mechanism for processing objection not implemented"
+}
+
+violations contains msg if {
+	not input.iso27701.data_subject_rights.objection.direct_marketing_always_honored
+	msg := "ISO 27701 Annex B / GDPR Art. 21: Objection to direct marketing not always honored unconditionally"
+}
+
+violations contains msg if {
+	not input.iso27701.data_subject_rights.automated_decisions.human_review_available
+	msg := "ISO 27701 Annex B / GDPR Art. 22: Human review not available for automated decision-making"
+}
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+compliance_report := {
+	"standard": "ISO/IEC 27701:2019",
+	"domain": "Annex B — GDPR Data Subject Rights Mapping",
+	"compliant": compliant,
+	"violation_count": count(violations),
+	"violations": violations,
+}

--- a/frameworks/privacy/iso27701/iso27701_main.rego
+++ b/frameworks/privacy/iso27701/iso27701_main.rego
@@ -1,0 +1,52 @@
+package iso27701.main
+
+import rego.v1
+
+import data.iso27701.data_subject_rights
+import data.iso27701.pii_controller
+import data.iso27701.pii_processor
+import data.iso27701.pims_requirements
+
+default overall_compliant := false
+
+overall_compliant if {
+	pims_requirements.compliant
+	pii_controller.compliant
+	pii_processor.compliant
+	data_subject_rights.compliant
+}
+
+modules_passing := count([m |
+	some m in [
+		pims_requirements.compliant,
+		pii_controller.compliant,
+		pii_processor.compliant,
+		data_subject_rights.compliant,
+	]
+	m == true
+])
+
+compliance_report := {
+	"standard": "ISO/IEC 27701:2019 — Privacy Information Management System",
+	"overall_compliant": overall_compliant,
+	"modules_passing": modules_passing,
+	"modules_total": 4,
+	"modules": {
+		"pims_requirements": {
+			"compliant": pims_requirements.compliant,
+			"details": pims_requirements.compliance_report,
+		},
+		"pii_controller": {
+			"compliant": pii_controller.compliant,
+			"details": pii_controller.compliance_report,
+		},
+		"pii_processor": {
+			"compliant": pii_processor.compliant,
+			"details": pii_processor.compliance_report,
+		},
+		"data_subject_rights": {
+			"compliant": data_subject_rights.compliant,
+			"details": data_subject_rights.compliance_report,
+		},
+	},
+}

--- a/frameworks/privacy/iso27701/iso27701_pii_controller.rego
+++ b/frameworks/privacy/iso27701/iso27701_pii_controller.rego
@@ -1,0 +1,147 @@
+package iso27701.pii_controller
+
+import rego.v1
+
+violations contains msg if {
+	not input.iso27701.pii_controller.collection_conditions.purposes_documented
+	msg := "ISO 27701 7.2.1: Purposes of PII processing not identified and documented"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.collection_conditions.lawful_basis_per_purpose
+	msg := "ISO 27701 7.2.2: Lawful basis not identified for each processing purpose"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.collection_conditions.consent_timing_defined
+	msg := "ISO 27701 7.2.3: When and how consent is to be obtained not determined"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.collection_conditions.consent_obtained_and_recorded
+	msg := "ISO 27701 7.2.4: Consent not obtained and recorded from PII principals"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.collection_conditions.privacy_notices_provided
+	msg := "ISO 27701 7.2.5: Privacy notices not provided to PII principals"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.collection_conditions.processor_contracts_include_dpo
+	msg := "ISO 27701 7.2.6: Contracts with PII processors do not include data protection obligations"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.collection_conditions.joint_controllership_documented
+	msg := "ISO 27701 7.2.7: Joint controllership arrangements not documented"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.pii_principal_obligations.obligations_determined
+	msg := "ISO 27701 7.3.1: Obligations to PII principals and means to fulfill them not determined"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.pii_principal_obligations.notice_at_collection
+	msg := "ISO 27701 7.3.2: Privacy notice not provided to PII principals at point of collection"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.pii_principal_obligations.consent_modification_mechanism
+	msg := "ISO 27701 7.3.3: Mechanism for PII principals to modify or withdraw consent not provided"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.pii_principal_obligations.access_mechanism
+	msg := "ISO 27701 7.3.4: Mechanism for PII principals to access their PII upon request not provided"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.pii_principal_obligations.erasure_mechanism
+	msg := "ISO 27701 7.3.5: Mechanism for erasure and right to be forgotten not provided"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.pii_principal_obligations.portability_mechanism
+	msg := "ISO 27701 7.3.6: Mechanism for data portability not provided"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.pii_principal_obligations.complaints_handled
+	msg := "ISO 27701 7.3.7: Process to handle complaints from PII principals not established"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.pii_principal_obligations.automated_decision_safeguards
+	msg := "ISO 27701 7.3.8: Safeguards for automated decision-making not implemented"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.privacy_by_design.collection_limited
+	msg := "ISO 27701 7.4.1: PII collection not limited (data minimization principle not applied)"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.privacy_by_design.processing_limited
+	msg := "ISO 27701 7.4.2: PII processing not limited to disclosed purposes (purpose limitation not applied)"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.privacy_by_design.accuracy_maintained
+	msg := "ISO 27701 7.4.3: Accuracy and quality of PII not maintained"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.privacy_by_design.minimization_goals_defined
+	msg := "ISO 27701 7.4.4: PII minimization goals not defined"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.privacy_by_design.deidentification_and_deletion
+	msg := "ISO 27701 7.4.5: PII de-identification and deletion processes not established"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.privacy_by_design.temporary_files_disposed
+	msg := "ISO 27701 7.4.6: Temporary files containing PII not disposed of appropriately"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.privacy_by_design.retention_schedule_enforced
+	msg := "ISO 27701 7.4.7: Retention schedule for PII not established or not enforced"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.privacy_by_design.transmission_controls
+	msg := "ISO 27701 7.4.8: Transmission controls for PII not implemented"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.pii_sharing.transfer_basis_established
+	msg := "ISO 27701 7.5.1: Basis for PII transfer to third parties not established"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.pii_sharing.transfer_destinations_documented
+	msg := "ISO 27701 7.5.2: Countries and organizations PII is transferred to not documented"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_controller.pii_sharing.disclosure_records_maintained
+	msg := "ISO 27701 7.5.3: Records of PII disclosures to third parties not maintained"
+}
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+compliance_report := {
+	"standard": "ISO/IEC 27701:2019",
+	"domain": "Clause 7 — PII Controller Requirements",
+	"compliant": compliant,
+	"violation_count": count(violations),
+	"violations": violations,
+}

--- a/frameworks/privacy/iso27701/iso27701_pii_processor.rego
+++ b/frameworks/privacy/iso27701/iso27701_pii_processor.rego
@@ -1,0 +1,82 @@
+package iso27701.pii_processor
+
+import rego.v1
+
+violations contains msg if {
+	not input.iso27701.pii_processor.collection_conditions.customer_instructions_documented
+	msg := "ISO 27701 8.2.1: PII not processed only under documented customer instructions"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_processor.collection_conditions.purposes_limited_to_customer
+	msg := "ISO 27701 8.2.2: Organization's processing purposes not limited to fulfilling customer's purposes"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_processor.collection_conditions.subprocessor_equivalent_obligations
+	msg := "ISO 27701 8.2.3: Subprocessors not contracted with equivalent data protection obligations"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_processor.collection_conditions.marketing_use_prohibited
+	msg := "ISO 27701 8.2.4: Marketing use of PII not prohibited without explicit customer authorization"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_processor.pii_principal_obligations.principal_rights_mechanism
+	msg := "ISO 27701 8.3.1: Mechanism to support PII principal rights fulfillment by controller not provided"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_processor.pii_principal_obligations.records_traceable
+	msg := "ISO 27701 8.3.2: Records do not enable PII principal requests to be traced"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_processor.privacy_by_design.controls_throughout_lifecycle
+	msg := "ISO 27701 8.4.1: Privacy controls not maintained throughout processing lifecycle"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_processor.privacy_by_design.temporary_files_documented_and_disposed
+	msg := "ISO 27701 8.4.2: Temporary files not documented and disposed of appropriately"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_processor.privacy_by_design.return_transfer_disposal_on_termination
+	msg := "ISO 27701 8.4.3: Return, transfer, or disposal of PII not defined for contract termination"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_processor.pii_sharing.third_party_disclosure_basis
+	msg := "ISO 27701 8.5.1: Basis for disclosure of PII to third parties or law enforcement not established"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_processor.pii_sharing.binding_disclosure_info_to_customer
+	msg := "ISO 27701 8.5.2: Information about legally binding disclosure requests not provided to customer"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_processor.pii_sharing.subprocessor_disclosures_documented
+	msg := "ISO 27701 8.5.3: Subprocessor disclosures not documented"
+}
+
+violations contains msg if {
+	not input.iso27701.pii_processor.pii_sharing.jurisdictional_transfer_notification
+	msg := "ISO 27701 8.5.4: Notification of PII transfers between jurisdictions not provided"
+}
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+compliance_report := {
+	"standard": "ISO/IEC 27701:2019",
+	"domain": "Clause 8 — PII Processor Requirements",
+	"compliant": compliant,
+	"violation_count": count(violations),
+	"violations": violations,
+}

--- a/frameworks/privacy/iso27701/iso27701_pims_requirements.rego
+++ b/frameworks/privacy/iso27701/iso27701_pims_requirements.rego
@@ -1,0 +1,97 @@
+package iso27701.pims_requirements
+
+import rego.v1
+
+violations contains msg if {
+	not input.iso27701.pims_requirements.context.privacy_factors_identified
+	msg := "ISO 27701 5.2: Privacy context factors not identified across applicable jurisdictions"
+}
+
+violations contains msg if {
+	not input.iso27701.pims_requirements.context.internal_privacy_factors_documented
+	msg := "ISO 27701 5.2: Internal privacy factors (data flows, processing purposes, retention) not documented"
+}
+
+violations contains msg if {
+	not input.iso27701.pims_requirements.interested_parties.stakeholders_identified
+	msg := "ISO 27701 5.3: Stakeholders with privacy interests not identified (data subjects, regulators, processors)"
+}
+
+violations contains msg if {
+	not input.iso27701.pims_requirements.interested_parties.dpa_requirements_documented
+	msg := "ISO 27701 5.3: Requirements of Data Protection Authorities and privacy regulators not documented"
+}
+
+violations contains msg if {
+	not input.iso27701.pims_requirements.scope.pii_processing_covered
+	msg := "ISO 27701 5.4: PIMS scope does not cover all PII processing activities"
+}
+
+violations contains msg if {
+	not input.iso27701.pims_requirements.scope.third_party_interfaces_in_scope
+	msg := "ISO 27701 5.4: Interfaces with third parties processing PII are not included in PIMS scope"
+}
+
+violations contains msg if {
+	not input.iso27701.pims_requirements.leadership.executive_sponsor_designated
+	msg := "ISO 27701 5.5: Executive sponsor for privacy program not designated"
+}
+
+violations contains msg if {
+	not input.iso27701.pims_requirements.leadership.privacy_resources_allocated
+	msg := "ISO 27701 5.5: Privacy resources (budget, staff) not allocated"
+}
+
+violations contains msg if {
+	not input.iso27701.pims_requirements.privacy_policy.approved_by_top_management
+	msg := "ISO 27701 5.6: Overarching privacy policy not approved by top management"
+}
+
+violations contains msg if {
+	not input.iso27701.pims_requirements.privacy_policy.reviewed_annually
+	msg := "ISO 27701 5.6: Privacy policy not reviewed annually"
+}
+
+violations contains msg if {
+	not input.iso27701.pims_requirements.risk.privacy_risk_assessment_conducted
+	msg := "ISO 27701 6.1: Privacy risk assessment not conducted covering all processing activities"
+}
+
+violations contains msg if {
+	not input.iso27701.pims_requirements.risk.dpias_for_high_risk
+	msg := "ISO 27701 6.1: Data Protection Impact Assessments not conducted for high-risk processing activities"
+}
+
+violations contains msg if {
+	not input.iso27701.pims_requirements.risk.risk_treatment_documented
+	msg := "ISO 27701 6.1: Privacy risks not treated or accepted with documented rationale"
+}
+
+violations contains msg if {
+	not input.iso27701.pims_requirements.objectives.established_and_measurable
+	msg := "ISO 27701 6.2: Privacy objectives not established or not measurable"
+}
+
+violations contains msg if {
+	not input.iso27701.pims_requirements.objectives.communicated
+	msg := "ISO 27701 6.2: Privacy objectives not communicated across the organization"
+}
+
+violations contains msg if {
+	not input.iso27701.pims_requirements.planning_changes.privacy_impact_assessed
+	msg := "ISO 27701 6.3: Privacy impact of organizational changes not assessed before implementation"
+}
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+compliance_report := {
+	"standard": "ISO/IEC 27701:2019",
+	"domain": "Clauses 5-6 — Core PIMS Requirements",
+	"compliant": compliant,
+	"violation_count": count(violations),
+	"violations": violations,
+}

--- a/governance/eu_ai_act/eu_ai_act_governance.rego
+++ b/governance/eu_ai_act/eu_ai_act_governance.rego
@@ -1,0 +1,199 @@
+package eu_ai_act.governance
+
+import rego.v1
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+# =============================================================================
+# Article 26 — Obligations of Deployers
+# =============================================================================
+
+violations contains msg if {
+	not input.eu_ai_act.governance.deployer.uses_system_per_provider_instructions == true
+	msg := "Article 26.1: High-risk AI system not used in accordance with provider's instructions for use; deployers must follow intended purpose and usage conditions"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.governance.deployer.human_oversight_assigned == true
+	msg := "Article 26.1: Human oversight not assigned to competent natural persons with the authority, competence, and resources to perform effective oversight"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.governance.deployer.oversight_persons_adequately_trained == true
+	msg := "Article 26.1: Persons assigned to human oversight not provided with adequate training, instructions, and authority to identify and address anomalies"
+}
+
+violations contains msg if {
+	input.eu_ai_act.governance.deployer.high_risk_public_or_private_sector == true
+	not input.eu_ai_act.governance.deployer.fundamental_rights_impact_assessment_conducted == true
+	msg := "Article 26.9 / Article 27: Fundamental Rights Impact Assessment (FRIA) not conducted before deploying high-risk AI system in public or private sector context"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.governance.deployer.registered_use_in_eu_database == true
+	input.eu_ai_act.governance.deployer.annex_iii_use_case == true
+	msg := "Article 26.8: Deployer's use of Annex III high-risk AI system not registered in the EU database for high-risk AI systems"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.governance.deployer.data_breach_reporting_established == true
+	msg := "Article 26: Data breach and serious incident reporting procedures not established for the deployed high-risk AI system"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.governance.deployer.input_data_relevance_verified == true
+	msg := "Article 26.5: Deployer has not verified that input data is relevant and sufficiently representative for the intended purpose of the high-risk AI system"
+}
+
+# =============================================================================
+# Article 27 — Fundamental Rights Impact Assessment (FRIA)
+# =============================================================================
+
+violations contains msg if {
+	input.eu_ai_act.governance.fria.assessment_required == true
+	not input.eu_ai_act.governance.fria.assessment_conducted == true
+	msg := "Article 27: Fundamental Rights Impact Assessment (FRIA) not conducted before deploying high-risk AI in contexts affecting natural persons' rights"
+}
+
+violations contains msg if {
+	input.eu_ai_act.governance.fria.assessment_required == true
+	not input.eu_ai_act.governance.fria.affected_fundamental_rights_identified == true
+	msg := "Article 27: FRIA completed but affected fundamental rights (dignity, non-discrimination, privacy, fair trial, etc.) not specifically identified and assessed"
+}
+
+violations contains msg if {
+	input.eu_ai_act.governance.fria.assessment_required == true
+	not input.eu_ai_act.governance.fria.notification_of_affected_persons_process == true
+	msg := "Article 27: Process for notifying affected persons about the high-risk AI deployment and their rights not established as part of the FRIA"
+}
+
+violations contains msg if {
+	input.eu_ai_act.governance.fria.assessment_required == true
+	not input.eu_ai_act.governance.fria.results_available_to_competent_authorities == true
+	msg := "Article 27: FRIA results not available to competent authorities upon request; assessments must be retained and accessible for regulatory review"
+}
+
+violations contains msg if {
+	input.eu_ai_act.governance.fria.assessment_required == true
+	not input.eu_ai_act.governance.fria.risk_mitigation_measures_identified == true
+	msg := "Article 27: FRIA did not result in identification of risk mitigation measures for identified fundamental rights impacts"
+}
+
+# =============================================================================
+# Article 28 — Obligations when Deployer Becomes Provider
+# =============================================================================
+
+violations contains msg if {
+	input.eu_ai_act.governance.deployer_as_provider.substantially_modified_high_risk_ai == true
+	not input.eu_ai_act.governance.deployer_as_provider.provider_obligations_assumed == true
+	msg := "Article 28: Deployer has substantially modified a high-risk AI system but has not assumed full provider obligations; substantial modification triggers all Article 16 and 17 requirements"
+}
+
+violations contains msg if {
+	input.eu_ai_act.governance.deployer_as_provider.placed_under_own_name_or_trademark == true
+	not input.eu_ai_act.governance.deployer_as_provider.provider_obligations_assumed == true
+	msg := "Article 28: Deployer has placed high-risk AI system on market under own name or trademark without assuming provider obligations; this constitutes acting as a provider"
+}
+
+violations contains msg if {
+	input.eu_ai_act.governance.deployer_as_provider.provider_obligations_assumed == true
+	not input.eu_ai_act.governance.deployer_as_provider.conformity_assessment_redone == true
+	msg := "Article 28: Deployer acting as provider has not conducted a new conformity assessment after substantially modifying the high-risk AI system"
+}
+
+# =============================================================================
+# Article 72 — Post-Market Monitoring
+# =============================================================================
+
+violations contains msg if {
+	not input.eu_ai_act.governance.post_market.monitoring_plan_established == true
+	msg := "Article 72: Post-market monitoring plan not established; providers of high-risk AI must actively collect and analyze performance data after deployment"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.governance.post_market.monitoring_covers_annex_vii_content == true
+	msg := "Article 72: Post-market monitoring plan does not address required elements specified in Annex VII of the EU AI Act"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.governance.post_market.serious_incidents_reported_to_authority == true
+	msg := "Article 72: Serious incidents involving the high-risk AI system not reported to national competent authority without undue delay upon discovery"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.governance.post_market.near_misses_tracked == true
+	msg := "Article 72: Near-miss events (incidents that did not cause harm but could have) not tracked and analyzed as part of post-market monitoring"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.governance.post_market.performance_metrics_collected == true
+	msg := "Article 72: Performance metrics required by the post-market monitoring plan not systematically collected from deployed high-risk AI systems"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.governance.post_market.corrective_actions_taken_when_needed == true
+	msg := "Article 72: Corrective actions not taken when post-market monitoring data indicates the AI system no longer meets applicable requirements"
+}
+
+# =============================================================================
+# Article 77 — Fundamental Rights Authorities Access
+# =============================================================================
+
+violations contains msg if {
+	not input.eu_ai_act.governance.fundamental_rights_bodies.dpa_access_granted == true
+	msg := "Article 77: Data Protection Authority (DPA) not granted access to documentation, logs, and conformity assessment records for fundamental rights oversight"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.governance.fundamental_rights_bodies.equality_body_access_granted == true
+	msg := "Article 77: Equality body not granted access to documentation required for fundamental rights review of high-risk AI systems under their oversight mandate"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.governance.fundamental_rights_bodies.cooperation_procedure_established == true
+	msg := "Article 77: No cooperation procedure established with fundamental rights bodies; providers and deployers must have a process for responding to access requests from these bodies"
+}
+
+# =============================================================================
+# Article 78 — Confidentiality
+# =============================================================================
+
+violations contains msg if {
+	not input.eu_ai_act.governance.confidentiality.trade_secrets_protected_in_assessments == true
+	msg := "Article 78: Trade secrets and commercially sensitive information not protected during conformity assessment processes and authority reviews"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.governance.confidentiality.competent_authority_confidentiality_binding == true
+	msg := "Article 78: National competent authorities have not established binding confidentiality obligations for personnel handling commercially sensitive AI system information"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.governance.confidentiality.confidentiality_obligations_documented == true
+	msg := "Article 78: Confidentiality obligations for information disclosed during conformity assessments and market surveillance activities not documented in agreements or procedures"
+}
+
+# =============================================================================
+# Compliance report
+# =============================================================================
+
+compliance_report := {
+	"module": "governance_deployer",
+	"standard": "EU AI Act — Title VI, Articles 26-28, 72, 77-78",
+	"applies_from": "August 2026",
+	"compliant": compliant,
+	"total_violations": count(violations),
+	"violations": violations,
+	"articles_assessed": [
+		"Article 26 — Obligations of deployers",
+		"Article 27 — Fundamental Rights Impact Assessment (FRIA)",
+		"Article 28 — Obligations when deployer becomes provider",
+		"Article 72 — Post-market monitoring",
+		"Article 77 — Access for fundamental rights authorities",
+		"Article 78 — Confidentiality",
+	],
+}

--- a/governance/eu_ai_act/eu_ai_act_gpai.rego
+++ b/governance/eu_ai_act/eu_ai_act_gpai.rego
@@ -1,0 +1,173 @@
+package eu_ai_act.gpai
+
+import rego.v1
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+# =============================================================================
+# Article 53 — Obligations for All GPAI Model Providers
+# =============================================================================
+
+violations contains msg if {
+	not input.eu_ai_act.gpai.article_53.technical_documentation_drawn_up == true
+	msg := "Article 53.1: Technical documentation for the GPAI model not drawn up and maintained in accordance with Annex XI requirements"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.gpai.article_53.technical_documentation_kept_current == true
+	msg := "Article 53.1: GPAI model technical documentation not kept up to date following material changes to the model or its capabilities"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.gpai.article_53.information_provided_to_downstream_providers == true
+	msg := "Article 53.1: Information and documentation not provided to downstream providers intending to integrate the GPAI model into their AI systems"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.gpai.article_53.downstream_documentation_adequate == true
+	msg := "Article 53.1: Documentation provided to downstream providers does not adequately describe the model's capabilities, limitations, and conditions of use"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.gpai.article_53.copyright_compliance_policy_established == true
+	msg := "Article 53.1(c): Copyright compliance policy not established; GPAI model providers must implement a policy to respect copyright law in training data"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.gpai.article_53.copyright_compliance_policy_published == true
+	msg := "Article 53.1(c): Copyright compliance policy not made publicly available; transparency about training data copyright practices is required"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.gpai.article_53.training_data_summary_published == true
+	msg := "Article 53.1(d): Summary of training data used to develop the GPAI model not published and made publicly available"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.gpai.article_53.training_data_summary_adequate == true
+	msg := "Article 53.1(d): Published summary of training data is not sufficiently detailed to enable understanding of the model's capabilities and limitations"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.gpai.article_53.model_cards_or_equivalent == true
+	msg := "Article 53: No model card or equivalent technical summary document available describing intended use cases, known limitations, and evaluation results"
+}
+
+# =============================================================================
+# Article 54 — Authorized Representatives for Non-EU Providers
+# =============================================================================
+
+violations contains msg if {
+	input.eu_ai_act.gpai.article_54.provider_established_outside_eu == true
+	not input.eu_ai_act.gpai.article_54.authorized_representative_designated == true
+	msg := "Article 54: GPAI model provider established outside the EU has not designated an authorized representative established in the EU"
+}
+
+violations contains msg if {
+	input.eu_ai_act.gpai.article_54.provider_established_outside_eu == true
+	not input.eu_ai_act.gpai.article_54.representative_has_full_mandate == true
+	msg := "Article 54: Designated EU authorized representative does not hold a full mandate to act on behalf of the provider and be held responsible for obligations"
+}
+
+violations contains msg if {
+	input.eu_ai_act.gpai.article_54.provider_established_outside_eu == true
+	not input.eu_ai_act.gpai.article_54.representative_registered_with_national_authority == true
+	msg := "Article 54: Authorized representative not registered with the relevant national competent authority in the EU member state of establishment"
+}
+
+# =============================================================================
+# Article 55 — Systemic Risk Classification and Obligations (>10^25 FLOPs)
+# =============================================================================
+
+violations contains msg if {
+	input.eu_ai_act.gpai.article_55.training_flops_exceeds_threshold == true
+	not input.eu_ai_act.gpai.article_55.notified_to_ai_office == true
+	msg := "Article 55.1: GPAI model with training computation exceeding 10^25 FLOPs not notified to the AI Office within two weeks of classification"
+}
+
+violations contains msg if {
+	input.eu_ai_act.gpai.article_55.training_flops_exceeds_threshold == true
+	not input.eu_ai_act.gpai.article_55.notification_timely == true
+	msg := "Article 55.1: Notification to AI Office for systemic-risk GPAI model not submitted within the two-week deadline after reaching the 10^25 FLOPs threshold"
+}
+
+violations contains msg if {
+	input.eu_ai_act.gpai.article_55.systemic_risk_model == true
+	not input.eu_ai_act.gpai.article_55.model_evaluation_conducted == true
+	msg := "Article 55.1(a): Model evaluation including adversarial testing not conducted for GPAI model with systemic risk; standardized protocols must be followed"
+}
+
+violations contains msg if {
+	input.eu_ai_act.gpai.article_55.systemic_risk_model == true
+	not input.eu_ai_act.gpai.article_55.adversarial_testing_performed == true
+	msg := "Article 55.1(a): Adversarial testing not performed on systemic-risk GPAI model to assess and mitigate systemic risks including critical infrastructure harms"
+}
+
+violations contains msg if {
+	input.eu_ai_act.gpai.article_55.systemic_risk_model == true
+	not input.eu_ai_act.gpai.article_55.serious_incident_reporting_established == true
+	msg := "Article 55.1(b): Serious incident reporting procedure not established for systemic-risk GPAI model; incidents must be reported to the AI Office without undue delay"
+}
+
+violations contains msg if {
+	input.eu_ai_act.gpai.article_55.systemic_risk_model == true
+	not input.eu_ai_act.gpai.article_55.cybersecurity_measures_proportionate == true
+	msg := "Article 55.1(c): Cybersecurity measures not implemented or not proportionate to the systemic risks posed by the GPAI model"
+}
+
+violations contains msg if {
+	input.eu_ai_act.gpai.article_55.systemic_risk_model == true
+	not input.eu_ai_act.gpai.article_55.physical_cybersecurity_protections == true
+	msg := "Article 55.1(c): Physical and logical access controls to protect model weights, parameters, and infrastructure not implemented for systemic-risk GPAI model"
+}
+
+violations contains msg if {
+	input.eu_ai_act.gpai.article_55.systemic_risk_model == true
+	not input.eu_ai_act.gpai.article_55.energy_efficiency_reporting_provided == true
+	msg := "Article 55.1(d): Energy efficiency reporting not provided to the European Commission for systemic-risk GPAI model; power consumption data must be disclosed"
+}
+
+violations contains msg if {
+	input.eu_ai_act.gpai.article_55.systemic_risk_model == true
+	not input.eu_ai_act.gpai.article_55.systemic_risk_mitigation_measures_documented == true
+	msg := "Article 55: Systemic risk mitigation measures not documented; providers of systemic-risk GPAI models must maintain records of identified risks and mitigation actions"
+}
+
+# =============================================================================
+# Article 56 — Codes of Practice
+# =============================================================================
+
+violations contains msg if {
+	not input.eu_ai_act.gpai.article_56.code_of_practice_adhered_to == true
+	not input.eu_ai_act.gpai.article_56.equivalent_compliance_demonstrated == true
+	msg := "Article 56: GPAI model provider has not adhered to a relevant code of practice or demonstrated equivalent compliance through alternative means accepted by the AI Office"
+}
+
+violations contains msg if {
+	input.eu_ai_act.gpai.article_56.equivalent_compliance_demonstrated == true
+	not input.eu_ai_act.gpai.article_56.equivalent_compliance_documented == true
+	msg := "Article 56: Equivalent compliance with GPAI code of practice claimed but technical and organizational measures demonstrating equivalence are not documented"
+}
+
+# =============================================================================
+# Compliance report
+# =============================================================================
+
+compliance_report := {
+	"module": "gpai_obligations",
+	"standard": "EU AI Act — Title VIII, Articles 51-56",
+	"applies_from": "August 2025",
+	"compliant": compliant,
+	"total_violations": count(violations),
+	"violations": violations,
+	"articles_assessed": [
+		"Article 53 — Obligations for all GPAI model providers",
+		"Article 54 — Authorized representatives for non-EU providers",
+		"Article 55 — Systemic risk classification and obligations (>10^25 FLOPs)",
+		"Article 56 — Codes of practice",
+	],
+}

--- a/governance/eu_ai_act/eu_ai_act_high_risk.rego
+++ b/governance/eu_ai_act/eu_ai_act_high_risk.rego
@@ -1,0 +1,344 @@
+package eu_ai_act.high_risk
+
+import rego.v1
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+# =============================================================================
+# Article 9 — Risk Management System
+# =============================================================================
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.risk_management.system_established == true
+	msg := "Article 9: Continuous risk management system not established for this high-risk AI system as required throughout the entire lifecycle"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.risk_management.system_documented == true
+	msg := "Article 9: Risk management system not documented; written records of risk identification, estimation, and evaluation measures are required"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.risk_management.risks_identified == true
+	msg := "Article 9: Known and reasonably foreseeable risks to health, safety, or fundamental rights have not been identified and estimated"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.risk_management.risks_evaluated_with_representative_data == true
+	msg := "Article 9: Risk evaluation not conducted against testing data representative of the intended purpose and conditions of use"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.risk_management.residual_risks_communicated == true
+	msg := "Article 9: Residual risks after risk mitigation measures have not been communicated to deployers in instructions for use"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.risk_management.updated_post_market == true
+	msg := "Article 9: Risk management system not updated based on post-market monitoring data; continuous lifecycle review is required"
+}
+
+# =============================================================================
+# Article 10 — Data and Data Governance
+# =============================================================================
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.data_governance.training_data_governance_established == true
+	msg := "Article 10: Data governance practices not established for training datasets used to develop the high-risk AI system"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.data_governance.validation_data_governance_established == true
+	msg := "Article 10: Data governance practices not established for validation datasets; separate validation from training data is required"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.data_governance.test_data_governance_established == true
+	msg := "Article 10: Data governance practices not established for test datasets used to evaluate system performance"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.data_governance.datasets_examined_for_biases == true
+	msg := "Article 10: Training, validation, and test datasets not examined for possible biases that could lead to discriminatory outcomes"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.data_governance.data_lineage_documented == true
+	msg := "Article 10: Data provenance and lineage not documented; origin, collection method, and transformations of datasets must be recorded"
+}
+
+violations contains msg if {
+	input.eu_ai_act.high_risk.data_governance.processes_personal_data == true
+	not input.eu_ai_act.high_risk.data_governance.gdpr_compliant_practices == true
+	msg := "Article 10: Personal data in training or evaluation datasets processed without GDPR-compliant data protection practices"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.data_governance.datasets_adequate_for_intended_purpose == true
+	msg := "Article 10: Datasets not verified to be sufficiently adequate, representative, and free of errors for the intended purpose of the AI system"
+}
+
+# =============================================================================
+# Article 11 — Technical Documentation
+# =============================================================================
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.technical_documentation.prepared_before_market_placement == true
+	msg := "Article 11: Technical documentation (per Annex IV) not prepared before the high-risk AI system was placed on the market or put into service"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.technical_documentation.kept_up_to_date == true
+	msg := "Article 11: Technical documentation not kept up to date following material changes to the AI system or its intended purpose"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.technical_documentation.contains_annex_iv_content == true
+	msg := "Article 11: Technical documentation does not contain all required elements specified in Annex IV of the EU AI Act"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.technical_documentation.available_to_national_authorities == true
+	msg := "Article 11: Technical documentation not available or accessible to national competent authorities upon request"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.technical_documentation.describes_design_specifications == true
+	msg := "Article 11: Technical documentation does not describe general design specifications, choices made, and assumptions relied upon"
+}
+
+# =============================================================================
+# Article 12 — Record-Keeping and Logging
+# =============================================================================
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.record_keeping.automatic_logging_enabled == true
+	msg := "Article 12: Automatic logging of events during system operation not enabled; high-risk AI systems must generate logs throughout their operational lifetime"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.record_keeping.log_retention_period_adequate == true
+	msg := "Article 12: Log retention period does not meet requirements; logs must be retained for an appropriate period aligned with legal obligations"
+}
+
+violations contains msg if {
+	input.eu_ai_act.high_risk.record_keeping.is_biometric_system == true
+	not input.eu_ai_act.high_risk.record_keeping.biometric_logs_retained_for_law_enforcement_duration == true
+	msg := "Article 12: Biometric identification system logs not retained for the duration required for law enforcement use cases"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.record_keeping.logs_enable_post_hoc_audit == true
+	msg := "Article 12: Logs do not enable post-hoc verification and monitoring of system performance by competent authorities"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.record_keeping.event_types_sufficient == true
+	msg := "Article 12: Event types captured in logs are insufficient relative to the level of risk and the intended purpose of the system"
+}
+
+# =============================================================================
+# Article 13 — Transparency and Information to Deployers
+# =============================================================================
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.transparency.instructions_for_use_provided == true
+	msg := "Article 13: Instructions for use not provided to deployers; high-risk AI systems must be accompanied by adequate instructions in accessible language"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.transparency.intended_purpose_disclosed == true
+	msg := "Article 13: Intended purpose of the AI system not disclosed in instructions for use"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.transparency.accuracy_level_disclosed == true
+	msg := "Article 13: Level of accuracy, robustness, and cybersecurity performance not disclosed in instructions for use"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.transparency.known_risks_disclosed == true
+	msg := "Article 13: Known and foreseeable risks to health, safety, and fundamental rights not disclosed to deployers"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.transparency.human_oversight_measures_described == true
+	msg := "Article 13: Human oversight measures not described in instructions for use; deployers must be informed of required oversight responsibilities"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.transparency.capability_limitations_disclosed == true
+	msg := "Article 13: Technical capabilities and limitations of the AI system not disclosed, including circumstances where reliability may be compromised"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.transparency.residual_risks_disclosed_to_deployers == true
+	msg := "Article 13: Residual risks not communicated to deployers in instructions for use"
+}
+
+# =============================================================================
+# Article 14 — Human Oversight
+# =============================================================================
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.human_oversight.oversight_measures_built_in == true
+	not input.eu_ai_act.high_risk.human_oversight.oversight_measures_specified_for_deployers == true
+	msg := "Article 14: Human oversight measures neither built into the system design nor specified for deployer implementation"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.human_oversight.effective_monitoring_by_natural_persons == true
+	msg := "Article 14: System not designed to enable effective monitoring by natural persons during the period of use"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.human_oversight.halt_capability_provided == true
+	msg := "Article 14: No capability provided to halt or interrupt system operation; deployers must be able to stop the system using a stop button or equivalent procedure"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.human_oversight.override_capability_provided == true
+	msg := "Article 14: Deployers cannot disregard or override system outputs; capability to intervene in system operation is required"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.human_oversight.over_reliance_prevention_documented == true
+	msg := "Article 14: No documented measures to prevent automation bias or over-reliance on AI system outputs by deployer staff"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.human_oversight.responsible_persons_identified == true
+	msg := "Article 14: Natural persons responsible for human oversight not identified and assigned appropriate competence, authority, and resources"
+}
+
+# =============================================================================
+# Article 15 — Accuracy, Robustness, and Cybersecurity
+# =============================================================================
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.accuracy_robustness.accuracy_levels_specified == true
+	msg := "Article 15: Accuracy levels for the high-risk AI system not specified and validated against representative datasets"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.accuracy_robustness.robustness_against_errors_demonstrated == true
+	msg := "Article 15: Robustness of the AI system against errors, faults, and inconsistencies not demonstrated through appropriate testing"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.accuracy_robustness.resilience_against_manipulation_demonstrated == true
+	msg := "Article 15: Resilience against hostile third-party attempts to alter system use, outputs, or performance not demonstrated"
+}
+
+violations contains msg if {
+	input.eu_ai_act.high_risk.accuracy_robustness.safety_critical_system == true
+	not input.eu_ai_act.high_risk.accuracy_robustness.technical_redundancy_solutions_implemented == true
+	msg := "Article 15: Technical redundancy solutions not implemented for safety-critical high-risk AI system; backup or fail-safe mechanisms are required"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.accuracy_robustness.cybersecurity_measures_implemented == true
+	msg := "Article 15: Cybersecurity measures not implemented to protect the AI system against unauthorized access, tampering, and data poisoning"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.accuracy_robustness.metrics_publicly_disclosed == true
+	msg := "Article 15: Performance metrics including accuracy and robustness not disclosed in technical documentation or instructions for use"
+}
+
+# =============================================================================
+# Article 16 — Obligations of Providers
+# =============================================================================
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.provider_obligations.conformity_assessment_completed == true
+	msg := "Article 16: Conformity assessment not completed before placing the high-risk AI system on the EU market or putting it into service"
+}
+
+violations contains msg if {
+	input.eu_ai_act.high_risk.provider_obligations.ce_marking_required == true
+	not input.eu_ai_act.high_risk.provider_obligations.ce_marking_affixed == true
+	msg := "Article 16: CE marking not affixed; high-risk AI systems must bear CE marking indicating conformity with the EU AI Act"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.provider_obligations.eu_declaration_of_conformity_drawn_up == true
+	msg := "Article 16: EU Declaration of Conformity not drawn up; providers must declare that the high-risk AI system meets all applicable requirements"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.provider_obligations.registered_in_eu_database == true
+	msg := "Article 16: High-risk AI system (Annex III use case) not registered in the EU database for high-risk AI systems before market placement"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.provider_obligations.post_market_monitoring_in_place == true
+	msg := "Article 16: Post-market monitoring system not established; providers must actively collect and analyze data on system performance after deployment"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.provider_obligations.serious_incident_reporting_procedure == true
+	msg := "Article 16: Serious incident reporting procedure not established; providers must report serious incidents to national competent authorities"
+}
+
+# =============================================================================
+# Article 17 — Quality Management System
+# =============================================================================
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.quality_management.qms_established == true
+	msg := "Article 17: Quality management system not established; providers of high-risk AI systems must implement a documented QMS covering all provider obligations"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.quality_management.written_compliance_policies == true
+	msg := "Article 17: Written policies and procedures for regulatory compliance not established as part of the quality management system"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.quality_management.resource_management_documented == true
+	msg := "Article 17: Resource management procedures (technical, human, computational) not documented in the quality management system"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.quality_management.competence_awareness_training_procedures == true
+	msg := "Article 17: Competence, awareness, and training procedures for personnel involved in AI system development not established"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.quality_management.design_development_control_procedures == true
+	msg := "Article 17: Design and development control procedures not established, including design reviews, verification, and validation activities"
+}
+
+violations contains msg if {
+	not input.eu_ai_act.high_risk.quality_management.corrective_action_procedures == true
+	msg := "Article 17: Corrective action procedures for non-conformities and incidents not established in the quality management system"
+}
+
+# =============================================================================
+# Compliance report
+# =============================================================================
+
+compliance_report := {
+	"module": "high_risk_requirements",
+	"standard": "EU AI Act — Title III, Articles 6-49",
+	"applies_from": "August 2026",
+	"compliant": compliant,
+	"total_violations": count(violations),
+	"violations": violations,
+	"articles_assessed": [
+		"Article 9 — Risk Management System",
+		"Article 10 — Data and Data Governance",
+		"Article 11 — Technical Documentation",
+		"Article 12 — Record-Keeping and Logging",
+		"Article 13 — Transparency and Information to Deployers",
+		"Article 14 — Human Oversight",
+		"Article 15 — Accuracy, Robustness, and Cybersecurity",
+		"Article 16 — Obligations of Providers",
+		"Article 17 — Quality Management System",
+	],
+}

--- a/governance/eu_ai_act/eu_ai_act_main.rego
+++ b/governance/eu_ai_act/eu_ai_act_main.rego
@@ -1,0 +1,199 @@
+package eu_ai_act.main
+
+import rego.v1
+
+import data.eu_ai_act.prohibited
+import data.eu_ai_act.high_risk
+import data.eu_ai_act.transparency
+import data.eu_ai_act.gpai
+import data.eu_ai_act.governance
+
+# =============================================================================
+# Applicable modules based on risk tier
+# =============================================================================
+
+applicable_modules := modules if {
+	input.eu_ai_act.system_classification.risk_tier == "prohibited"
+	modules := ["prohibited_practices"]
+}
+
+applicable_modules := modules if {
+	input.eu_ai_act.system_classification.risk_tier == "high_risk"
+	modules := ["prohibited_practices", "high_risk_requirements", "transparency_obligations", "governance_deployer"]
+}
+
+applicable_modules := modules if {
+	input.eu_ai_act.system_classification.risk_tier == "limited_risk"
+	modules := ["prohibited_practices", "transparency_obligations"]
+}
+
+applicable_modules := modules if {
+	input.eu_ai_act.system_classification.risk_tier == "minimal_risk"
+	modules := ["prohibited_practices"]
+}
+
+applicable_modules := modules if {
+	input.eu_ai_act.system_classification.risk_tier == "gpai"
+	modules := ["prohibited_practices", "gpai_obligations", "governance_deployer"]
+}
+
+default applicable_modules := ["prohibited_practices"]
+
+# =============================================================================
+# Per-module compliance results
+# =============================================================================
+
+default prohibited_compliant := false
+
+prohibited_compliant if {
+	prohibited.compliant
+}
+
+default high_risk_compliant := false
+
+high_risk_compliant if {
+	high_risk.compliant
+}
+
+default transparency_compliant := false
+
+transparency_compliant if {
+	transparency.compliant
+}
+
+default gpai_compliant := false
+
+gpai_compliant if {
+	gpai.compliant
+}
+
+default governance_compliant := false
+
+governance_compliant if {
+	governance.compliant
+}
+
+# =============================================================================
+# Modules passing — count only applicable modules
+# =============================================================================
+
+modules_passing := count([1 |
+	some module_name in applicable_modules
+	module_compliant_map[module_name] == true
+])
+
+module_compliant_map := {
+	"prohibited_practices": prohibited_compliant,
+	"high_risk_requirements": high_risk_compliant,
+	"transparency_obligations": transparency_compliant,
+	"gpai_obligations": gpai_compliant,
+	"governance_deployer": governance_compliant,
+}
+
+# =============================================================================
+# Overall compliance — only applicable modules count
+# =============================================================================
+
+default overall_compliant := false
+
+overall_compliant if {
+	modules_passing == count(applicable_modules)
+	count(applicable_modules) > 0
+}
+
+default compliant := false
+
+compliant if {
+	overall_compliant
+}
+
+# =============================================================================
+# Risk tier label
+# =============================================================================
+
+risk_tier := input.eu_ai_act.system_classification.risk_tier
+
+# =============================================================================
+# Aggregate violations — only modules applicable to the risk tier
+# =============================================================================
+
+violations_prohibited := [v |
+	"prohibited_practices" in applicable_modules
+	some v in prohibited.violations
+]
+
+violations_high_risk := [v |
+	"high_risk_requirements" in applicable_modules
+	some v in high_risk.violations
+]
+
+violations_transparency := [v |
+	"transparency_obligations" in applicable_modules
+	some v in transparency.violations
+]
+
+violations_gpai := [v |
+	"gpai_obligations" in applicable_modules
+	some v in gpai.violations
+]
+
+violations_governance := [v |
+	"governance_deployer" in applicable_modules
+	some v in governance.violations
+]
+
+all_violations_1 := array.concat(
+	violations_prohibited,
+	violations_transparency,
+)
+
+all_violations_2 := array.concat(
+	violations_high_risk,
+	violations_gpai,
+)
+
+all_violations := array.concat(
+	array.concat(all_violations_1, all_violations_2),
+	violations_governance,
+)
+
+# =============================================================================
+# Top-level compliance report
+# =============================================================================
+
+compliance_report := {
+	"standard": "EU Artificial Intelligence Act — Regulation (EU) 2024/1689",
+	"overall_compliant": overall_compliant,
+	"risk_tier": risk_tier,
+	"applicable_modules": applicable_modules,
+	"modules_passing": modules_passing,
+	"modules_total": 5,
+	"total_violations": count(all_violations),
+	"modules": {
+		"prohibited_practices": {
+			"compliant": prohibited_compliant,
+			"applicable": "prohibited_practices" in applicable_modules,
+			"details": prohibited.compliance_report,
+		},
+		"high_risk_requirements": {
+			"compliant": high_risk_compliant,
+			"applicable": "high_risk_requirements" in applicable_modules,
+			"details": high_risk.compliance_report,
+		},
+		"transparency_obligations": {
+			"compliant": transparency_compliant,
+			"applicable": "transparency_obligations" in applicable_modules,
+			"details": transparency.compliance_report,
+		},
+		"gpai_obligations": {
+			"compliant": gpai_compliant,
+			"applicable": "gpai_obligations" in applicable_modules,
+			"details": gpai.compliance_report,
+		},
+		"governance_deployer": {
+			"compliant": governance_compliant,
+			"applicable": "governance_deployer" in applicable_modules,
+			"details": governance.compliance_report,
+		},
+	},
+}

--- a/governance/eu_ai_act/eu_ai_act_prohibited.rego
+++ b/governance/eu_ai_act/eu_ai_act_prohibited.rego
@@ -1,0 +1,232 @@
+package eu_ai_act.prohibited
+
+import rego.v1
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+# =============================================================================
+# Article 5.1(a) — Subliminal manipulation beyond conscious awareness
+# =============================================================================
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.subliminal_manipulation.uses_subliminal_techniques == true
+	msg := "Article 5.1(a): AI system employs subliminal techniques beyond a person's consciousness to materially distort behavior in a manner causing or likely to cause significant harm"
+}
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.subliminal_manipulation.exploits_psychological_weaknesses == true
+	msg := "Article 5.1(a): AI system exploits psychological weaknesses or biases of persons in a manner causing or likely to cause significant harm"
+}
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.subliminal_manipulation.exploits_cognitive_biases == true
+	msg := "Article 5.1(a): AI system exploits cognitive biases to manipulate behavior in ways that impair free and informed decision-making"
+}
+
+# =============================================================================
+# Article 5.1(b) — Exploitation of vulnerabilities of specific groups
+# =============================================================================
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.vulnerability_exploitation.targets_age_vulnerability == true
+	input.eu_ai_act.prohibited.vulnerability_exploitation.causes_significant_harm == true
+	msg := "Article 5.1(b): AI system exploits vulnerabilities due to age of a specific group in a manner causing or likely to cause significant harm"
+}
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.vulnerability_exploitation.targets_disability_vulnerability == true
+	input.eu_ai_act.prohibited.vulnerability_exploitation.causes_significant_harm == true
+	msg := "Article 5.1(b): AI system exploits vulnerabilities due to disability of a specific group in a manner causing or likely to cause significant harm"
+}
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.vulnerability_exploitation.targets_social_economic_situation == true
+	input.eu_ai_act.prohibited.vulnerability_exploitation.causes_significant_harm == true
+	msg := "Article 5.1(b): AI system exploits vulnerabilities due to social or economic situation of a specific group causing or likely to cause significant harm"
+}
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.vulnerability_exploitation.distorts_behavior == true
+	not input.eu_ai_act.prohibited.vulnerability_exploitation.harm_prevented_by_safeguards == true
+	msg := "Article 5.1(b): AI system causes harmful distortion of behavior of persons belonging to vulnerable groups without adequate safeguards"
+}
+
+# =============================================================================
+# Article 5.1(c) — Social scoring by public authorities
+# =============================================================================
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.social_scoring.deployed_by_public_authority == true
+	input.eu_ai_act.prohibited.social_scoring.evaluates_persons_based_on_social_behavior == true
+	msg := "Article 5.1(c): Public authority AI system evaluates or classifies persons based on social behavior or personal characteristics leading to detrimental or unfavorable treatment"
+}
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.social_scoring.deployed_by_public_authority == true
+	input.eu_ai_act.prohibited.social_scoring.treatment_is_unjustified == true
+	msg := "Article 5.1(c): AI system causes unjustified or disproportionate treatment of persons in social contexts unrelated to the context in which the data was generated"
+}
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.social_scoring.deployed_by_public_authority == true
+	input.eu_ai_act.prohibited.social_scoring.treatment_is_disproportionate == true
+	msg := "Article 5.1(c): AI system by public authority causes disproportionate detrimental treatment compared to the gravity of the social behavior assessed"
+}
+
+# =============================================================================
+# Article 5.1(d) — Real-time remote biometric identification in public spaces
+# =============================================================================
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.realtime_biometric_id.deployed_in_public_spaces == true
+	input.eu_ai_act.prohibited.realtime_biometric_id.deployed_by_law_enforcement == true
+	not input.eu_ai_act.prohibited.realtime_biometric_id.exception_applies == true
+	msg := "Article 5.1(d): Real-time remote biometric identification system deployed in publicly accessible spaces by law enforcement without applicable exception"
+}
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.realtime_biometric_id.deployed_in_public_spaces == true
+	input.eu_ai_act.prohibited.realtime_biometric_id.deployed_by_law_enforcement == true
+	input.eu_ai_act.prohibited.realtime_biometric_id.exception_applies == true
+	not input.eu_ai_act.prohibited.realtime_biometric_id.prior_judicial_authorization == true
+	not input.eu_ai_act.prohibited.realtime_biometric_id.prior_independent_body_authorization == true
+	msg := "Article 5.1(d): Real-time remote biometric identification deployed under exception without required prior judicial or independent body authorization"
+}
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.realtime_biometric_id.deployed_in_public_spaces == true
+	input.eu_ai_act.prohibited.realtime_biometric_id.deployed_by_law_enforcement == true
+	input.eu_ai_act.prohibited.realtime_biometric_id.exception_applies == true
+	not input.eu_ai_act.prohibited.realtime_biometric_id.limited_to_annex_ii_offenses == true
+	msg := "Article 5.1(d): Real-time remote biometric identification under exception not limited to specific criminal offenses listed in Annex II"
+}
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.realtime_biometric_id.deployed_in_public_spaces == true
+	input.eu_ai_act.prohibited.realtime_biometric_id.geographically_unlimited == true
+	msg := "Article 5.1(d): Real-time remote biometric identification deployment is not geographically and temporally limited as required for authorized exceptions"
+}
+
+# =============================================================================
+# Article 5.1(e) — Biometric categorization inferring sensitive attributes
+# =============================================================================
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.biometric_categorization.infers_race == true
+	not input.eu_ai_act.prohibited.biometric_categorization.law_enforcement_strict_conditions == true
+	msg := "Article 5.1(e): AI system categorizes individuals by race inferred from biometric data without meeting strict law enforcement conditions"
+}
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.biometric_categorization.infers_political_opinion == true
+	not input.eu_ai_act.prohibited.biometric_categorization.law_enforcement_strict_conditions == true
+	msg := "Article 5.1(e): AI system categorizes individuals by political opinion inferred from biometric data without meeting strict law enforcement conditions"
+}
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.biometric_categorization.infers_religion == true
+	not input.eu_ai_act.prohibited.biometric_categorization.law_enforcement_strict_conditions == true
+	msg := "Article 5.1(e): AI system categorizes individuals by religion or philosophical belief inferred from biometric data without meeting strict law enforcement conditions"
+}
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.biometric_categorization.infers_trade_union_membership == true
+	not input.eu_ai_act.prohibited.biometric_categorization.law_enforcement_strict_conditions == true
+	msg := "Article 5.1(e): AI system categorizes individuals by trade union membership inferred from biometric data without meeting strict law enforcement conditions"
+}
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.biometric_categorization.infers_sexual_orientation == true
+	not input.eu_ai_act.prohibited.biometric_categorization.law_enforcement_strict_conditions == true
+	msg := "Article 5.1(e): AI system categorizes individuals by sexual orientation or gender identity inferred from biometric data without meeting strict law enforcement conditions"
+}
+
+# =============================================================================
+# Article 5.1(f) — Emotion recognition in workplace or educational institutions
+# =============================================================================
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.emotion_recognition.deployed_in_workplace == true
+	not input.eu_ai_act.prohibited.emotion_recognition.medical_purpose == true
+	not input.eu_ai_act.prohibited.emotion_recognition.safety_purpose == true
+	msg := "Article 5.1(f): Emotion recognition system used in workplace context without documented medical or safety purpose exception"
+}
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.emotion_recognition.deployed_in_educational_institution == true
+	not input.eu_ai_act.prohibited.emotion_recognition.medical_purpose == true
+	not input.eu_ai_act.prohibited.emotion_recognition.safety_purpose == true
+	msg := "Article 5.1(f): Emotion recognition system used in educational institution without documented medical or safety purpose exception"
+}
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.emotion_recognition.exception_claimed == true
+	not input.eu_ai_act.prohibited.emotion_recognition.exception_documented == true
+	msg := "Article 5.1(f): Emotion recognition exception (medical or safety) claimed but not formally documented as required"
+}
+
+# =============================================================================
+# Article 5.1(g) — Untargeted scraping for facial recognition databases
+# =============================================================================
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.facial_recognition_scraping.database_created_by_scraping == true
+	input.eu_ai_act.prohibited.facial_recognition_scraping.scraping_untargeted == true
+	msg := "Article 5.1(g): Facial recognition database created or expanded through untargeted scraping of facial images from internet or CCTV footage"
+}
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.facial_recognition_scraping.database_created_by_scraping == true
+	not input.eu_ai_act.prohibited.facial_recognition_scraping.scraping_targeted == true
+	not input.eu_ai_act.prohibited.facial_recognition_scraping.legal_basis_documented == true
+	msg := "Article 5.1(g): Facial recognition database creation via scraping lacks documented legal basis and targeted scope justification"
+}
+
+# =============================================================================
+# Article 5.1(h) — Predictive policing based solely on profiling
+# =============================================================================
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.predictive_policing.assesses_individual_criminal_risk == true
+	input.eu_ai_act.prohibited.predictive_policing.based_solely_on_profiling == true
+	not input.eu_ai_act.prohibited.predictive_policing.objective_factual_basis_present == true
+	msg := "Article 5.1(h): AI system assesses risk of criminal offense by individual persons based solely on profiling without objective factual basis relating to that person"
+}
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.predictive_policing.assesses_individual_criminal_risk == true
+	input.eu_ai_act.prohibited.predictive_policing.uses_only_group_characteristics == true
+	msg := "Article 5.1(h): Predictive policing system uses only group-level characteristics or statistical profiling without individual objective factual basis"
+}
+
+violations contains msg if {
+	input.eu_ai_act.prohibited.predictive_policing.crime_prediction_without_human_review == true
+	msg := "Article 5.1(h): Predictive policing system produces crime risk assessments for individuals without meaningful human review before any enforcement action"
+}
+
+# =============================================================================
+# Compliance report
+# =============================================================================
+
+compliance_report := {
+	"module": "prohibited_practices",
+	"standard": "EU AI Act — Title II, Article 5",
+	"applies_from": "February 2025",
+	"compliant": compliant,
+	"total_violations": count(violations),
+	"violations": violations,
+	"articles_assessed": [
+		"5.1(a) — Subliminal manipulation",
+		"5.1(b) — Exploitation of vulnerabilities",
+		"5.1(c) — Social scoring by public authorities",
+		"5.1(d) — Real-time remote biometric identification",
+		"5.1(e) — Biometric categorization inferring sensitive attributes",
+		"5.1(f) — Emotion recognition in workplace/education",
+		"5.1(g) — Untargeted facial recognition scraping",
+		"5.1(h) — Predictive policing on individual basis",
+	],
+}

--- a/governance/eu_ai_act/eu_ai_act_transparency.rego
+++ b/governance/eu_ai_act/eu_ai_act_transparency.rego
@@ -1,0 +1,169 @@
+package eu_ai_act.transparency
+
+import rego.v1
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+# =============================================================================
+# Article 50.1 — Chatbots interacting with natural persons
+# =============================================================================
+
+violations contains msg if {
+	input.eu_ai_act.transparency.chatbot.interacts_with_natural_persons == true
+	not input.eu_ai_act.transparency.chatbot.users_informed_of_ai_nature == true
+	not input.eu_ai_act.transparency.chatbot.obvious_ai_context == true
+	msg := "Article 50.1: Chatbot or conversational AI system does not inform users they are interacting with an AI and not a human at the start of each interaction"
+}
+
+violations contains msg if {
+	input.eu_ai_act.transparency.chatbot.interacts_with_natural_persons == true
+	not input.eu_ai_act.transparency.chatbot.disclosure_at_interaction_start == true
+	not input.eu_ai_act.transparency.chatbot.obvious_ai_context == true
+	msg := "Article 50.1: AI interaction disclosure not provided at the start of the interaction; disclosure must occur before the user becomes engaged in the conversation"
+}
+
+violations contains msg if {
+	input.eu_ai_act.transparency.chatbot.interacts_with_natural_persons == true
+	input.eu_ai_act.transparency.chatbot.obvious_ai_context == true
+	not input.eu_ai_act.transparency.chatbot.obvious_ai_context_documented == true
+	msg := "Article 50.1: 'Obvious AI context' exception claimed for chatbot disclosure exemption but not formally documented with justification"
+}
+
+violations contains msg if {
+	input.eu_ai_act.transparency.chatbot.impersonates_human == true
+	msg := "Article 50.1: AI system actively impersonates a natural person in a way that could deceive users about the AI nature of the interaction"
+}
+
+# =============================================================================
+# Article 50.2 — Emotion recognition and biometric categorization
+# =============================================================================
+
+violations contains msg if {
+	input.eu_ai_act.transparency.emotion_recognition.system_deployed == true
+	not input.eu_ai_act.transparency.emotion_recognition.persons_notified == true
+	msg := "Article 50.2: Persons exposed to emotion recognition system not notified of the system's operation and the fact that they are subject to it"
+}
+
+violations contains msg if {
+	input.eu_ai_act.transparency.emotion_recognition.processes_personal_data == true
+	not input.eu_ai_act.transparency.emotion_recognition.gdpr_compliant == true
+	msg := "Article 50.2: Emotion recognition system processes personal data without compliance with applicable data protection requirements including GDPR"
+}
+
+violations contains msg if {
+	input.eu_ai_act.transparency.emotion_recognition.requires_consent == true
+	not input.eu_ai_act.transparency.emotion_recognition.consent_obtained == true
+	msg := "Article 50.2: GDPR consent not obtained from individuals before processing their biometric or emotional state data"
+}
+
+violations contains msg if {
+	input.eu_ai_act.transparency.biometric_categorization.system_deployed == true
+	not input.eu_ai_act.transparency.biometric_categorization.persons_notified == true
+	msg := "Article 50.2: Persons subject to biometric categorization system not notified of the categorization and its basis"
+}
+
+# =============================================================================
+# Article 50.3 — Deep fakes and AI-generated/manipulated content
+# =============================================================================
+
+violations contains msg if {
+	input.eu_ai_act.transparency.deep_fake.generates_synthetic_image == true
+	not input.eu_ai_act.transparency.deep_fake.labeled_as_ai_generated == true
+	not input.eu_ai_act.transparency.deep_fake.legitimate_purpose_evident == true
+	msg := "Article 50.3: AI-generated or AI-manipulated image not labeled as artificially generated or manipulated; machine-readable disclosure is required"
+}
+
+violations contains msg if {
+	input.eu_ai_act.transparency.deep_fake.generates_synthetic_audio == true
+	not input.eu_ai_act.transparency.deep_fake.labeled_as_ai_generated == true
+	not input.eu_ai_act.transparency.deep_fake.legitimate_purpose_evident == true
+	msg := "Article 50.3: AI-generated or AI-manipulated audio content not labeled as artificially generated or manipulated"
+}
+
+violations contains msg if {
+	input.eu_ai_act.transparency.deep_fake.generates_synthetic_video == true
+	not input.eu_ai_act.transparency.deep_fake.labeled_as_ai_generated == true
+	not input.eu_ai_act.transparency.deep_fake.legitimate_purpose_evident == true
+	msg := "Article 50.3: AI-generated or AI-manipulated video content not labeled as artificially generated or manipulated"
+}
+
+violations contains msg if {
+	input.eu_ai_act.transparency.deep_fake.labeled_as_ai_generated == true
+	not input.eu_ai_act.transparency.deep_fake.machine_readable_disclosure_embedded == true
+	msg := "Article 50.3: AI-generated content disclosure not embedded as machine-readable metadata; technical labeling in content format is required in addition to human-visible labeling"
+}
+
+violations contains msg if {
+	input.eu_ai_act.transparency.deep_fake.legitimate_purpose_evident == true
+	not input.eu_ai_act.transparency.deep_fake.purpose_documented == true
+	msg := "Article 50.3: Legitimate purpose exception (satire, art, clearly fictional) for deep fake disclosure claimed but not documented"
+}
+
+# =============================================================================
+# Article 50.4 — AI-generated text on matters of public interest
+# =============================================================================
+
+violations contains msg if {
+	input.eu_ai_act.transparency.public_interest_text.generates_text_on_public_interest == true
+	not input.eu_ai_act.transparency.public_interest_text.labeled_as_ai_generated == true
+	not input.eu_ai_act.transparency.public_interest_text.human_editorial_responsibility_taken == true
+	msg := "Article 50.4: AI-generated text on matters of public interest not labeled as AI-generated; labeling is required unless human editorial responsibility has been assumed"
+}
+
+violations contains msg if {
+	input.eu_ai_act.transparency.public_interest_text.human_editorial_responsibility_taken == true
+	not input.eu_ai_act.transparency.public_interest_text.editorial_review_process_documented == true
+	msg := "Article 50.4: Human editorial responsibility exception claimed for AI-generated public interest text but editorial review process is not documented"
+}
+
+violations contains msg if {
+	input.eu_ai_act.transparency.public_interest_text.generates_text_on_public_interest == true
+	not input.eu_ai_act.transparency.public_interest_text.disclosure_format_compliant == true
+	msg := "Article 50.4: Format of AI-generated text disclosure does not meet requirements; disclosure must be clear, prominent, and distinguishable from the content"
+}
+
+# =============================================================================
+# Article 50.5 — Deployment transparency and EU database registration
+# =============================================================================
+
+violations contains msg if {
+	input.eu_ai_act.transparency.deployment.high_risk_system == true
+	not input.eu_ai_act.transparency.deployment.registered_in_eu_database == true
+	msg := "Article 50.5: High-risk AI system not registered in the EU database for AI systems as required before deployment"
+}
+
+violations contains msg if {
+	input.eu_ai_act.transparency.deployment.deployer_of_emotion_recognition == true
+	not input.eu_ai_act.transparency.deployment.affected_persons_informed == true
+	msg := "Article 50.5: Deployer of emotion recognition system has not informed affected persons of the system's deployment and use"
+}
+
+violations contains msg if {
+	input.eu_ai_act.transparency.deployment.deployer_of_emotion_recognition == true
+	not input.eu_ai_act.transparency.deployment.information_provided_before_exposure == true
+	msg := "Article 50.5: Information about emotion recognition system not provided to affected persons before their exposure to the system"
+}
+
+# =============================================================================
+# Compliance report
+# =============================================================================
+
+compliance_report := {
+	"module": "transparency_obligations",
+	"standard": "EU AI Act — Title IV, Article 50",
+	"applies_from": "August 2026",
+	"compliant": compliant,
+	"total_violations": count(violations),
+	"violations": violations,
+	"articles_assessed": [
+		"Article 50.1 — Chatbots interacting with natural persons",
+		"Article 50.2 — Emotion recognition and biometric categorization",
+		"Article 50.3 — Deep fakes and AI-generated/manipulated content",
+		"Article 50.4 — AI-generated text on matters of public interest",
+		"Article 50.5 — Deployment transparency and EU database registration",
+	],
+}


### PR DESCRIPTION
## Summary

Adds 5 new compliance frameworks across 48 files (+7,211 lines), all passing `opa check`.

| Framework | Location | Files | Controls/Requirements |
|-----------|----------|-------|----------------------|
| **CSA CCM v4.0** | `frameworks/management/csa_ccm/` | 17 | 16 domains, 197 controls |
| **ISO/IEC 27701:2019** | `frameworks/privacy/iso27701/` | 5 | PIMS, PII Controller/Processor, DSR (67 checks) |
| **NIST SP 800-171 Rev 3** | `frameworks/federal/nist/sp_800_171/` | 14 | 14 families, 110 CUI requirements (completes existing skeleton) |
| **CCPA / CPRA** | `frameworks/privacy/ccpa/` | 5 | Consumer rights, sensitive PI, data practices (68 checks) |
| **EU AI Act (2024/1689)** | `governance/eu_ai_act/` | 6 | Prohibited (Art. 5), High-Risk (Art. 9-17), Transparency (Art. 50), GPAI (Art. 53-56), Governance (Art. 26-78) |

**Total policy count: 396 → 444**

## Design notes

- All files use Rego v1 syntax (`import rego.v1`), `violations contains msg if` pattern, `default compliant := false`
- EU AI Act main aggregator includes `applicable_modules` rule — filters which modules apply by risk tier (`prohibited`, `high_risk`, `limited_risk`, `minimal_risk`, `gpai`)
- NIST 800-171 aggregator uses `object.get` guards for the pre-existing access_control module (which lacks a `compliant` rule) to prevent undefined propagation
- OPA routing for all 5: `opa-compliance` container (:8182)

## Test plan

- [ ] `opa check` passes on all 48 files (pre-commit hook already confirmed this)
- [ ] Load new frameworks into local OPA compliance container: `curl -X PUT --data-binary @<file> http://192.168.4.62:8182/v1/policies/<name>`
- [ ] Verify main aggregator endpoints return structured JSON
- [ ] Add `csa_ccm`, `iso27701`, `nist_800_171`, `ccpa`, `eu_ai_act` to `opa_framework_map` in `site_config.yml` (done in companion AAC PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)