### PR TITLE
chore(approval-policy): add ynotbha@aisle-five.com as authorized approver

### DIFF
--- a/enforcement/git/approval_policy.rego
+++ b/enforcement/git/approval_policy.rego
@@ -16,6 +16,7 @@ protected_paths := {
 
 # Users authorized to approve changes
 authorized_approvers := {
+    "ynotbha@aisle-five.com",
     "tcoulter@example.com",
     "john.doe@example.com",
     "security-team@example.com",


### PR DESCRIPTION
## Summary

The \`authorized_approvers\` set in \`enforcement/git/approval_policy.rego\`
previously contained only placeholder \`example.com\` emails. The policy was
decorative — every commit that touched a protected path failed the
check unless signed with one of the unused placeholders.

Adds \`ynotbha@aisle-five.com\` so legitimate \`Approved-By:\` trailers from
the real repo owner satisfy the policy.

## Test plan

- [x] \`opa test enforcement/git/approval_policy.rego -v\` → 3/3 pass
- [ ] Submodule pointer bump in compliance repo unblocks the \`Validate Approvals\` check on PRs that touch protected paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)