### PR TITLE
feat: GEISA runtime compliance Rego library (API, ADM, LEE, VEE)

### DIFF
--- a/governance/geisa/geisa_adm.rego
+++ b/governance/geisa/geisa_adm.rego
@@ -1,0 +1,103 @@
+package governance.geisa.adm
+
+import rego.v1
+
+# ─── GEISA ADM Pillar — Application/Device Management via LwM2M ───────────────
+# Validates that a GEISA application was properly deployed and managed via
+# OMA LwM2M (Object 9 — Software Management). Checks registration, version,
+# and post-install object state.
+#
+# Input schema:
+#   input.manifest.applicationId               — app identity (must match pkg_name)
+#   input.lwm2m.registered                     — boolean
+#   input.lwm2m.version                        — string "1.1" or higher
+#   input.lwm2m.registered_objects             — array of URI strings (e.g. "/9/0")
+#   input.lwm2m.object9.pkg_name               — installed package name
+#   input.lwm2m.object9.update_state           — 4 = Installed
+#   input.lwm2m.object9.update_result          — 1 = Success
+#   input.lwm2m.object9.activation_state       — 1 = Active
+#
+# Authors: Tim Coulter, Claude (Anthropic)
+# ─────────────────────────────────────────────────────────────────────────────
+
+default compliant := false
+
+_lwm2m := input.lwm2m
+
+_obj9 := input.lwm2m.object9
+
+# LwM2M version comparison: "1.1" >= "1.1" and "1.2" >= "1.1"
+_lwm2m_version_ok if {
+	parts := split(_lwm2m.version, ".")
+	to_number(parts[0]) > 1
+}
+
+_lwm2m_version_ok if {
+	parts := split(_lwm2m.version, ".")
+	to_number(parts[0]) == 1
+	to_number(parts[1]) >= 1
+}
+
+# ─── Violations ──────────────────────────────────────────────────────────────
+
+violations contains "ADM: lwm2m input missing or not an object" if {
+	not is_object(input.lwm2m)
+}
+
+violations contains "ADM: device is not registered with LwM2M server" if {
+	is_object(_lwm2m)
+	not _lwm2m.registered == true
+}
+
+violations contains sprintf("ADM: LwM2M version must be >= 1.1, got '%s'", [_lwm2m.version]) if {
+	is_object(_lwm2m)
+	is_string(_lwm2m.version)
+	not _lwm2m_version_ok
+}
+
+violations contains "ADM: Object /9 (Software Management) must be registered" if {
+	is_object(_lwm2m)
+	is_array(_lwm2m.registered_objects)
+	not "/9/0" in _lwm2m.registered_objects
+}
+
+violations contains "ADM: lwm2m.object9 missing or not an object" if {
+	is_object(_lwm2m)
+	not is_object(input.lwm2m.object9)
+}
+
+violations contains sprintf("ADM: update_result must be 1 (Success), got %v", [_obj9.update_result]) if {
+	is_object(_obj9)
+	_obj9.update_result != 1
+}
+
+violations contains sprintf("ADM: update_state must be 4 (Installed), got %v", [_obj9.update_state]) if {
+	is_object(_obj9)
+	_obj9.update_state != 4
+}
+
+violations contains "ADM: activation_state must be 1 (Active)" if {
+	is_object(_obj9)
+	_obj9.activation_state != 1
+}
+
+violations contains sprintf("ADM: Object9 pkg_name '%s' does not match manifest applicationId '%s'", [_obj9.pkg_name, input.manifest.applicationId]) if {
+	is_object(_obj9)
+	is_string(input.manifest.applicationId)
+	_obj9.pkg_name != input.manifest.applicationId
+}
+
+# ─── Output ──────────────────────────────────────────────────────────────────
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+	"pillar": "ADM",
+	"compliant": compliant,
+	"violation_count": count(violations),
+	"violations": violations,
+	"lwm2m_version": _lwm2m.version,
+	"registered": _lwm2m.registered,
+	"registered_objects": _lwm2m.registered_objects,
+	"object9": _obj9,
+}

--- a/governance/geisa/geisa_api.rego
+++ b/governance/geisa/geisa_api.rego
@@ -1,0 +1,101 @@
+package governance.geisa.api
+
+import rego.v1
+
+# ─── GEISA API Pillar — Platform Discovery Compliance ─────────────────────────
+# Validates that a deployed GEISA application successfully completed Platform
+# Discovery and that its MQTT topic naming follows the GEISA spec invariant:
+#
+#   Publish topic:   geisa/api/platform/discovery/req/<applicationId>
+#   Subscribe topic: geisa/api/platform/discovery/rsp/<applicationId>
+#
+# Input schema:
+#   input.manifest.applicationId   — reverse-DNS app identifier
+#   input.manifest.geisa.uses      — array of GEISA service names used
+#   input.manifest.permissions.mqtt.publish   — declared MQTT publish topics
+#   input.manifest.permissions.mqtt.subscribe — declared MQTT subscribe topics
+#   input.discovery_response.status_code      — 1 = OK
+#   input.discovery_response.geisa_version    — {major, minor, patch}
+#   input.discovery_response.pillars.api      — boolean
+#
+# Authors: Tim Coulter, Claude (Anthropic)
+# ─────────────────────────────────────────────────────────────────────────────
+
+default compliant := false
+
+_app_id := input.manifest.applicationId
+
+_discovery := input.discovery_response
+
+_uses := input.manifest.geisa.uses
+
+_mqtt_pub := input.manifest.permissions.mqtt.publish
+
+_mqtt_sub := input.manifest.permissions.mqtt.subscribe
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+_expected_pub_topic := sprintf("geisa/api/platform/discovery/req/%s", [_app_id])
+
+_expected_sub_topic := sprintf("geisa/api/platform/discovery/rsp/%s", [_app_id])
+
+# ─── Violations ──────────────────────────────────────────────────────────────
+
+violations contains "API: platform discovery response missing or not an object" if {
+	not is_object(input.discovery_response)
+}
+
+violations contains sprintf("API: platform discovery status_code must be 1 (OK), got %v", [_discovery.status_code]) if {
+	is_object(_discovery)
+	_discovery.status_code != 1
+}
+
+violations contains "API: GEISA version must be >= 1.0" if {
+	is_object(_discovery)
+	is_object(_discovery.geisa_version)
+	_discovery.geisa_version.major < 1
+}
+
+violations contains "API: discovery_response.pillars.api must be true" if {
+	is_object(_discovery)
+	is_object(_discovery.pillars)
+	not _discovery.pillars.api == true
+}
+
+violations contains "API: manifest.geisa.uses must include 'platform-discovery'" if {
+	is_array(_uses)
+	not "platform-discovery" in _uses
+}
+
+violations contains sprintf("API: manifest must declare publish topic '%s'", [_expected_pub_topic]) if {
+	is_array(_mqtt_pub)
+	not _expected_pub_topic in _mqtt_pub
+}
+
+violations contains sprintf("API: manifest must declare subscribe topic '%s'", [_expected_sub_topic]) if {
+	is_array(_mqtt_sub)
+	not _expected_sub_topic in _mqtt_sub
+}
+
+violations contains "API: manifest.applicationId must be set" if {
+	not is_string(input.manifest.applicationId)
+}
+
+violations contains "API: manifest.applicationId must be non-empty" if {
+	is_string(input.manifest.applicationId)
+	count(input.manifest.applicationId) == 0
+}
+
+# ─── Output ──────────────────────────────────────────────────────────────────
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+	"pillar": "API",
+	"compliant": compliant,
+	"violation_count": count(violations),
+	"violations": violations,
+	"app_id": _app_id,
+	"geisa_version": _discovery.geisa_version,
+	"platform_discovery_status": _discovery.status_code,
+}

--- a/governance/geisa/geisa_compliance.rego
+++ b/governance/geisa/geisa_compliance.rego
@@ -1,0 +1,93 @@
+package governance.geisa.compliance
+
+import rego.v1
+
+# ─── GEISA Runtime Compliance Orchestrator ────────────────────────────────────
+# Aggregates all four GEISA pillar compliance checks (API, ADM, LEE, VEE) into
+# a single compliance assessment. The `compliant` rule is true only when every
+# applicable pillar passes.
+#
+# Usage (OPA):
+#   POST /v1/data/governance/geisa/compliance
+#   Body: { "input": <geisa_runtime_facts> }
+#
+# Required input schema:
+#   input.manifest
+#     .applicationId          — reverse-DNS app identifier
+#     .version                — semantic version string
+#     .geisa.uses             — array of GEISA services used
+#     .permissions.mqtt.{publish,subscribe} — MQTT topic declarations
+#   input.discovery_response
+#     .status_code            — 1 = OK
+#     .geisa_version          — {major, minor, patch}
+#     .pillars                — {api, adm, lee, vee}
+#   input.lwm2m
+#     .registered             — boolean
+#     .version                — "1.1" or higher
+#     .registered_objects     — array of LwM2M object URIs
+#     .object9                — {pkg_name, update_state, update_result, activation_state}
+#   input.container
+#     .runtime                — container runtime identifier
+#     .runtime_version        — version string
+#     .isolated               — boolean
+#     .network_mode           — network configuration description
+#
+# Authors: Tim Coulter, Claude (Anthropic)
+# ─────────────────────────────────────────────────────────────────────────────
+
+import data.governance.geisa.api
+import data.governance.geisa.adm
+import data.governance.geisa.lee
+import data.governance.geisa.vee
+
+default compliant := false
+
+# ─── Aggregate violations ─────────────────────────────────────────────────────
+
+all_violations := array.concat(
+	array.concat(
+		array.concat(
+			[v | some v in api.violations],
+			[v | some v in adm.violations],
+		),
+		[v | some v in lee.violations],
+	),
+	[v | some v in vee.violations],
+)
+
+# ─── Overall compliance ───────────────────────────────────────────────────────
+
+compliant if {
+	api.compliant
+	adm.compliant
+	lee.compliant
+	vee.compliant
+}
+
+# ─── Pillar summary ───────────────────────────────────────────────────────────
+
+_pillar_status(name, is_compliant) := {"pillar": name, "compliant": is_compliant, "violation_count": count([v | some v in all_violations; startswith(v, concat("", [name, ":"]))])}
+
+_pillars := [
+	{"pillar": "API", "compliant": api.compliant, "violation_count": count(api.violations)},
+	{"pillar": "ADM", "compliant": adm.compliant, "violation_count": count(adm.violations)},
+	{"pillar": "LEE", "compliant": lee.compliant, "violation_count": count(lee.violations)},
+	{"pillar": "VEE", "compliant": vee.compliant, "violation_count": count(vee.violations)},
+]
+
+# ─── Compliance report ────────────────────────────────────────────────────────
+
+compliance_report := {
+	"compliant": compliant,
+	"app_id": input.manifest.applicationId,
+	"app_version": input.manifest.version,
+	"total_violations": count(all_violations),
+	"pillars": _pillars,
+	"violations": all_violations,
+	"details": {
+		"api": api.compliance_report,
+		"adm": adm.compliance_report,
+		"lee": lee.compliance_report,
+		"vee": vee.compliance_report,
+	},
+}

--- a/governance/geisa/geisa_lee.rego
+++ b/governance/geisa/geisa_lee.rego
@@ -1,0 +1,74 @@
+package governance.geisa.lee
+
+import rego.v1
+
+# ─── GEISA LEE Pillar — Lightweight Execution Environment ─────────────────────
+# Validates that the GEISA application runs inside a recognized container/LEE
+# runtime. GEISA-LEE ensures applications execute in an isolated environment
+# with defined resource boundaries.
+#
+# Input schema:
+#   input.container.runtime          — string: "lxc", "docker", "podman", "wasm"
+#   input.container.runtime_version  — version string (X.Y.Z)
+#   input.container.isolated         — boolean: filesystem/process isolation
+#   input.container.network_mode     — string: describes network configuration
+#   input.discovery_response.pillars.lee — boolean: server declares LEE support
+#
+# Authors: Tim Coulter, Claude (Anthropic)
+# ─────────────────────────────────────────────────────────────────────────────
+
+default compliant := false
+
+_container := input.container
+
+_recognized_runtimes := {"lxc", "docker", "podman", "containerd", "wasm", "kata", "firecracker"}
+
+# ─── Violations ──────────────────────────────────────────────────────────────
+
+violations contains "LEE: container input missing or not an object" if {
+	not is_object(input.container)
+}
+
+violations contains "LEE: container.runtime must be set" if {
+	is_object(_container)
+	not is_string(_container.runtime)
+}
+
+violations contains "LEE: container.runtime must be non-empty" if {
+	is_object(_container)
+	is_string(_container.runtime)
+	count(_container.runtime) == 0
+}
+
+violations contains sprintf("LEE: container.runtime '%s' is not a recognized GEISA-LEE runtime", [_container.runtime]) if {
+	is_object(_container)
+	is_string(_container.runtime)
+	count(_container.runtime) > 0
+	not _container.runtime in _recognized_runtimes
+}
+
+violations contains "LEE: container.isolated must be true" if {
+	is_object(_container)
+	not _container.isolated == true
+}
+
+violations contains "LEE: discovery_response must declare lee pillar as true" if {
+	is_object(input.discovery_response)
+	is_object(input.discovery_response.pillars)
+	not input.discovery_response.pillars.lee == true
+}
+
+# ─── Output ──────────────────────────────────────────────────────────────────
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+	"pillar": "LEE",
+	"compliant": compliant,
+	"violation_count": count(violations),
+	"violations": violations,
+	"runtime": _container.runtime,
+	"runtime_version": _container.runtime_version,
+	"isolated": _container.isolated,
+	"network_mode": _container.network_mode,
+}

--- a/governance/geisa/geisa_test_input.json
+++ b/governance/geisa/geisa_test_input.json
@@ -1,0 +1,70 @@
+{
+  "input": {
+    "manifest": {
+      "applicationId": "com.example.app",
+      "version": "0.1.0",
+      "runtime": {
+        "type": "native-linux",
+        "cpuArchitecture": "x86_64"
+      },
+      "entrypoint": {
+        "command": "./geisa-app",
+        "args": ["com.example.app", "127.0.0.1", "1883"]
+      },
+      "permissions": {
+        "mqtt": {
+          "publish": [
+            "geisa/api/platform/discovery/req/com.example.app"
+          ],
+          "subscribe": [
+            "geisa/api/platform/discovery/rsp/com.example.app"
+          ]
+        }
+      },
+      "geisa": {
+        "apiVersion": "1.0",
+        "uses": ["platform-discovery"]
+      }
+    },
+    "discovery_response": {
+      "status_code": 1,
+      "status_message": "OK",
+      "geisa_version": {
+        "major": 1,
+        "minor": 0,
+        "patch": 0
+      },
+      "pillars": {
+        "api": true,
+        "adm": true,
+        "lee": true,
+        "vee": false
+      },
+      "device": {
+        "manufacturer": "ExampleGrid",
+        "model": "GEISA-Meter-DevKit",
+        "serial_number": "SN123456"
+      }
+    },
+    "lwm2m": {
+      "registered": true,
+      "version": "1.1",
+      "registered_objects": [
+        "/1/0", "/2/0", "/3/0", "/4/0", "/5/0",
+        "/6/0", "/7/0", "/9/0", "/31024/0"
+      ],
+      "object9": {
+        "pkg_name": "com.example.app",
+        "update_state": 4,
+        "update_result": 1,
+        "activation_state": 1
+      }
+    },
+    "container": {
+      "runtime": "lxc",
+      "runtime_version": "4.0.12",
+      "isolated": true,
+      "network_mode": "host-shared"
+    }
+  }
+}

--- a/governance/geisa/geisa_vee.rego
+++ b/governance/geisa/geisa_vee.rego
@@ -1,0 +1,74 @@
+package governance.geisa.vee
+
+import rego.v1
+
+# ─── GEISA VEE Pillar — Virtual Execution Environment ─────────────────────────
+# Validates VEE compliance when the device and/or manifest declare VEE support.
+# VEE extends LEE with hardware-level virtualization (hypervisor, TEE, etc.).
+# This check is CONDITIONAL — if discovery_response.pillars.vee == false and the
+# manifest does not declare VEE usage, no violations are raised.
+#
+# Input schema:
+#   input.discovery_response.pillars.vee  — boolean: server declares VEE support
+#   input.container.runtime               — must be a VEE-capable runtime if vee=true
+#   input.container.vee_type              — optional: "hypervisor", "tee", "unikernel"
+#
+# Authors: Tim Coulter, Claude (Anthropic)
+# ─────────────────────────────────────────────────────────────────────────────
+
+default compliant := false
+
+_pillars := input.discovery_response.pillars
+
+_container := input.container
+
+_vee_capable_runtimes := {"kata", "firecracker", "qemu", "xen", "tee-ta"}
+
+# VEE is not required if the server advertises vee=false
+default _vee_required := false
+
+_vee_required if {
+	is_object(_pillars)
+	_pillars.vee == true
+}
+
+# ─── Violations (only when VEE is required) ───────────────────────────────────
+
+violations contains "VEE: discovery_response.pillars.vee is true but container.runtime is not VEE-capable" if {
+	_vee_required
+	is_object(_container)
+	is_string(_container.runtime)
+	not _container.runtime in _vee_capable_runtimes
+}
+
+violations contains "VEE: discovery_response.pillars.vee is true but container input is missing" if {
+	_vee_required
+	not is_object(input.container)
+}
+
+# ─── Output ──────────────────────────────────────────────────────────────────
+
+# When VEE is not required, the pillar trivially passes.
+compliant if {
+	not _vee_required
+}
+
+compliant if {
+	_vee_required
+	count(violations) == 0
+}
+
+_vee_status := "not_required" if { not _vee_required }
+
+_vee_status := "required_and_compliant" if { _vee_required; count(violations) == 0 }
+
+_vee_status := "required_and_non_compliant" if { _vee_required; count(violations) > 0 }
+
+compliance_report := {
+	"pillar": "VEE",
+	"compliant": compliant,
+	"vee_required": _vee_required,
+	"vee_status": _vee_status,
+	"violation_count": count(violations),
+	"violations": violations,
+}


### PR DESCRIPTION
## Summary

- **geisa_api.rego** — Platform Discovery API pillar: validates MQTT topic naming invariant (`geisa/api/platform/discovery/req/<appId>`), discovery response status, and GEISA version ≥ 1.0
- **geisa_adm.rego** — ADM pillar: LwM2M registration, version ≥ 1.1, Object /9 presence, update_result=1 (success), update_state=4 (installed), activation_state=1, pkg_name matches manifest applicationId
- **geisa_lee.rego** — LEE pillar: validates container runtime is recognized (lxc, docker, podman, kata, etc.) and isolation flag is set
- **geisa_vee.rego** — VEE pillar: conditional — no violations raised when `discovery_response.pillars.vee == false`; enforces VEE-capable runtime only when VEE is declared
- **geisa_compliance.rego** — Orchestrator: aggregates all four pillars, single `compliant` boolean, full `compliance_report` with per-pillar details
- **geisa_test_input.json** — Example input from the L9 GEISA capstone demo (`com.example.app` in LXC 4.0.12 via LwM2M 1.1/Object 9)

## Test plan

- [x] `opa check policies/governance/geisa/` — all files parse without errors
- [x] Each pillar module tested independently with `opa eval` against demo input
- [x] Orchestrator tested end-to-end: `compliant: true`, 0 violations across all 4 pillars
- [x] VEE conditional behavior confirmed: `vee_status: "not_required"` when `pillars.vee == false`
- [x] Pre-commit Rego validation hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)