### PR TITLE
feat(cis/saas/m365): CIS Microsoft 365 Foundations Benchmark v3.1.0

### DIFF
--- a/benchmarks/cis/saas/README.md
+++ b/benchmarks/cis/saas/README.md
@@ -1,0 +1,20 @@
+# CIS SaaS Benchmarks
+
+Rego policies evaluating SaaS-tenant compliance against the CIS
+Benchmarks family of SaaS-specific guidance. Unlike the OS / cloud
+benchmarks elsewhere in this library, SaaS benchmarks operate on
+**tenant-level state** pulled from the vendor's admin API rather
+than per-host facts.
+
+| Subdirectory | Benchmark | Vendor admin API |
+|---|---|---|
+| [`m365/`](m365/) | CIS Microsoft 365 Foundations Benchmark v3.1.0 | Microsoft Graph |
+
+Companion fact-gathering Ansible modules live in the **AAC
+compliance repo** at `collections/ansible_collections/aac/<vendor>/`.
+This library only holds the Rego — the evaluation logic. Where the
+state comes from is the Ansible side's concern.
+
+Each subdirectory ships a per-vendor README documenting the
+benchmark version, the section breakdown, and any Graph (or
+equivalent) coverage gaps.

--- a/benchmarks/cis/saas/m365/README.md
+++ b/benchmarks/cis/saas/m365/README.md
@@ -1,0 +1,75 @@
+# CIS Microsoft 365 Foundations Benchmark — Rego Library
+
+Policies evaluating a Microsoft 365 tenant's compliance against the
+[**CIS Microsoft 365 Foundations Benchmark v3.1.0**](https://www.cisecurity.org/benchmark/microsoft_365).
+
+## Section coverage
+
+| Section | Area | Rego module | Package |
+|---|---|---|---|
+| 1 | Microsoft Entra (Identity) | [`identity_validation.rego`](identity_validation.rego) | `cis_m365.identity` |
+| 2 | Microsoft Defender | [`defender_validation.rego`](defender_validation.rego) | `cis_m365.defender` |
+| 3 | Microsoft Purview | [`purview_validation.rego`](purview_validation.rego) | `cis_m365.purview` |
+| 4 | Microsoft Exchange | [`exchange_validation.rego`](exchange_validation.rego) | `cis_m365.exchange` |
+| 5 | Microsoft Fabric | [`fabric_validation.rego`](fabric_validation.rego) | `cis_m365.fabric` |
+| 6 | Microsoft SharePoint | [`sharepoint_validation.rego`](sharepoint_validation.rego) | `cis_m365.sharepoint` |
+| 7 | Microsoft Teams | [`teams_validation.rego`](teams_validation.rego) | `cis_m365.teams` |
+
+Every module exposes a `compliance_report` rule with this shape:
+
+```
+{
+  "section": "<num>",
+  "name": "<section name>",
+  "controls_evaluated": <int>,
+  "violations": [<str>, ...],
+  "violation_count": <int>,
+  "compliant": <bool>
+}
+```
+
+OPA query path: `/v1/data/cis_m365/<section>/compliance_report`.
+
+## Input contract
+
+Facts arrive from the
+[`aac.m365` Ansible collection](https://github.com/ynotbhatc/compliance/tree/main/collections/ansible_collections/aac/m365)
+in the AAC compliance repo. Each module's expected input shape is
+documented at the top of its Rego file. The fact-collection modules
+pull state from Microsoft Graph; the Rego doesn't care how the
+state was obtained, only that the shape matches.
+
+## Coverage gaps
+
+These are documented in the relevant module's `compliance_report`
+or surfaced explicitly as violations so the operator knows what
+ISN'T being evaluated:
+
+- **Section 5 (Fabric)**: most tenant settings need the Fabric
+  Admin REST API, not Graph. The `compliance_report` carries a
+  `coverage_note`; `violation_coverage` fires if fewer than 3
+  controls are evaluable from Graph alone.
+- **Section 4 (Exchange)**: mailbox audit toggle isn't surfaced
+  tenant-wide in Graph v1.0; the Ansible module samples per-user
+  audit settings as a proxy.
+- **Sections needing Exchange Online PowerShell** (transport rules,
+  anti-phishing policy detail): not currently evaluated. A future
+  `aac.m365` PowerShell-wrapper module would supplement.
+
+## Running the tests
+
+The Rego unit tests live in [`tests/`](tests/):
+
+```bash
+opa test benchmarks/cis/saas/m365/ benchmarks/cis/saas/m365/tests/ -v
+```
+
+End-to-end smoke tests (load all modules into a live OPA, POST
+synthetic facts, assert report shape) live in the AAC compliance
+repo at `demos/m365/tests/smoke_test.py`.
+
+## Benchmark version
+
+Pinned to **CIS Microsoft 365 Foundations Benchmark v3.1.0**.
+Each violation message references the CIS control number it
+implements so the trace is auditable.

--- a/benchmarks/cis/saas/m365/defender_validation.rego
+++ b/benchmarks/cis/saas/m365/defender_validation.rego
@@ -1,0 +1,76 @@
+# CIS Microsoft 365 Foundations Benchmark — Section 2 (Microsoft Defender)
+#
+# Evaluates the facts emitted by aac.m365.m365_defender_facts.
+# Reads the Secure Score control implementation_status as the
+# primary evidence — every Defender for O365 setting Microsoft
+# considers a security baseline is represented there.
+
+package cis_m365.defender
+
+import rego.v1
+
+default compliant := false
+
+
+# Helper — was a Secure Score control marked Implemented?
+control_implemented(control_id) if {
+    input.controls_by_id[control_id] == "Implemented"
+}
+
+# Reusable violation factory. Each rule below names the control id
+# Microsoft uses internally and the CIS clause that depends on it.
+
+violation_2_1_1 contains msg if {
+    not control_implemented("ATPSafeAttachments")
+    msg := "CIS 2.1.1: Safe Attachments policy not implemented; malware reaches inboxes before sandbox detonation"
+}
+
+violation_2_1_2 contains msg if {
+    not control_implemented("ATPSafeLinks")
+    msg := "CIS 2.1.2: Safe Links policy not implemented; users can click time-of-click malicious URLs"
+}
+
+violation_2_1_3 contains msg if {
+    not control_implemented("AntiPhishPolicy")
+    msg := "CIS 2.1.3: anti-phishing baseline policy not implemented"
+}
+
+violation_2_1_4 contains msg if {
+    not control_implemented("MailboxIntelligence")
+    msg := "CIS 2.1.4: mailbox intelligence (impersonation protection) not implemented"
+}
+
+violation_2_1_5 contains msg if {
+    not control_implemented("ZeroHourAutoPurge")
+    msg := "CIS 2.1.5: zero-hour auto-purge for malware/phish not implemented; post-delivery cleanup unavailable"
+}
+
+violation_2_1_7 contains msg if {
+    not control_implemented("CommonAttachmentTypesFiltered")
+    msg := "CIS 2.1.7: common attachment types (.exe, .bat, ...) not filtered"
+}
+
+violation_2_1_8 contains msg if {
+    not control_implemented("AntiMalwarePolicy")
+    msg := "CIS 2.1.8: anti-malware baseline policy not implemented"
+}
+
+
+violations contains v if { some v in violation_2_1_1 }
+violations contains v if { some v in violation_2_1_2 }
+violations contains v if { some v in violation_2_1_3 }
+violations contains v if { some v in violation_2_1_4 }
+violations contains v if { some v in violation_2_1_5 }
+violations contains v if { some v in violation_2_1_7 }
+violations contains v if { some v in violation_2_1_8 }
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "section": "2",
+    "name": "Microsoft Defender",
+    "controls_evaluated": 7,
+    "violations": violations,
+    "violation_count": count(violations),
+    "compliant": compliant,
+}

--- a/benchmarks/cis/saas/m365/exchange_validation.rego
+++ b/benchmarks/cis/saas/m365/exchange_validation.rego
@@ -1,0 +1,138 @@
+# CIS Microsoft 365 Foundations Benchmark — Section 4 (Microsoft Exchange)
+#
+# Evaluates the facts emitted by aac.m365.m365_exchange_facts.
+#
+# Input shape (see module RETURN block for the canonical version):
+#   {
+#     "verified_domains": [
+#       {"id": "example.com", "is_default": true,
+#        "spf_present": bool, "dmarc_present": bool, "dkim_present": bool}
+#     ],
+#     "mailbox_audit_summary": {
+#       "sampled": int, "audit_enabled": int,
+#       "audit_disabled": int, "evaluable": bool
+#     },
+#     "secure_score_controls": [
+#       {"id": "...", "implementation_status": "Implemented|NotImplemented|..."}
+#     ],
+#     "org_settings": {...}
+#   }
+
+package cis_m365.exchange
+
+import rego.v1
+
+default compliant := false
+
+
+# ── 4.1.1 — Mailbox auditing enabled tenant-wide ───────────────────
+
+# The Graph v1.0 surface lets us probe per-user mailboxAuditEnabled.
+# If ANY sampled user has it disabled, the tenant-wide default is
+# almost certainly off (the per-user setting inherits the tenant
+# default unless explicitly overridden).
+violation_4_1_1 contains msg if {
+    input.mailbox_audit_summary.evaluable
+    input.mailbox_audit_summary.audit_disabled > 0
+    msg := sprintf("CIS 4.1.1: %d of %d sampled mailboxes have audit disabled; enable tenant-wide mailbox audit", [
+        input.mailbox_audit_summary.audit_disabled,
+        input.mailbox_audit_summary.sampled,
+    ])
+}
+
+# When we couldn't evaluate (no mailboxAuditEnabled in any sampled
+# response), surface that explicitly rather than silently passing.
+violation_4_1_1 contains msg if {
+    not input.mailbox_audit_summary.evaluable
+    input.mailbox_audit_summary.sampled > 0
+    msg := "CIS 4.1.1: mailbox audit state not evaluable via Graph; verify tenant-wide setting via Exchange admin center"
+}
+
+
+# ── 4.5.1 — SPF record on every verified non-Microsoft domain ──────
+
+# Microsoft's onmicrosoft.com domain auto-publishes SPF via Microsoft
+# itself; we only check customer-owned domains.
+
+customer_domains contains d if {
+    some d in input.verified_domains
+    not d.is_initial
+}
+
+violation_4_5_1 contains msg if {
+    some d in customer_domains
+    not d.spf_present
+    msg := sprintf("CIS 4.5.1: domain %q has no SPF record published; spoofed mail will not be rejected", [d.id])
+}
+
+
+# ── 4.6.1 — DKIM signing for every verified non-Microsoft domain ──
+
+violation_4_6_1 contains msg if {
+    some d in customer_domains
+    not d.dkim_present
+    msg := sprintf("CIS 4.6.1: domain %q has no DKIM CNAME selectors; outbound mail can't be cryptographically authenticated", [d.id])
+}
+
+
+# ── 4.7.1 — DMARC policy for every verified non-Microsoft domain ──
+
+violation_4_7_1 contains msg if {
+    some d in customer_domains
+    not d.dmarc_present
+    msg := sprintf("CIS 4.7.1: domain %q has no DMARC record; recipients have no policy guidance on what to do with failed SPF/DKIM", [d.id])
+}
+
+
+# ── 4.8.1 — External sender tagging enabled ─────────────────────────
+
+# Read from Secure Score. If the relevant control row exists and is
+# anything other than "Implemented", flag it. If the row is missing
+# entirely, fall back to a softer "not evaluable" warning so the
+# operator knows we couldn't see the setting.
+
+external_tag_control := c if {
+    some c in input.secure_score_controls
+    c.id == "ExternalSenderTagging"
+}
+
+violation_4_8_1 contains msg if {
+    external_tag_control
+    external_tag_control.implementation_status != "Implemented"
+    msg := "CIS 4.8.1: External sender tagging is not enabled; users won't see the visual cue distinguishing external from internal mail"
+}
+
+
+# ── 4.11.1 — SMTP AUTH disabled tenant-wide ────────────────────────
+
+smtp_auth_control := c if {
+    some c in input.secure_score_controls
+    c.id == "SMTPAuthDisabled"
+}
+
+violation_4_11_1 contains msg if {
+    smtp_auth_control
+    smtp_auth_control.implementation_status != "Implemented"
+    msg := "CIS 4.11.1: SMTP AUTH is enabled at the tenant level; legacy basic auth on SMTP submission permits credential-stuffing attacks"
+}
+
+
+# ── Roll-up ─────────────────────────────────────────────────────────
+
+violations contains v if { some v in violation_4_1_1 }
+violations contains v if { some v in violation_4_5_1 }
+violations contains v if { some v in violation_4_6_1 }
+violations contains v if { some v in violation_4_7_1 }
+violations contains v if { some v in violation_4_8_1 }
+violations contains v if { some v in violation_4_11_1 }
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "section": "4",
+    "name": "Microsoft Exchange",
+    "controls_evaluated": 6,
+    "violations": violations,
+    "violation_count": count(violations),
+    "compliant": compliant,
+}

--- a/benchmarks/cis/saas/m365/fabric_validation.rego
+++ b/benchmarks/cis/saas/m365/fabric_validation.rego
@@ -1,0 +1,73 @@
+# CIS Microsoft 365 Foundations Benchmark — Section 5 (Microsoft Fabric)
+#
+# Evaluates the facts emitted by aac.m365.m365_fabric_facts.
+#
+# A note about coverage: most Fabric / Power BI tenant settings
+# live in the Fabric Admin REST API, not in Graph v1.0. The
+# `graph_only_coverage` flag signals to operators that this
+# evaluation isn't exhaustive — what's here is real, but a full
+# Section 5 audit also needs the PowerShell / Fabric Admin REST
+# path. We surface that explicitly rather than silently passing.
+
+package cis_m365.fabric
+
+import rego.v1
+
+default compliant := false
+
+
+control_implemented(control_id) if {
+    input.controls_by_id[control_id] == "Implemented"
+}
+
+
+violation_5_1_1 contains msg if {
+    not control_implemented("FabricGuestUserAccess")
+    msg := "CIS 5.1.1: Fabric guest-user access not restricted"
+}
+
+violation_5_1_2 contains msg if {
+    not control_implemented("FabricExternalSharing")
+    msg := "CIS 5.1.2: Fabric external sharing not restricted; reports can leak data outside the tenant"
+}
+
+violation_5_1_3 contains msg if {
+    not control_implemented("FabricServicePrincipalSignIn")
+    msg := "CIS 5.1.3: Fabric service principal sign-in not governed"
+}
+
+violation_5_2_1 contains msg if {
+    not control_implemented("FabricPublicInternetAccess")
+    msg := "CIS 5.2.1: Fabric services accessible from public internet"
+}
+
+violation_5_3_1 contains msg if {
+    not control_implemented("FabricExportDataLimits")
+    msg := "CIS 5.3.1: Fabric export-data limits not configured; users can pull large extracts"
+}
+
+# Coverage gap evidence
+violation_coverage contains msg if {
+    input.controls_evaluable < 3
+    msg := sprintf("CIS Section 5: Graph surface evaluated %d Fabric controls; the rest require the Fabric Admin REST API — supplement this evaluation with the operator-side Fabric audit", [input.controls_evaluable])
+}
+
+
+violations contains v if { some v in violation_5_1_1 }
+violations contains v if { some v in violation_5_1_2 }
+violations contains v if { some v in violation_5_1_3 }
+violations contains v if { some v in violation_5_2_1 }
+violations contains v if { some v in violation_5_3_1 }
+violations contains v if { some v in violation_coverage }
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "section": "5",
+    "name": "Microsoft Fabric",
+    "controls_evaluated": 5,
+    "violations": violations,
+    "violation_count": count(violations),
+    "compliant": compliant,
+    "coverage_note": "Graph v1.0 doesn't expose the full Fabric admin surface; supplement with Fabric Admin REST API",
+}

--- a/benchmarks/cis/saas/m365/identity_validation.rego
+++ b/benchmarks/cis/saas/m365/identity_validation.rego
@@ -1,0 +1,114 @@
+# CIS Microsoft 365 Foundations Benchmark — Section 1 (Microsoft Entra)
+#
+# Evaluates the facts emitted by aac.m365.m365_identity_facts.
+#
+# Input shape:
+#   {
+#     "security_defaults_enabled": bool,
+#     "global_admins": [
+#       {"id": "...", "display_name": "...", "has_strong_mfa": bool, "mfa_methods": [...]}
+#     ],
+#     "conditional_access_policies": [
+#       {"id": "...", "display_name": "...", "state": "enabled|...|disabled",
+#        "conditions": {...}, "grant_controls": {...}}
+#     ],
+#     "user_mfa_methods": [...],
+#     "pim_role_assignments": [...],
+#     "pim_available": bool
+#   }
+
+package cis_m365.identity
+
+import rego.v1
+
+default compliant := false
+
+# ── 1.1.1 — Security Defaults disabled when Conditional Access in use ──
+#
+# CIS prefers Conditional Access over Security Defaults for any tenant
+# with the Entra P1+ licensing required for CA. If SD is on AND no CA
+# policies exist, that's actually fine; if BOTH are on, the SD layer
+# can mask CA effectiveness — flag it.
+
+has_active_ca_policies if {
+    some p in input.conditional_access_policies
+    p.state == "enabled"
+}
+
+violation_1_1_1 contains msg if {
+    input.security_defaults_enabled == true
+    has_active_ca_policies
+    msg := "CIS 1.1.1: Security Defaults is enabled AND active Conditional Access policies exist; disable Security Defaults to let CA take effect"
+}
+
+# ── 1.1.2 — Two-to-four Global Administrators designated ────────────────
+
+violation_1_1_2 contains msg if {
+    count(input.global_admins) < 2
+    msg := sprintf("CIS 1.1.2: Only %d Global Administrator(s); CIS requires at least 2 for redundancy", [count(input.global_admins)])
+}
+
+violation_1_1_2 contains msg if {
+    count(input.global_admins) > 4
+    msg := sprintf("CIS 1.1.2: %d Global Administrators is too many; CIS requires no more than 4 to limit blast radius", [count(input.global_admins)])
+}
+
+# ── 1.1.3 — All Global Administrators have strong MFA ─────────────────
+
+global_admins_without_strong_mfa contains admin if {
+    some admin in input.global_admins
+    admin.has_strong_mfa == false
+}
+
+violation_1_1_3 contains msg if {
+    some admin in global_admins_without_strong_mfa
+    msg := sprintf("CIS 1.1.3: Global Administrator %q lacks a strong MFA method", [admin.display_name])
+}
+
+# ── 1.1.4 — User MFA enforced via Conditional Access ─────────────────
+
+# A "good" enforcement is at least one ENABLED policy whose grantControls
+# require MFA. The conditions vary — the test is whether MFA is actually
+# being demanded somewhere.
+
+ca_policy_requires_mfa(p) if {
+    p.state == "enabled"
+    some control in p.grant_controls.builtInControls
+    control == "mfa"
+}
+
+violation_1_1_4 contains msg if {
+    not any_ca_enforces_mfa
+    msg := "CIS 1.1.4: No enabled Conditional Access policy requires MFA; user MFA is not enforced"
+}
+
+any_ca_enforces_mfa if {
+    some p in input.conditional_access_policies
+    ca_policy_requires_mfa(p)
+}
+
+# ── 1.1.5 — Privileged Identity Management configured ────────────────
+
+violation_1_1_5 contains msg if {
+    input.pim_available == false
+    msg := "CIS 1.1.5: Privileged Identity Management not detected; eligible-not-assigned roles aren't being used to limit standing privilege"
+}
+
+# ── Roll-up ─────────────────────────────────────────────────────────
+
+violations contains v if { some v in violation_1_1_1 }
+violations contains v if { some v in violation_1_1_2 }
+violations contains v if { some v in violation_1_1_3 }
+violations contains v if { some v in violation_1_1_4 }
+violations contains v if { some v in violation_1_1_5 }
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "section": "1",
+    "name": "Microsoft Entra (Identity)",
+    "controls_evaluated": 5,
+    "violations": violations,
+    "violation_count": count(violations),
+    "compliant": compliant,
+}

--- a/benchmarks/cis/saas/m365/purview_validation.rego
+++ b/benchmarks/cis/saas/m365/purview_validation.rego
@@ -1,0 +1,91 @@
+# CIS Microsoft 365 Foundations Benchmark — Section 3 (Microsoft Purview)
+#
+# Evaluates the facts emitted by aac.m365.m365_purview_facts.
+
+package cis_m365.purview
+
+import rego.v1
+
+default compliant := false
+
+
+control_implemented(control_id) if {
+    input.controls_by_id[control_id] == "Implemented"
+}
+
+
+# 3.1.1 — unified audit log enabled
+violation_3_1_1 contains msg if {
+    not control_implemented("UnifiedAuditLogEnabled")
+    msg := "CIS 3.1.1: unified audit log not enabled; security events aren't being captured tenant-wide"
+}
+
+# Cross-reference: if the audit log isn't accessible via Graph,
+# something more fundamental is wrong (or the app reg lacks scope).
+violation_3_1_1 contains msg if {
+    input.audit_log_accessible == false
+    msg := "CIS 3.1.1: audit log endpoint not reachable; verify app registration scope and unified audit log state"
+}
+
+# 3.1.2 — audit log retention >= 1 year
+violation_3_1_2 contains msg if {
+    not control_implemented("AuditLogRetention")
+    msg := "CIS 3.1.2: audit log retention < 1 year (Microsoft default 90 days for non-E5); enable extended retention"
+}
+
+# 3.2.1 — alerts for malicious emails
+violation_3_2_1 contains msg if {
+    not control_implemented("AlertsForMaliciousEmails")
+    msg := "CIS 3.2.1: malicious-email alert policy not implemented"
+}
+
+# 3.3.1 — DLP policy exists
+violation_3_3_1 contains msg if {
+    not control_implemented("DLPPolicy")
+    msg := "CIS 3.3.1: no Data Loss Prevention policy detected; sensitive data exfiltration is unmanaged"
+}
+
+# 3.4.1 — Customer Key (or equivalent BYOK) — Implemented expected for E5
+violation_3_4_1 contains msg if {
+    not control_implemented("CustomerKeyEncryption")
+    msg := "CIS 3.4.1: Customer Key (BYOK) not implemented; tenant data is encrypted with Microsoft-managed keys only"
+}
+
+# 3.5.1 — Insider Risk policy active
+violation_3_5_1 contains msg if {
+    not control_implemented("InsiderRiskPolicy")
+    msg := "CIS 3.5.1: Insider Risk Management policy not active"
+}
+
+# Cross-cutting evidence: eDiscovery presence shows Purview is in
+# active use. Absence alone isn't a violation but worth surfacing
+# as a soft signal so operators know if their Purview footprint
+# is empty.
+violation_evidence_purview_inactive contains msg if {
+    input.ediscovery_cases_count == 0
+    msg := "Purview inactive evidence: no eDiscovery cases configured; tenant may not be actively using Purview governance"
+}
+
+
+violations contains v if { some v in violation_3_1_1 }
+violations contains v if { some v in violation_3_1_2 }
+violations contains v if { some v in violation_3_2_1 }
+violations contains v if { some v in violation_3_3_1 }
+violations contains v if { some v in violation_3_4_1 }
+violations contains v if { some v in violation_3_5_1 }
+
+# Soft evidence is in its own list — the customer can choose
+# whether to treat it as a violation for their purposes.
+soft_findings contains s if { some s in violation_evidence_purview_inactive }
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "section": "3",
+    "name": "Microsoft Purview",
+    "controls_evaluated": 6,
+    "violations": violations,
+    "soft_findings": soft_findings,
+    "violation_count": count(violations),
+    "compliant": compliant,
+}

--- a/benchmarks/cis/saas/m365/sharepoint_validation.rego
+++ b/benchmarks/cis/saas/m365/sharepoint_validation.rego
@@ -1,0 +1,88 @@
+# CIS Microsoft 365 Foundations Benchmark — Section 6 (SharePoint Online)
+#
+# Evaluates the facts emitted by aac.m365.m365_sharepoint_facts.
+# Uses Secure Score as the primary surface, with /admin/sharepoint/
+# settings as a richer secondary source where reachable (beta API).
+
+package cis_m365.sharepoint
+
+import rego.v1
+
+default compliant := false
+
+
+control_implemented(control_id) if {
+    input.controls_by_id[control_id] == "Implemented"
+}
+
+
+# 6.1.1 — legacy auth disabled
+violation_6_1_1 contains msg if {
+    not control_implemented("SharePointLegacyAuthDisabled")
+    msg := "CIS 6.1.1: legacy authentication protocols enabled for SharePoint; modern-auth-only policy not enforced"
+}
+
+# Secondary check from /admin/sharepoint/settings (richer signal)
+violation_6_1_1 contains msg if {
+    input.settings_reachable
+    input.legacy_auth_protocols_enabled == true
+    msg := "CIS 6.1.1: legacyAuthProtocolsEnabled=true at the tenant level"
+}
+
+# 6.1.2 — external sharing scope
+violation_6_1_2 contains msg if {
+    not control_implemented("SharePointExternalSharing")
+    msg := "CIS 6.1.2: external sharing not restricted; default is most-permissive"
+}
+
+# Stricter check: sharingCapability should be "ExternalUserAndGuestSharing"
+# or stricter (NOT "ExistingExternalUserSharingOnly" alone, NOT
+# "Disabled" unless that's the goal).
+violation_6_1_2 contains msg if {
+    input.settings_reachable
+    input.sharing_capability == "ExternalUserAndGuestSharing"
+    msg := "CIS 6.1.2: sharingCapability=ExternalUserAndGuestSharing is the most-permissive setting; restrict to ExistingExternalUserSharingOnly or Disabled"
+}
+
+# 6.2.1 — guest reshare
+violation_6_2_1 contains msg if {
+    not control_implemented("SharePointGuestSharing")
+    msg := "CIS 6.2.1: guest users not restricted from resharing"
+}
+
+# 6.3.1 — re-auth for shared links
+violation_6_3_1 contains msg if {
+    not control_implemented("SharePointLinkReauth")
+    msg := "CIS 6.3.1: re-authentication for shared links not enforced"
+}
+
+# 6.4.1 — default link type not anyone
+violation_6_4_1 contains msg if {
+    not control_implemented("SharePointDefaultLinkType")
+    msg := "CIS 6.4.1: default shared link type isn't 'specific people' or 'organization-only'"
+}
+
+# Stricter check from settings
+violation_6_4_1 contains msg if {
+    input.settings_reachable
+    input.default_sharing_link_type == "AnonymousAccess"
+    msg := "CIS 6.4.1: defaultSharingLinkType=AnonymousAccess; new links create world-readable URLs by default"
+}
+
+
+violations contains v if { some v in violation_6_1_1 }
+violations contains v if { some v in violation_6_1_2 }
+violations contains v if { some v in violation_6_2_1 }
+violations contains v if { some v in violation_6_3_1 }
+violations contains v if { some v in violation_6_4_1 }
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "section": "6",
+    "name": "Microsoft SharePoint",
+    "controls_evaluated": 5,
+    "violations": violations,
+    "violation_count": count(violations),
+    "compliant": compliant,
+}

--- a/benchmarks/cis/saas/m365/teams_validation.rego
+++ b/benchmarks/cis/saas/m365/teams_validation.rego
@@ -1,0 +1,64 @@
+# CIS Microsoft 365 Foundations Benchmark — Section 7 (Microsoft Teams)
+#
+# Evaluates the facts emitted by aac.m365.m365_teams_facts.
+
+package cis_m365.teams
+
+import rego.v1
+
+default compliant := false
+
+
+control_implemented(control_id) if {
+    input.controls_by_id[control_id] == "Implemented"
+}
+
+
+violation_7_1_1 contains msg if {
+    not control_implemented("TeamsExternalAccess")
+    msg := "CIS 7.1.1: Teams external access not restricted; users can federate with arbitrary tenants"
+}
+
+violation_7_1_2 contains msg if {
+    not control_implemented("TeamsGuestAccess")
+    msg := "CIS 7.1.2: Teams guest access not properly scoped"
+}
+
+violation_7_2_1 contains msg if {
+    not control_implemented("TeamsAnonymousJoin")
+    msg := "CIS 7.2.1: anonymous users can join Teams meetings"
+}
+
+violation_7_2_2 contains msg if {
+    not control_implemented("TeamsAutoAdmit")
+    msg := "CIS 7.2.2: meeting auto-admit policy is too permissive; external attendees skip the lobby"
+}
+
+violation_7_3_1 contains msg if {
+    not control_implemented("TeamsCloudRecording")
+    msg := "CIS 7.3.1: cloud recording governance not configured"
+}
+
+violation_7_4_1 contains msg if {
+    not control_implemented("TeamsThirdPartyApps")
+    msg := "CIS 7.4.1: third-party Teams apps not restricted; users can install unvetted integrations"
+}
+
+
+violations contains v if { some v in violation_7_1_1 }
+violations contains v if { some v in violation_7_1_2 }
+violations contains v if { some v in violation_7_2_1 }
+violations contains v if { some v in violation_7_2_2 }
+violations contains v if { some v in violation_7_3_1 }
+violations contains v if { some v in violation_7_4_1 }
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "section": "7",
+    "name": "Microsoft Teams",
+    "controls_evaluated": 6,
+    "violations": violations,
+    "violation_count": count(violations),
+    "compliant": compliant,
+}

--- a/benchmarks/cis/saas/m365/tests/test_exchange_validation.rego
+++ b/benchmarks/cis/saas/m365/tests/test_exchange_validation.rego
@@ -1,0 +1,142 @@
+# Rego tests for cis_m365.exchange. Pin each violation rule's
+# positive and negative path; pin the customer-vs-initial domain
+# filter.
+
+package cis_m365.exchange_test
+
+import rego.v1
+import data.cis_m365.exchange
+
+
+# Baseline that should pass cleanly.
+base_input := {
+    "verified_domains": [
+        {
+            "id": "acme.onmicrosoft.com",
+            "is_default": false,
+            "is_initial": true,
+            "spf_present": false,    # don't care — initial domain
+            "dmarc_present": false,
+            "dkim_present": false,
+        },
+        {
+            "id": "acme.com",
+            "is_default": true,
+            "is_initial": false,
+            "spf_present": true,
+            "dmarc_present": true,
+            "dkim_present": true,
+        },
+    ],
+    "mailbox_audit_summary": {
+        "sampled": 10,
+        "audit_enabled": 10,
+        "audit_disabled": 0,
+        "evaluable": true,
+    },
+    "secure_score_controls": [
+        {"id": "ExternalSenderTagging", "implementation_status": "Implemented"},
+        {"id": "SMTPAuthDisabled", "implementation_status": "Implemented"},
+    ],
+    "org_settings": {"display_name": "Acme", "tenant_type": "AAD", "verified_domain_count": 2},
+}
+
+
+# ── Clean baseline is compliant ────────────────────────────────────
+
+test_clean_baseline_is_compliant if {
+    exchange.compliant with input as base_input
+}
+
+
+# ── 4.1.1 — Mailbox auditing ────────────────────────────────────────
+
+test_4_1_1_violation_when_any_mailbox_audit_disabled if {
+    inp := json.patch(base_input, [
+        {"op": "replace", "path": "/mailbox_audit_summary/audit_disabled", "value": 1},
+    ])
+    some msg in exchange.violation_4_1_1 with input as inp
+    contains(msg, "audit disabled")
+}
+
+test_4_1_1_violation_when_not_evaluable if {
+    inp := json.patch(base_input, [
+        {"op": "replace", "path": "/mailbox_audit_summary/evaluable", "value": false},
+    ])
+    some msg in exchange.violation_4_1_1 with input as inp
+    contains(msg, "not evaluable")
+}
+
+
+# ── 4.5.1 — SPF on customer domains, NOT on .onmicrosoft.com ───────
+
+test_4_5_1_violation_when_customer_domain_missing_spf if {
+    inp := json.patch(base_input, [
+        {"op": "replace", "path": "/verified_domains/1/spf_present", "value": false},
+    ])
+    some msg in exchange.violation_4_5_1 with input as inp
+    contains(msg, "acme.com")
+}
+
+test_4_5_1_no_violation_for_initial_domain_even_without_spf if {
+    # The acme.onmicrosoft.com row already has spf_present=false in
+    # the baseline; it should NOT generate a violation.
+    count(exchange.violation_4_5_1) == 0 with input as base_input
+}
+
+
+# ── 4.6.1 — DKIM ───────────────────────────────────────────────────
+
+test_4_6_1_violation_when_customer_domain_missing_dkim if {
+    inp := json.patch(base_input, [
+        {"op": "replace", "path": "/verified_domains/1/dkim_present", "value": false},
+    ])
+    some msg in exchange.violation_4_6_1 with input as inp
+    contains(msg, "DKIM")
+}
+
+
+# ── 4.7.1 — DMARC ──────────────────────────────────────────────────
+
+test_4_7_1_violation_when_customer_domain_missing_dmarc if {
+    inp := json.patch(base_input, [
+        {"op": "replace", "path": "/verified_domains/1/dmarc_present", "value": false},
+    ])
+    some msg in exchange.violation_4_7_1 with input as inp
+    contains(msg, "DMARC")
+}
+
+
+# ── 4.8.1 — External sender tagging ─────────────────────────────────
+
+test_4_8_1_violation_when_external_tag_not_implemented if {
+    inp := json.patch(base_input, [
+        {"op": "replace", "path": "/secure_score_controls/0/implementation_status", "value": "NotImplemented"},
+    ])
+    some msg in exchange.violation_4_8_1 with input as inp
+    contains(msg, "External sender tagging")
+}
+
+
+# ── 4.11.1 — SMTP AUTH disabled ────────────────────────────────────
+
+test_4_11_1_violation_when_smtp_auth_not_disabled if {
+    inp := json.patch(base_input, [
+        {"op": "replace", "path": "/secure_score_controls/1/implementation_status", "value": "NotImplemented"},
+    ])
+    some msg in exchange.violation_4_11_1 with input as inp
+    contains(msg, "SMTP AUTH")
+}
+
+
+# ── Roll-up sanity ─────────────────────────────────────────────────
+
+test_violation_count_roughly_matches_rule_failures if {
+    inp := json.patch(base_input, [
+        {"op": "replace", "path": "/verified_domains/1/spf_present", "value": false},
+        {"op": "replace", "path": "/verified_domains/1/dmarc_present", "value": false},
+        {"op": "replace", "path": "/secure_score_controls/0/implementation_status", "value": "NotImplemented"},
+    ])
+    not exchange.compliant with input as inp
+    exchange.compliance_report.violation_count >= 3 with input as inp
+}

--- a/benchmarks/cis/saas/m365/tests/test_identity_validation.rego
+++ b/benchmarks/cis/saas/m365/tests/test_identity_validation.rego
@@ -1,0 +1,114 @@
+# Rego tests for cis_m365.identity. Pin the violation rules.
+
+package cis_m365.identity_test
+
+import rego.v1
+import data.cis_m365.identity
+
+
+# Convenience builders so the test cases stay legible.
+
+base_input := {
+    "security_defaults_enabled": false,
+    "global_admins": [
+        {"display_name": "alice", "has_strong_mfa": true},
+        {"display_name": "bob", "has_strong_mfa": true},
+    ],
+    "conditional_access_policies": [
+        {
+            "id": "ca-1",
+            "display_name": "Require MFA for all users",
+            "state": "enabled",
+            "grant_controls": {"builtInControls": ["mfa"]},
+        },
+    ],
+    "pim_available": true,
+    "pim_role_assignments": [],
+}
+
+
+# ── 1.1.1 — Security Defaults + CA collision ────────────────────────
+
+test_1_1_1_violation_when_security_defaults_on_with_ca if {
+    inp := json.patch(base_input, [{"op": "replace", "path": "/security_defaults_enabled", "value": true}])
+    some msg in identity.violation_1_1_1 with input as inp
+    contains(msg, "Security Defaults is enabled")
+}
+
+test_1_1_1_no_violation_when_security_defaults_off if {
+    count(identity.violation_1_1_1) == 0 with input as base_input
+}
+
+test_1_1_1_no_violation_when_ca_disabled_even_if_sd_on if {
+    inp := json.patch(base_input, [
+        {"op": "replace", "path": "/security_defaults_enabled", "value": true},
+        {"op": "replace", "path": "/conditional_access_policies/0/state", "value": "disabled"},
+    ])
+    count(identity.violation_1_1_1) == 0 with input as inp
+}
+
+
+# ── 1.1.2 — Global admin count ──────────────────────────────────────
+
+test_1_1_2_violation_when_under_two_admins if {
+    inp := json.patch(base_input, [{"op": "replace", "path": "/global_admins", "value": [
+        {"display_name": "alice", "has_strong_mfa": true},
+    ]}])
+    some msg in identity.violation_1_1_2 with input as inp
+    contains(msg, "at least 2")
+}
+
+test_1_1_2_violation_when_over_four_admins if {
+    inp := json.patch(base_input, [{"op": "replace", "path": "/global_admins", "value": [
+        {"display_name": "u1", "has_strong_mfa": true},
+        {"display_name": "u2", "has_strong_mfa": true},
+        {"display_name": "u3", "has_strong_mfa": true},
+        {"display_name": "u4", "has_strong_mfa": true},
+        {"display_name": "u5", "has_strong_mfa": true},
+    ]}])
+    some msg in identity.violation_1_1_2 with input as inp
+    contains(msg, "too many")
+}
+
+
+# ── 1.1.3 — Strong MFA on every Global Admin ────────────────────────
+
+test_1_1_3_violation_when_admin_lacks_strong_mfa if {
+    inp := json.patch(base_input, [{"op": "replace", "path": "/global_admins/0/has_strong_mfa", "value": false}])
+    some msg in identity.violation_1_1_3 with input as inp
+    contains(msg, "alice")
+}
+
+
+# ── 1.1.4 — User MFA enforced via CA ────────────────────────────────
+
+test_1_1_4_violation_when_no_ca_requires_mfa if {
+    inp := json.patch(base_input, [{"op": "replace", "path": "/conditional_access_policies/0/grant_controls/builtInControls", "value": ["block"]}])
+    some msg in identity.violation_1_1_4 with input as inp
+    contains(msg, "No enabled Conditional Access policy requires MFA")
+}
+
+
+# ── 1.1.5 — PIM available ───────────────────────────────────────────
+
+test_1_1_5_violation_when_pim_unavailable if {
+    inp := json.patch(base_input, [{"op": "replace", "path": "/pim_available", "value": false}])
+    some msg in identity.violation_1_1_5 with input as inp
+    contains(msg, "Privileged Identity Management")
+}
+
+
+# ── Roll-up ─────────────────────────────────────────────────────────
+
+test_clean_tenant_is_compliant if {
+    identity.compliant with input as base_input
+}
+
+test_violation_count_matches_rule_count if {
+    inp := json.patch(base_input, [
+        {"op": "replace", "path": "/security_defaults_enabled", "value": true},
+        {"op": "replace", "path": "/pim_available", "value": false},
+    ])
+    not identity.compliant with input as inp
+    identity.compliance_report.violation_count >= 2 with input as inp
+}

--- a/benchmarks/cis/saas/m365/tests/test_remaining_sections.rego
+++ b/benchmarks/cis/saas/m365/tests/test_remaining_sections.rego
@@ -1,0 +1,199 @@
+# Rego tests for cis_m365 sections 2/3/5/6/7. Each section has the
+# same shape — controls_by_id is the primary surface — so the tests
+# compress: build a baseline input where every relevant control is
+# "Implemented" (clean), then flip one at a time to confirm each
+# control's violation rule fires.
+
+package cis_m365.remaining_sections_test
+
+import rego.v1
+
+import data.cis_m365.defender
+import data.cis_m365.purview
+import data.cis_m365.fabric
+import data.cis_m365.sharepoint
+import data.cis_m365.teams
+
+
+# ── Defender ─────────────────────────────────────────────────────────
+
+defender_clean_input := {
+    "controls_by_id": {
+        "ATPSafeAttachments": "Implemented",
+        "ATPSafeLinks": "Implemented",
+        "AntiPhishPolicy": "Implemented",
+        "MailboxIntelligence": "Implemented",
+        "ZeroHourAutoPurge": "Implemented",
+        "CommonAttachmentTypesFiltered": "Implemented",
+        "AntiMalwarePolicy": "Implemented",
+    },
+}
+
+test_defender_clean_is_compliant if {
+    defender.compliant with input as defender_clean_input
+}
+
+test_defender_safe_attachments_violation if {
+    inp := json.patch(defender_clean_input, [
+        {"op": "replace", "path": "/controls_by_id/ATPSafeAttachments", "value": "NotImplemented"},
+    ])
+    some msg in defender.violation_2_1_1 with input as inp
+    contains(msg, "Safe Attachments")
+}
+
+test_defender_zap_violation if {
+    inp := json.patch(defender_clean_input, [
+        {"op": "replace", "path": "/controls_by_id/ZeroHourAutoPurge", "value": "NotImplemented"},
+    ])
+    some msg in defender.violation_2_1_5 with input as inp
+    contains(msg, "zero-hour auto-purge")
+}
+
+
+# ── Purview ──────────────────────────────────────────────────────────
+
+purview_clean_input := {
+    "controls_by_id": {
+        "UnifiedAuditLogEnabled": "Implemented",
+        "AuditLogRetention": "Implemented",
+        "AlertsForMaliciousEmails": "Implemented",
+        "DLPPolicy": "Implemented",
+        "CustomerKeyEncryption": "Implemented",
+        "InsiderRiskPolicy": "Implemented",
+    },
+    "audit_log_accessible": true,
+    "ediscovery_cases_count": 1,
+}
+
+test_purview_clean_is_compliant if {
+    purview.compliant with input as purview_clean_input
+}
+
+test_purview_audit_log_inaccessible_violation if {
+    inp := json.patch(purview_clean_input, [
+        {"op": "replace", "path": "/audit_log_accessible", "value": false},
+    ])
+    some msg in purview.violation_3_1_1 with input as inp
+    contains(msg, "not reachable")
+}
+
+test_purview_dlp_violation if {
+    inp := json.patch(purview_clean_input, [
+        {"op": "replace", "path": "/controls_by_id/DLPPolicy", "value": "NotImplemented"},
+    ])
+    some msg in purview.violation_3_3_1 with input as inp
+    contains(msg, "Data Loss Prevention")
+}
+
+test_purview_inactive_soft_finding if {
+    inp := json.patch(purview_clean_input, [
+        {"op": "replace", "path": "/ediscovery_cases_count", "value": 0},
+    ])
+    some s in purview.soft_findings with input as inp
+    contains(s, "inactive evidence")
+}
+
+
+# ── Fabric ───────────────────────────────────────────────────────────
+
+fabric_clean_input := {
+    "controls_by_id": {
+        "FabricGuestUserAccess": "Implemented",
+        "FabricExternalSharing": "Implemented",
+        "FabricServicePrincipalSignIn": "Implemented",
+        "FabricPublicInternetAccess": "Implemented",
+        "FabricExportDataLimits": "Implemented",
+    },
+    "controls_evaluable": 5,
+}
+
+test_fabric_clean_is_compliant if {
+    fabric.compliant with input as fabric_clean_input
+}
+
+test_fabric_external_sharing_violation if {
+    inp := json.patch(fabric_clean_input, [
+        {"op": "replace", "path": "/controls_by_id/FabricExternalSharing", "value": "NotImplemented"},
+    ])
+    some msg in fabric.violation_5_1_2 with input as inp
+    contains(msg, "external sharing")
+}
+
+test_fabric_coverage_violation_when_few_evaluable if {
+    inp := json.patch(fabric_clean_input, [
+        {"op": "replace", "path": "/controls_evaluable", "value": 1},
+    ])
+    some msg in fabric.violation_coverage with input as inp
+    contains(msg, "Fabric Admin REST API")
+}
+
+
+# ── SharePoint ───────────────────────────────────────────────────────
+
+sharepoint_clean_input := {
+    "controls_by_id": {
+        "SharePointLegacyAuthDisabled": "Implemented",
+        "SharePointExternalSharing": "Implemented",
+        "SharePointGuestSharing": "Implemented",
+        "SharePointLinkReauth": "Implemented",
+        "SharePointDefaultLinkType": "Implemented",
+    },
+    "settings_reachable": true,
+    "legacy_auth_protocols_enabled": false,
+    "sharing_capability": "ExistingExternalUserSharingOnly",
+    "default_sharing_link_type": "Internal",
+}
+
+test_sharepoint_clean_is_compliant if {
+    sharepoint.compliant with input as sharepoint_clean_input
+}
+
+test_sharepoint_external_sharing_most_permissive_violation if {
+    inp := json.patch(sharepoint_clean_input, [
+        {"op": "replace", "path": "/sharing_capability", "value": "ExternalUserAndGuestSharing"},
+    ])
+    some msg in sharepoint.violation_6_1_2 with input as inp
+    contains(msg, "ExternalUserAndGuestSharing")
+}
+
+test_sharepoint_anonymous_default_link_violation if {
+    inp := json.patch(sharepoint_clean_input, [
+        {"op": "replace", "path": "/default_sharing_link_type", "value": "AnonymousAccess"},
+    ])
+    some msg in sharepoint.violation_6_4_1 with input as inp
+    contains(msg, "AnonymousAccess")
+}
+
+
+# ── Teams ────────────────────────────────────────────────────────────
+
+teams_clean_input := {
+    "controls_by_id": {
+        "TeamsExternalAccess": "Implemented",
+        "TeamsGuestAccess": "Implemented",
+        "TeamsAnonymousJoin": "Implemented",
+        "TeamsAutoAdmit": "Implemented",
+        "TeamsCloudRecording": "Implemented",
+        "TeamsThirdPartyApps": "Implemented",
+    },
+}
+
+test_teams_clean_is_compliant if {
+    teams.compliant with input as teams_clean_input
+}
+
+test_teams_third_party_apps_violation if {
+    inp := json.patch(teams_clean_input, [
+        {"op": "replace", "path": "/controls_by_id/TeamsThirdPartyApps", "value": "NotImplemented"},
+    ])
+    some msg in teams.violation_7_4_1 with input as inp
+    contains(msg, "third-party")
+}
+
+test_teams_anonymous_join_violation if {
+    inp := json.patch(teams_clean_input, [
+        {"op": "replace", "path": "/controls_by_id/TeamsAnonymousJoin", "value": "NotImplemented"},
+    ])
+    some msg in teams.violation_7_2_1 with input as inp
+    contains(msg, "anonymous")
+}


### PR DESCRIPTION
## Summary

New category: **SaaS benchmarks**. Inaugural set is CIS Microsoft 365 — Rego evaluating Microsoft 365 tenant state pulled from Microsoft Graph by the [\`aac.m365\`](https://github.com/ynotbhatc/compliance/tree/main/collections/ansible_collections/aac/m365) Ansible collection in the AAC compliance repo.

## Section coverage (all seven)

| Section | Area | Rego module | Controls |
|---|---|---|---|
| 1 | Microsoft Entra | \`identity_validation.rego\` | 5 |
| 2 | Microsoft Defender | \`defender_validation.rego\` | 7 |
| 3 | Microsoft Purview | \`purview_validation.rego\` | 6 + soft findings |
| 4 | Microsoft Exchange | \`exchange_validation.rego\` | 6 |
| 5 | Microsoft Fabric | \`fabric_validation.rego\` | 5 + coverage note |
| 6 | Microsoft SharePoint | \`sharepoint_validation.rego\` | 5 |
| 7 | Microsoft Teams | \`teams_validation.rego\` | 6 |

## Architecture

Every section's Rego exposes a \`compliance_report\` rule with a uniform shape:

\`\`\`
{
  \"section\": \"<num>\",
  \"name\": \"<section name>\",
  \"controls_evaluated\": <int>,
  \"violations\": [<str>, ...],
  \"violation_count\": <int>,
  \"compliant\": <bool>
}
\`\`\`

So the consuming side (AAC playbook + Grafana dashboard) treats all 7 sections identically. OPA query path: \`/v1/data/cis_m365/<section>/compliance_report\`.

## Coverage gaps (documented honestly in the Rego itself)

- **Section 5** — most Fabric tenant settings need the Fabric Admin REST API, not Graph. \`coverage_note\` + \`violation_coverage\` fire when fewer than 3 controls are evaluable.
- **Section 4** — mailbox audit toggle isn't surfaced tenant-wide in Graph v1.0; the module approximates via per-user sampling.
- **Sections needing Exchange Online PowerShell** (transport rules, anti-phishing detail) — out of scope until a PowerShell-wrapper module ships.

## Tests

**36 Rego unit tests** under \`benchmarks/cis/saas/m365/tests/\`, all passing:

\`\`\`
opa test benchmarks/cis/saas/m365/ benchmarks/cis/saas/m365/tests/ -v
PASS: 36/36
\`\`\`

End-to-end smoke tests (load all modules into a live OPA, POST synthetic facts, assert report shape) live in the AAC compliance repo at \`demos/m365/tests/smoke_test.py\`.

## Companion changes

The AAC compliance repo PR ([ynotbhatc/compliance — upcoming](https://github.com/ynotbhatc/compliance/pulls)) does three things in parallel with this:

1. Ships the \`aac.m365\` Ansible collection (fact-collection modules + assessment playbook)
2. Ships the Grafana dashboard rendering the per-section compliance evidence
3. Bumps the submodule pointer in \`policies/\` to the commit landed by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)