### PR TITLE
fix: rename nist_800_171 main package to match framework key

### DIFF
--- a/frameworks/federal/nist/sp_800_171/nist_800_171_main.rego
+++ b/frameworks/federal/nist/sp_800_171/nist_800_171_main.rego
@@ -1,4 +1,4 @@
-package nist.sp800_171.main
+package nist_800_171.main
 
 import rego.v1
 


### PR DESCRIPTION
Renames `package nist.sp800_171.main` → `package nist_800_171.main` in `nist_800_171_main.rego`.

**Why:** The AAC `opa_framework_map` key is `nist_800_171`, which the generic framework assessment resolves to OPA path `/v1/data/nist_800_171/main/compliance_report`. The old package name `nist.sp800_171.main` was exposed at `/v1/data/nist/sp800_171/main/...` — a mismatch. The fix aligns the OPA data path with the routing key.

Sub-module packages (`nist.sp800_171.access_control`, etc.) are unchanged; the main aggregator imports them via `data.nist.sp800_171.*` which still resolves correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)