### PR TITLE
Wire 6 partial frameworks to /v1/data/<framework>/main contract

### DIFF
--- a/frameworks/compliance/nis2/nis2_main.rego
+++ b/frameworks/compliance/nis2/nis2_main.rego
@@ -31,6 +31,19 @@ compliant if {
     count(violations) == 0
 }
 
+# Defaults — without these, an empty input makes compliance_report undefined
+# and the OPA endpoint returns null.
+default entity_name     := "unknown"
+default entity_type     := "unknown"
+default sector          := "unknown"
+default entity_category := "unknown"
+default assessed_at     := "unknown"
+entity_name     := input.entity_name
+entity_type     := input.entity_type
+sector          := input.sector
+entity_category := input.entity_category
+assessed_at     := input.assessment_date
+
 # ── Article 21(2)(a) — Risk Analysis & Security Policies ────────────────────
 
 violations contains msg if {
@@ -234,11 +247,11 @@ compliance_report := {
     "framework":       "EU Network and Information Security Directive 2 (NIS2)",
     "directive":       "Directive (EU) 2022/2555",
     "transposition":   "October 2024",
-    "entity_name":     input.entity_name,
-    "entity_type":     input.entity_type,
-    "sector":          input.sector,
-    "entity_category": input.entity_category,
-    "assessed_at":     input.assessment_date,
+    "entity_name":     entity_name,
+    "entity_type":     entity_type,
+    "sector":          sector,
+    "entity_category": entity_category,
+    "assessed_at":     assessed_at,
     "compliant":       compliant,
     "total_controls":  34,
     "violations":      violations,

--- a/frameworks/compliance/nis2/tests/test_nis2_main.rego
+++ b/frameworks/compliance/nis2/tests/test_nis2_main.rego
@@ -1,0 +1,39 @@
+package nis2.main_test
+
+import rego.v1
+import data.nis2.main
+
+test_compliance_report_defined_on_empty_input if {
+    r := main.compliance_report with input as {}
+    r.framework == "EU Network and Information Security Directive 2 (NIS2)"
+    is_number(r.total_controls)
+    count(r.violations) >= 0
+}
+
+test_non_compliant_on_empty_input if {
+    not main.compliant with input as {}
+}
+
+test_violations_emitted_on_empty_input if {
+    count(main.violations) > 20 with input as {}
+}
+
+test_defaults_for_metadata if {
+    r := main.compliance_report with input as {}
+    r.entity_name == "unknown"
+    r.sector == "unknown"
+    r.assessed_at == "unknown"
+}
+
+test_metadata_picked_up_from_input if {
+    r := main.compliance_report with input as {
+        "entity_name": "Big Bank Plc",
+        "entity_type": "credit_institution",
+        "sector": "banking",
+        "entity_category": "essential",
+        "assessment_date": "2026-06-26",
+    }
+    r.entity_name == "Big Bank Plc"
+    r.sector == "banking"
+    r.assessed_at == "2026-06-26"
+}

--- a/frameworks/federal/fedramp/fedramp_main_adapter.rego
+++ b/frameworks/federal/fedramp/fedramp_main_adapter.rego
@@ -1,0 +1,60 @@
+package fedramp.main
+
+import rego.v1
+import data.fedramp as f
+
+# FedRAMP main adapter — exposes the standard contract
+# (compliance_report, violations, compliant) at /v1/data/fedramp/main/...
+# on top of the existing `package fedramp` policy module, which uses
+# its own names (fedramp_compliant, all_violations, fedramp_compliance_report).
+#
+# Generic playbook contract:
+#   /v1/data/fedramp/main/compliance_report
+#
+# The upstream module's fedramp_compliance_report references input fields
+# (impact_level, etc.) directly, so it goes undefined on empty input.
+# We compute the area summary here from the upstream violation_* sets so
+# the adapter's compliance_report is always defined.
+
+default compliant := false
+default impact_level := "unknown"
+default assessed_at := "unknown"
+
+compliant := f.fedramp_compliant
+
+impact_level := input.impact_level
+assessed_at := input.assessment_date
+
+violations := f.all_violations
+
+# Per-area summaries — recomputed locally instead of pulling from the
+# upstream report (which is input-dependent).
+area_summary := {
+    "authorization":           {"violations": count(f.violation_authorization),  "compliant": count(f.violation_authorization)  == 0},
+    "cryptography":            {"violations": count(f.violation_crypto),         "compliant": count(f.violation_crypto)         == 0},
+    "data_residency":          {"violations": count(f.violation_data_residency), "compliant": count(f.violation_data_residency) == 0},
+    "personnel_security":      {"violations": count(f.violation_personnel),      "compliant": count(f.violation_personnel)      == 0},
+    "continuous_monitoring":   {"violations": count(f.violation_conmon),         "compliant": count(f.violation_conmon)         == 0},
+    "third_party_assessment":  {"violations": count(f.violation_3pao),           "compliant": count(f.violation_3pao)           == 0},
+    "supply_chain":            {"violations": count(f.violation_scrm),           "compliant": count(f.violation_scrm)           == 0},
+}
+
+# FedRAMP control counts vary by impact level (Low: ~125, Moderate: ~325,
+# High: ~421). Reported here as the baseline summary.
+default total_controls := 325   # Moderate baseline (most common for cloud services)
+total_controls := 125 if impact_level == "low"
+total_controls := 325 if impact_level == "moderate"
+total_controls := 421 if impact_level == "high"
+
+compliance_report := {
+    "framework":       "FedRAMP",
+    "regulation":      "Federal Risk and Authorization Management Program",
+    "baseline":        "NIST SP 800-53 Rev 5 + FedRAMP overlays",
+    "impact_level":    impact_level,
+    "assessed_at":     assessed_at,
+    "compliant":       compliant,
+    "violations":      violations,
+    "violation_count": count(violations),
+    "total_controls":  total_controls,
+    "area_summary":    area_summary,
+}

--- a/frameworks/federal/fedramp/tests/test_fedramp_main.rego
+++ b/frameworks/federal/fedramp/tests/test_fedramp_main.rego
@@ -1,0 +1,37 @@
+package fedramp.main_test
+
+import rego.v1
+import data.fedramp.main
+
+test_compliance_report_defined_on_empty_input if {
+    r := main.compliance_report with input as {}
+    r.framework == "FedRAMP"
+    is_number(r.total_controls)
+    is_array(r.violations)
+}
+
+test_non_compliant_on_empty_input if {
+    not main.compliant with input as {}
+}
+
+test_violations_emitted_on_empty_input if {
+    count(main.violations) > 0 with input as {}
+}
+
+test_default_impact_level_is_moderate if {
+    r := main.compliance_report with input as {}
+    r.impact_level == "unknown"
+    r.total_controls == 325
+}
+
+test_low_impact_drops_total_controls if {
+    r := main.compliance_report with input as {"impact_level": "low"}
+    r.impact_level == "low"
+    r.total_controls == 125
+}
+
+test_high_impact_raises_total_controls if {
+    r := main.compliance_report with input as {"impact_level": "high"}
+    r.impact_level == "high"
+    r.total_controls == 421
+}

--- a/frameworks/federal/nist/ai_rmf/nist_ai_rmf_main.rego
+++ b/frameworks/federal/nist/ai_rmf/nist_ai_rmf_main.rego
@@ -1,0 +1,47 @@
+package nist_ai_rmf.main
+
+import rego.v1
+import data.nist.ai_rmf as ai
+
+# NIST AI RMF main adapter — exposes the standard contract
+# (compliance_report, violations, compliant) at
+# /v1/data/nist_ai_rmf/main/compliance_report
+# on top of the existing `package nist.ai_rmf` module.
+
+default compliant := false
+default ai_system_name := "unknown"
+default assessed_at := "unknown"
+
+compliant := ai.ai_rmf_compliant
+
+ai_system_name := input.ai_system.name
+assessed_at := input.assessment_date
+
+violations := ai.all_violations
+
+# Per-function summary computed locally (upstream's ai_rmf_compliance_report
+# references input.ai_system.name so it goes undefined on empty input).
+function_summary := {
+    "GOVERN":  {"violations": count(ai.violation_govern),          "compliant": count(ai.violation_govern)          == 0},
+    "MAP":     {"violations": count(ai.violation_map),             "compliant": count(ai.violation_map)             == 0},
+    "MEASURE": {"violations": count(ai.violation_measure),         "compliant": count(ai.violation_measure)         == 0},
+    "MANAGE":  {"violations": count(ai.violation_manage),          "compliant": count(ai.violation_manage)          == 0},
+    "TRUSTWORTHINESS": {"violations": count(ai.violation_trustworthiness), "compliant": count(ai.violation_trustworthiness) == 0},
+}
+
+# AI RMF 1.0 spans 4 core functions (GOVERN, MAP, MEASURE, MANAGE), each with
+# multiple categories. Reference catalog has ~70 categories/subcategories.
+total_controls := 70
+
+compliance_report := {
+    "framework":       "NIST AI Risk Management Framework (AI RMF)",
+    "version":         "1.0",
+    "published":       "2023-01",
+    "ai_system":       ai_system_name,
+    "assessed_at":     assessed_at,
+    "compliant":       compliant,
+    "violations":      violations,
+    "violation_count": count(violations),
+    "total_controls":  total_controls,
+    "function_summary": function_summary,
+}

--- a/frameworks/federal/nist/ai_rmf/tests/test_nist_ai_rmf_main.rego
+++ b/frameworks/federal/nist/ai_rmf/tests/test_nist_ai_rmf_main.rego
@@ -1,0 +1,38 @@
+package nist_ai_rmf.main_test
+
+import rego.v1
+import data.nist_ai_rmf.main
+
+test_compliance_report_defined_on_empty_input if {
+    r := main.compliance_report with input as {}
+    r.framework == "NIST AI Risk Management Framework (AI RMF)"
+    r.version == "1.0"
+    is_number(r.total_controls)
+    is_array(r.violations)
+}
+
+test_non_compliant_on_empty_input if {
+    not main.compliant with input as {}
+}
+
+test_violations_emitted_on_empty_input if {
+    count(main.violations) > 0 with input as {}
+}
+
+test_function_summary_present if {
+    r := main.compliance_report with input as {}
+    r.function_summary.GOVERN
+    r.function_summary.MAP
+    r.function_summary.MEASURE
+    r.function_summary.MANAGE
+    r.function_summary.TRUSTWORTHINESS
+}
+
+test_ai_system_name_from_input if {
+    r := main.compliance_report with input as {
+        "ai_system": {"name": "ResumeRanker"},
+        "assessment_date": "2026-06-26",
+    }
+    r.ai_system == "ResumeRanker"
+    r.assessed_at == "2026-06-26"
+}

--- a/frameworks/federal/nist/cybersecurity_framework_2.0/detect/detect.rego
+++ b/frameworks/federal/nist/cybersecurity_framework_2.0/detect/detect.rego
@@ -1,0 +1,112 @@
+package nist.csf.detect
+
+import rego.v1
+
+# NIST Cybersecurity Framework 2.0 — DETECT (DE) function
+# Develop and implement appropriate activities to identify the occurrence
+# of a cybersecurity event in a timely manner.
+
+default compliant := false
+
+# DE.AE — Anomalies and Events
+violation contains msg if {
+    not input.detect.anomalies_events.baseline_established
+    msg := "CSF DE.AE-01: Baseline of network operations and expected data flows not established"
+}
+
+violation contains msg if {
+    not input.detect.anomalies_events.detected_events_analyzed
+    msg := "CSF DE.AE-02: Detected events not analyzed to understand attack targets/methods"
+}
+
+violation contains msg if {
+    not input.detect.anomalies_events.event_data_aggregated
+    msg := "CSF DE.AE-03: Event data not aggregated and correlated from multiple sources"
+}
+
+violation contains msg if {
+    not input.detect.anomalies_events.impact_determined
+    msg := "CSF DE.AE-04: Impact of events not determined"
+}
+
+violation contains msg if {
+    not input.detect.anomalies_events.alert_thresholds_established
+    msg := "CSF DE.AE-05: Incident alert thresholds not established"
+}
+
+# DE.CM — Security Continuous Monitoring
+violation contains msg if {
+    not input.detect.continuous_monitoring.network_monitored
+    msg := "CSF DE.CM-01: Network not monitored to detect potential cybersecurity events"
+}
+
+violation contains msg if {
+    not input.detect.continuous_monitoring.physical_environment_monitored
+    msg := "CSF DE.CM-02: Physical environment not monitored for unauthorized access"
+}
+
+violation contains msg if {
+    not input.detect.continuous_monitoring.personnel_activity_monitored
+    msg := "CSF DE.CM-03: Personnel activity not monitored for anomalous behavior"
+}
+
+violation contains msg if {
+    not input.detect.continuous_monitoring.malicious_code_detected
+    msg := "CSF DE.CM-04: Malicious code not detected via continuous scanning"
+}
+
+violation contains msg if {
+    not input.detect.continuous_monitoring.unauthorized_mobile_code_detected
+    msg := "CSF DE.CM-05: Unauthorized mobile code not detected"
+}
+
+violation contains msg if {
+    not input.detect.continuous_monitoring.external_provider_activity_monitored
+    msg := "CSF DE.CM-06: External service provider activity not monitored"
+}
+
+violation contains msg if {
+    not input.detect.continuous_monitoring.unauthorized_personnel_devices_monitored
+    msg := "CSF DE.CM-07: Monitoring for unauthorized personnel/connections/devices/software not performed"
+}
+
+violation contains msg if {
+    not input.detect.continuous_monitoring.vulnerability_scans_performed
+    msg := "CSF DE.CM-08: Vulnerability scans not performed"
+}
+
+# DE.DP — Detection Processes
+violation contains msg if {
+    not input.detect.detection_processes.roles_defined
+    msg := "CSF DE.DP-01: Roles and responsibilities for detection not well-defined"
+}
+
+violation contains msg if {
+    not input.detect.detection_processes.activities_comply_with_requirements
+    msg := "CSF DE.DP-02: Detection activities don't comply with all applicable requirements"
+}
+
+violation contains msg if {
+    not input.detect.detection_processes.detection_processes_tested
+    msg := "CSF DE.DP-03: Detection processes not tested"
+}
+
+violation contains msg if {
+    not input.detect.detection_processes.event_information_communicated
+    msg := "CSF DE.DP-04: Event detection information not communicated"
+}
+
+violation contains msg if {
+    not input.detect.detection_processes.detection_processes_improved
+    msg := "CSF DE.DP-05: Detection processes not continuously improved"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "function": "DETECT",
+    "controls_evaluated": 18,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/federal/nist/cybersecurity_framework_2.0/govern/governance.rego
+++ b/frameworks/federal/nist/cybersecurity_framework_2.0/govern/governance.rego
@@ -193,3 +193,80 @@ nist_csf_govern_compliance := {
     "cybersecurity_procedures": cybersecurity_procedures,
     "overall_compliant": nist_csf_govern_compliant
 }
+
+# ── Violation set (for nist_csf.main orchestrator) ────────────────────────
+
+violation contains msg if {
+    not organizational_strategy_established
+    msg := "CSF GV.OC-01: Organizational cybersecurity strategy not documented/approved/reviewed"
+}
+
+violation contains msg if {
+    not cybersecurity_governance_established
+    msg := "CSF GV.OC-02: Cybersecurity governance structure lacks defined roles or accountability"
+}
+
+violation contains msg if {
+    not cybersecurity_policy_established
+    msg := "CSF GV.OC-03: Cybersecurity policy not established/current/communicated"
+}
+
+violation contains msg if {
+    not roles_responsibilities_established
+    msg := "CSF GV.OC-04: Cybersecurity roles/responsibilities not documented or assigned"
+}
+
+violation contains msg if {
+    not supply_chain_risk_management
+    msg := "CSF GV.OC-05: Supply chain risk management program not in place"
+}
+
+violation contains msg if {
+    not risk_management_strategy
+    msg := "CSF GV.RM-01: Risk management strategy not documented with tolerance/appetite"
+}
+
+violation contains msg if {
+    not risk_analysis_prioritization
+    msg := "CSF GV.RM-02: Risk analysis, prioritization, and response plans missing"
+}
+
+violation contains msg if {
+    not risk_mitigation_prioritized
+    msg := "CSF GV.RM-03: Risk mitigation actions not prioritized with timelines"
+}
+
+violation contains msg if {
+    not strategic_direction_informs_risk
+    msg := "CSF GV.RM-04: Strategic direction not linked to risk management decisions"
+}
+
+violation contains msg if {
+    not standardized_risk_calculation
+    msg := "CSF GV.RM-06: Standardized risk calculation methodology missing"
+}
+
+violation contains msg if {
+    not supply_chain_policy
+    msg := "CSF GV.SC-01: Supply chain cybersecurity policy not maintained"
+}
+
+violation contains msg if {
+    not supplier_pre_assessment
+    msg := "CSF GV.SC-04: Suppliers not assessed prior to establishing relationships"
+}
+
+violation contains msg if {
+    not supplier_ongoing_assessment
+    msg := "CSF GV.SC-05: Suppliers not continuously assessed during relationships"
+}
+
+violation contains msg if {
+    not cybersecurity_policy_maintenance
+    msg := "CSF GV.PO-01: Cybersecurity policy maintenance process missing"
+}
+
+violation contains msg if {
+    not cybersecurity_procedures
+    msg := "CSF GV.PO-02: Procedures to implement cybersecurity policy not maintained"
+}

--- a/frameworks/federal/nist/cybersecurity_framework_2.0/identify/identify.rego
+++ b/frameworks/federal/nist/cybersecurity_framework_2.0/identify/identify.rego
@@ -1,0 +1,111 @@
+package nist.csf.identify
+
+import rego.v1
+
+# NIST Cybersecurity Framework 2.0 — IDENTIFY (ID) function
+# Develop the organizational understanding to manage cybersecurity risk to
+# systems, people, assets, data, and capabilities.
+
+default compliant := false
+
+# ID.AM — Asset Management
+violation contains msg if {
+    not input.identify.asset_management.physical_devices_inventoried
+    msg := "CSF ID.AM-01: Physical devices and systems not inventoried"
+}
+
+violation contains msg if {
+    not input.identify.asset_management.software_platforms_inventoried
+    msg := "CSF ID.AM-02: Software platforms and applications not inventoried"
+}
+
+violation contains msg if {
+    not input.identify.asset_management.organizational_communication_mapped
+    msg := "CSF ID.AM-03: Organizational communication and data flows not mapped"
+}
+
+violation contains msg if {
+    not input.identify.asset_management.external_systems_cataloged
+    msg := "CSF ID.AM-04: External information systems not cataloged"
+}
+
+violation contains msg if {
+    not input.identify.asset_management.resources_prioritized
+    msg := "CSF ID.AM-05: Resources not prioritized based on classification/criticality"
+}
+
+# ID.BE — Business Environment
+violation contains msg if {
+    not input.identify.business_environment.role_in_supply_chain_identified
+    msg := "CSF ID.BE-01: Organization's role in the supply chain not identified/communicated"
+}
+
+violation contains msg if {
+    not input.identify.business_environment.role_in_critical_infrastructure_identified
+    msg := "CSF ID.BE-02: Role in critical infrastructure / sector not identified"
+}
+
+violation contains msg if {
+    not input.identify.business_environment.priorities_for_mission_established
+    msg := "CSF ID.BE-03: Priorities for organizational mission/objectives/activities not established"
+}
+
+# ID.GV — Governance (deferred to GOVERN function in CSF 2.0; included here for legacy)
+
+# ID.RA — Risk Assessment
+violation contains msg if {
+    not input.identify.risk_assessment.asset_vulnerabilities_identified
+    msg := "CSF ID.RA-01: Asset vulnerabilities not identified and documented"
+}
+
+violation contains msg if {
+    not input.identify.risk_assessment.cyber_threat_intelligence_received
+    msg := "CSF ID.RA-02: Cyber threat intelligence not received from information-sharing forums"
+}
+
+violation contains msg if {
+    not input.identify.risk_assessment.threats_identified_and_documented
+    msg := "CSF ID.RA-03: Internal and external threats not identified or documented"
+}
+
+violation contains msg if {
+    not input.identify.risk_assessment.potential_impacts_identified
+    msg := "CSF ID.RA-04: Potential business impacts and likelihoods not identified"
+}
+
+violation contains msg if {
+    not input.identify.risk_assessment.risk_determined
+    msg := "CSF ID.RA-05: Threats/vulnerabilities/likelihoods/impacts not used to determine risk"
+}
+
+# ID.RM — Risk Management Strategy
+violation contains msg if {
+    not input.identify.risk_management.processes_established
+    msg := "CSF ID.RM-01: Risk management processes not established/managed/agreed-to"
+}
+
+violation contains msg if {
+    not input.identify.risk_management.risk_tolerance_determined
+    msg := "CSF ID.RM-02: Organizational risk tolerance not determined or clearly expressed"
+}
+
+# ID.SC — Supply Chain Risk Management
+violation contains msg if {
+    not input.identify.supply_chain.cyber_scrm_processes_established
+    msg := "CSF ID.SC-01: Cyber supply chain risk management processes not established"
+}
+
+violation contains msg if {
+    not input.identify.supply_chain.suppliers_identified
+    msg := "CSF ID.SC-02: Suppliers and third-party partners not identified/prioritized/assessed"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "function": "IDENTIFY",
+    "controls_evaluated": 17,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/federal/nist/cybersecurity_framework_2.0/nist_csf_main.rego
+++ b/frameworks/federal/nist/cybersecurity_framework_2.0/nist_csf_main.rego
@@ -44,7 +44,7 @@ violations := all_violations
 
 # Total controls evaluated across functions. Reflects the violation rules
 # present in each module — update when adding/removing rules.
-total_controls := 95   # GV(15) + ID(17) + PR(15) + DE(18) + RS(16) + RC(6) + adjustments
+total_controls := 87   # GV(15) + ID(17) + PR(15) + DE(18) + RS(16) + RC(6)
 
 compliant if { count(violations) == 0 }
 

--- a/frameworks/federal/nist/cybersecurity_framework_2.0/nist_csf_main.rego
+++ b/frameworks/federal/nist/cybersecurity_framework_2.0/nist_csf_main.rego
@@ -1,0 +1,70 @@
+package nist_csf.main
+
+import rego.v1
+
+# NIST Cybersecurity Framework 2.0 — Master orchestrator.
+#
+# Aggregates violations across all six CSF 2.0 functions and exports
+# the compliance_report shape expected by ansible/playbooks/generic_framework_assessment.yml.
+#
+# OPA endpoint: POST <opa_security>/v1/data/nist_csf/main/compliance_report
+#
+# Functions aggregated:
+#   GV — Govern   (existing module)
+#   ID — Identify (new)
+#   PR — Protect  (existing module — AC subset)
+#   DE — Detect   (new)
+#   RS — Respond  (new)
+#   RC — Recover  (new)
+
+import data.nist.csf.govern   as gv
+import data.nist.csf.identify as id_
+import data.nist.csf.protect  as pr
+import data.nist.csf.detect   as de
+import data.nist.csf.respond  as rs
+import data.nist.csf.recover  as rc
+
+default compliant := false
+
+gv_v := [v | some v in gv.violation]
+id_v := [v | some v in id_.violation]
+pr_v := [v | some v in pr.violation]
+de_v := [v | some v in de.violation]
+rs_v := [v | some v in rs.violation]
+rc_v := [v | some v in rc.violation]
+
+# Nested 2-arg array.concat per repo convention
+_gv_id    := array.concat(gv_v, id_v)
+_gv_id_pr := array.concat(_gv_id, pr_v)
+_gv_id_pr_de := array.concat(_gv_id_pr, de_v)
+_gv_id_pr_de_rs := array.concat(_gv_id_pr_de, rs_v)
+all_violations := array.concat(_gv_id_pr_de_rs, rc_v)
+
+violations := all_violations
+
+# Total controls evaluated across functions. Reflects the violation rules
+# present in each module — update when adding/removing rules.
+total_controls := 95   # GV(15) + ID(17) + PR(15) + DE(18) + RS(16) + RC(6) + adjustments
+
+compliant if { count(violations) == 0 }
+
+default assessed_at := "unknown"
+assessed_at := input.assessment_date
+
+compliance_report := {
+    "framework":       "NIST Cybersecurity Framework 2.0",
+    "version":         "2.0",
+    "assessed_at":     assessed_at,
+    "total_controls":  total_controls,
+    "violations":      violations,
+    "violation_count": count(violations),
+    "compliant":       compliant,
+    "function_summary": {
+        "govern":   {"violations": count(gv_v), "compliant": count(gv_v) == 0},
+        "identify": {"violations": count(id_v), "compliant": count(id_v) == 0},
+        "protect":  {"violations": count(pr_v), "compliant": count(pr_v) == 0},
+        "detect":   {"violations": count(de_v), "compliant": count(de_v) == 0},
+        "respond":  {"violations": count(rs_v), "compliant": count(rs_v) == 0},
+        "recover":  {"violations": count(rc_v), "compliant": count(rc_v) == 0},
+    },
+}

--- a/frameworks/federal/nist/cybersecurity_framework_2.0/protect/access_control.rego
+++ b/frameworks/federal/nist/cybersecurity_framework_2.0/protect/access_control.rego
@@ -229,3 +229,80 @@ nist_csf_protect_compliance := {
     "backup_processes": backup_processes,
     "overall_compliant": nist_csf_protect_compliant
 }
+
+# ── Violation set (for nist_csf.main orchestrator) ────────────────────────
+
+violation contains msg if {
+    not identity_credential_management
+    msg := "CSF PR.AC-01: Identities and credentials not managed for authorized users/devices"
+}
+
+violation contains msg if {
+    not physical_access_management
+    msg := "CSF PR.AC-02: Physical access to assets not managed/protected"
+}
+
+violation contains msg if {
+    not remote_access_management
+    msg := "CSF PR.AC-03: Remote access not managed (VPN, MFA, encryption)"
+}
+
+violation contains msg if {
+    not access_permissions_management
+    msg := "CSF PR.AC-04: Access permissions/least privilege/SoD not enforced"
+}
+
+violation contains msg if {
+    not network_integrity_protection
+    msg := "CSF PR.AC-05: Network integrity (segmentation, isolation) not protected"
+}
+
+violation contains msg if {
+    not identity_proofing
+    msg := "CSF PR.AC-06: Identities not proofed/bound to credentials"
+}
+
+violation contains msg if {
+    not authentication_mechanisms
+    msg := "CSF PR.AC-07: Authentication mechanisms not strength-aligned with risk"
+}
+
+violation contains msg if {
+    not user_awareness_training
+    msg := "CSF PR.AT-01: All users not trained on cybersecurity awareness"
+}
+
+violation contains msg if {
+    not data_at_rest_protection
+    msg := "CSF PR.DS-01: Data at rest not protected (encryption, access control)"
+}
+
+violation contains msg if {
+    not data_in_transit_protection
+    msg := "CSF PR.DS-02: Data in transit not protected (TLS, VPN, encrypted channels)"
+}
+
+violation contains msg if {
+    not asset_lifecycle_management
+    msg := "CSF PR.DS-03: Assets not formally managed through removal/transfer/disposition"
+}
+
+violation contains msg if {
+    not data_leak_protection
+    msg := "CSF PR.DS-05: Data-leak protections not implemented"
+}
+
+violation contains msg if {
+    not integrity_checking
+    msg := "CSF PR.DS-06: Integrity-checking mechanisms not used on software/firmware/data"
+}
+
+violation contains msg if {
+    not baseline_configuration_management
+    msg := "CSF PR.IP-01: Baseline configuration not created/maintained"
+}
+
+violation contains msg if {
+    not backup_processes
+    msg := "CSF PR.IP-04: Backups not conducted, maintained, and tested"
+}

--- a/frameworks/federal/nist/cybersecurity_framework_2.0/recover/recover.rego
+++ b/frameworks/federal/nist/cybersecurity_framework_2.0/recover/recover.rego
@@ -1,0 +1,52 @@
+package nist.csf.recover
+
+import rego.v1
+
+# NIST Cybersecurity Framework 2.0 — RECOVER (RC) function
+# Develop and implement appropriate activities to maintain plans for resilience
+# and to restore any capabilities or services impaired due to an incident.
+
+default compliant := false
+
+# RC.RP — Recovery Planning
+violation contains msg if {
+    not input.recover.recovery_planning.recovery_plan_executed
+    msg := "CSF RC.RP-01: Recovery plan not executed during or after a cybersecurity incident"
+}
+
+# RC.IM — Improvements
+violation contains msg if {
+    not input.recover.improvements.recovery_plans_incorporate_lessons
+    msg := "CSF RC.IM-01: Recovery plans don't incorporate lessons learned"
+}
+
+violation contains msg if {
+    not input.recover.improvements.recovery_strategies_updated
+    msg := "CSF RC.IM-02: Recovery strategies not updated"
+}
+
+# RC.CO — Communications
+violation contains msg if {
+    not input.recover.communications.public_relations_managed
+    msg := "CSF RC.CO-01: Public relations not managed during recovery"
+}
+
+violation contains msg if {
+    not input.recover.communications.reputation_repaired
+    msg := "CSF RC.CO-02: Reputation repair after an event not performed"
+}
+
+violation contains msg if {
+    not input.recover.communications.recovery_activities_communicated
+    msg := "CSF RC.CO-03: Recovery activities not communicated to internal stakeholders and leadership"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "function": "RECOVER",
+    "controls_evaluated": 6,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/federal/nist/cybersecurity_framework_2.0/respond/respond.rego
+++ b/frameworks/federal/nist/cybersecurity_framework_2.0/respond/respond.rego
@@ -1,0 +1,104 @@
+package nist.csf.respond
+
+import rego.v1
+
+# NIST Cybersecurity Framework 2.0 — RESPOND (RS) function
+# Develop and implement appropriate activities to take action regarding
+# a detected cybersecurity incident.
+
+default compliant := false
+
+# RS.RP — Response Planning
+violation contains msg if {
+    not input.respond.response_planning.response_plan_executed
+    msg := "CSF RS.RP-01: Response plan not executed during or after an incident"
+}
+
+# RS.CO — Communications
+violation contains msg if {
+    not input.respond.communications.personnel_know_roles
+    msg := "CSF RS.CO-01: Personnel don't know their roles when a response is needed"
+}
+
+violation contains msg if {
+    not input.respond.communications.events_reported_within_criteria
+    msg := "CSF RS.CO-02: Incidents not reported consistent with established criteria"
+}
+
+violation contains msg if {
+    not input.respond.communications.information_shared_with_stakeholders
+    msg := "CSF RS.CO-03: Response information not shared with internal stakeholders"
+}
+
+violation contains msg if {
+    not input.respond.communications.coordination_with_stakeholders
+    msg := "CSF RS.CO-04: Coordination with external stakeholders not aligned with plan"
+}
+
+violation contains msg if {
+    not input.respond.communications.voluntary_information_sharing
+    msg := "CSF RS.CO-05: Voluntary information sharing with external stakeholders not performed"
+}
+
+# RS.AN — Analysis
+violation contains msg if {
+    not input.respond.analysis.notifications_investigated
+    msg := "CSF RS.AN-01: Notifications from detection systems not investigated"
+}
+
+violation contains msg if {
+    not input.respond.analysis.incident_impact_understood
+    msg := "CSF RS.AN-02: Impact of incident not understood"
+}
+
+violation contains msg if {
+    not input.respond.analysis.forensics_performed
+    msg := "CSF RS.AN-03: Forensics not performed during/after incident"
+}
+
+violation contains msg if {
+    not input.respond.analysis.incidents_categorized
+    msg := "CSF RS.AN-04: Incidents not categorized consistent with response plan"
+}
+
+violation contains msg if {
+    not input.respond.analysis.vulnerability_disclosures_addressed
+    msg := "CSF RS.AN-05: Vulnerability disclosures from internal/external sources not addressed"
+}
+
+# RS.MI — Mitigation
+violation contains msg if {
+    not input.respond.mitigation.incidents_contained
+    msg := "CSF RS.MI-01: Incidents not contained"
+}
+
+violation contains msg if {
+    not input.respond.mitigation.incidents_mitigated
+    msg := "CSF RS.MI-02: Incidents not mitigated"
+}
+
+violation contains msg if {
+    not input.respond.mitigation.newly_identified_vulnerabilities_mitigated
+    msg := "CSF RS.MI-03: Newly identified vulnerabilities not mitigated or accepted as residual risk"
+}
+
+# RS.IM — Improvements
+violation contains msg if {
+    not input.respond.improvements.response_plans_incorporate_lessons
+    msg := "CSF RS.IM-01: Response plans don't incorporate lessons learned"
+}
+
+violation contains msg if {
+    not input.respond.improvements.response_strategies_updated
+    msg := "CSF RS.IM-02: Response strategies not updated"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "function": "RESPOND",
+    "controls_evaluated": 16,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/federal/nist/cybersecurity_framework_2.0/tests/test_nist_csf_main.rego
+++ b/frameworks/federal/nist/cybersecurity_framework_2.0/tests/test_nist_csf_main.rego
@@ -1,0 +1,57 @@
+package nist_csf.main_test
+
+import rego.v1
+
+import data.nist_csf.main
+
+# Smoke test — empty input should produce all violations and non-compliant.
+test_empty_input_non_compliant if {
+    not main.compliant with input as {}
+}
+
+test_empty_input_produces_violations if {
+    count(main.violations) > 50 with input as {}
+}
+
+test_compliance_report_shape if {
+    r := main.compliance_report with input as {}
+    r.framework == "NIST Cybersecurity Framework 2.0"
+    is_number(r.total_controls)
+    is_array(r.violations)
+    is_number(r.violation_count)
+    r.compliant == false
+}
+
+test_function_summary_has_all_six_functions if {
+    r := main.compliance_report with input as {}
+    r.function_summary.govern
+    r.function_summary.identify
+    r.function_summary.protect
+    r.function_summary.detect
+    r.function_summary.respond
+    r.function_summary.recover
+}
+
+# Partial-pass test — just the Recover function passes (only 6 controls).
+recover_fully_compliant_input := {
+    "recover": {
+        "recovery_planning": {"recovery_plan_executed": true},
+        "improvements": {"recovery_plans_incorporate_lessons": true, "recovery_strategies_updated": true},
+        "communications": {
+            "public_relations_managed": true,
+            "reputation_repaired": true,
+            "recovery_activities_communicated": true,
+        },
+    },
+}
+
+test_recover_function_passes_when_all_recover_inputs_true if {
+    r := main.compliance_report with input as recover_fully_compliant_input
+    r.function_summary.recover.compliant == true
+}
+
+test_other_functions_still_fail_when_only_recover_passes if {
+    r := main.compliance_report with input as recover_fully_compliant_input
+    r.function_summary.govern.compliant == false
+    r.function_summary.identify.compliant == false
+}

--- a/frameworks/federal/nist/sp_800_53/access_control/ac_controls.rego
+++ b/frameworks/federal/nist/sp_800_53/access_control/ac_controls.rego
@@ -232,3 +232,111 @@ nist_sp800_53_ac_compliance := {
     "reference_monitor": reference_monitor,
     "overall_compliant": nist_sp800_53_ac_compliant
 }
+
+# ── Violation set (for nist_800_53.main orchestrator) ─────────────────────
+# Boolean rules above are kept for compatibility with existing
+# comprehensive_test_suite.rego; this set turns them into the
+# violation-message shape required by the framework master.
+
+violation contains msg if {
+    not access_control_policy
+    msg := "NIST AC-1: Access control policy/procedures not documented, disseminated, or reviewed"
+}
+
+violation contains msg if {
+    not account_management
+    msg := "NIST AC-2: Account management lacks automated tooling, approval, reviews, or timely removal"
+}
+
+violation contains msg if {
+    not access_enforcement
+    msg := "NIST AC-3: Access enforcement does not implement MAC, DAC, and RBAC"
+}
+
+violation contains msg if {
+    not information_flow_enforcement
+    msg := "NIST AC-4: Information flow enforcement lacks security labels or automated flow control"
+}
+
+violation contains msg if {
+    not separation_of_duties
+    msg := "NIST AC-5: Separation of duties not implemented for critical functions"
+}
+
+violation contains msg if {
+    not least_privilege
+    msg := "NIST AC-6: Least privilege not enforced for privileged or non-privileged access"
+}
+
+violation contains msg if {
+    not unsuccessful_logon_attempts
+    msg := "NIST AC-7: Logon attempts not lockout-controlled (max 5 attempts, 15-min lockout)"
+}
+
+violation contains msg if {
+    not system_use_notification
+    msg := "NIST AC-8: System use notification banner/acknowledgment/consent missing"
+}
+
+violation contains msg if {
+    not previous_logon_notification
+    msg := "NIST AC-9: Previous logon notification not displayed to users"
+}
+
+violation contains msg if {
+    not concurrent_session_control
+    msg := "NIST AC-10: Concurrent session limits not configured"
+}
+
+violation contains msg if {
+    not session_lock
+    msg := "NIST AC-11: Session lock missing (inactivity timeout ≤15 min + pattern hiding required)"
+}
+
+violation contains msg if {
+    not session_termination
+    msg := "NIST AC-12: Session termination (automatic/user-initiated/admin) not supported"
+}
+
+violation contains msg if {
+    not permitted_actions_restricted
+    msg := "NIST AC-14: Permitted unauthenticated actions exceed approved list"
+}
+
+violation contains msg if {
+    not remote_access_control
+    msg := "NIST AC-17: Remote access not authorized/encrypted/monitored"
+}
+
+violation contains msg if {
+    not wireless_access_control
+    msg := "NIST AC-18: Wireless access not authorized/encrypted/monitored"
+}
+
+violation contains msg if {
+    not mobile_device_access_control
+    msg := "NIST AC-19: Mobile device access control missing usage restrictions or config requirements"
+}
+
+violation contains msg if {
+    not external_systems_control
+    msg := "NIST AC-20: External system use not authorized or governed by user agreements"
+}
+
+violation contains msg if {
+    not publicly_accessible_content
+    msg := "NIST AC-22: Publicly accessible content lacks review/removal process"
+}
+
+default compliant := false
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "family": "AC",
+    "name":   "Access Control",
+    "controls_evaluated": 18,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/federal/nist/sp_800_53/audit_accountability/au_controls.rego
+++ b/frameworks/federal/nist/sp_800_53/audit_accountability/au_controls.rego
@@ -58,8 +58,12 @@ violation contains msg if {
 }
 
 violation contains msg if {
-    input.au_controls.retention_period_days < 365
-    msg := sprintf("NIST AU-11: Audit record retention %d days is below 365-day minimum", [input.au_controls.retention_period_days])
+    # object.get defaults missing/undefined to 0 so the rule still fires
+    # when retention_period_days is absent (otherwise the undefined comparison
+    # silently skips the control and skews the violation count).
+    object.get(input.au_controls, "retention_period_days", 0) < 365
+    msg := sprintf("NIST AU-11: Audit record retention %d days is below 365-day minimum",
+                   [object.get(input.au_controls, "retention_period_days", 0)])
 }
 
 violation contains msg if {

--- a/frameworks/federal/nist/sp_800_53/audit_accountability/au_controls.rego
+++ b/frameworks/federal/nist/sp_800_53/audit_accountability/au_controls.rego
@@ -1,0 +1,79 @@
+package nist.sp800_53.audit_accountability
+
+import rego.v1
+
+# NIST SP 800-53 Rev 5 — Audit and Accountability (AU) Family
+# Generation, protection, review, and analysis of audit records.
+
+default compliant := false
+
+violation contains msg if {
+    not input.au_controls.policy.documented
+    msg := "NIST AU-1: Audit and accountability policy not documented"
+}
+
+violation contains msg if {
+    not input.au_controls.event_logging.enabled
+    msg := "NIST AU-2: Auditable events not identified or logging not enabled"
+}
+
+violation contains msg if {
+    not input.au_controls.content_of_records.adequate
+    msg := "NIST AU-3: Audit record content lacks who/what/when/where/source/outcome"
+}
+
+violation contains msg if {
+    not input.au_controls.storage_capacity.adequate
+    msg := "NIST AU-4: Audit record storage capacity insufficient for required retention"
+}
+
+violation contains msg if {
+    not input.au_controls.response_to_failures.alerting
+    msg := "NIST AU-5: Audit logging failure does not alert appropriate personnel"
+}
+
+violation contains msg if {
+    not input.au_controls.review_and_analysis.regular
+    msg := "NIST AU-6: Audit records not regularly reviewed or analyzed"
+}
+
+violation contains msg if {
+    not input.au_controls.reduction_and_reporting.tools_available
+    msg := "NIST AU-7: Audit record reduction/report-generation tooling unavailable"
+}
+
+violation contains msg if {
+    not input.au_controls.time_stamps.synchronized
+    msg := "NIST AU-8: Audit record time stamps not synchronized to authoritative source"
+}
+
+violation contains msg if {
+    not input.au_controls.protection_of_records.tamper_resistant
+    msg := "NIST AU-9: Audit records not protected against unauthorized modification/deletion"
+}
+
+violation contains msg if {
+    not input.au_controls.non_repudiation.implemented
+    msg := "NIST AU-10: Non-repudiation of actions by individuals not implemented"
+}
+
+violation contains msg if {
+    input.au_controls.retention_period_days < 365
+    msg := sprintf("NIST AU-11: Audit record retention %d days is below 365-day minimum", [input.au_controls.retention_period_days])
+}
+
+violation contains msg if {
+    not input.au_controls.generation.required_events_captured
+    msg := "NIST AU-12: Audit record generation does not capture all required events"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "family": "AU",
+    "name":   "Audit and Accountability",
+    "controls_evaluated": 12,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/federal/nist/sp_800_53/configuration_management/cm_controls.rego
+++ b/frameworks/federal/nist/sp_800_53/configuration_management/cm_controls.rego
@@ -1,0 +1,74 @@
+package nist.sp800_53.configuration_management
+
+import rego.v1
+
+# NIST SP 800-53 Rev 5 — Configuration Management (CM) Family
+# Baseline configurations, change control, and configuration monitoring.
+
+default compliant := false
+
+violation contains msg if {
+    not input.cm_controls.policy.documented
+    msg := "NIST CM-1: Configuration management policy not documented"
+}
+
+violation contains msg if {
+    not input.cm_controls.baseline_config.maintained
+    msg := "NIST CM-2: Baseline configuration not established or maintained for the system"
+}
+
+violation contains msg if {
+    not input.cm_controls.change_control.process_exists
+    msg := "NIST CM-3: Configuration change control process not in place"
+}
+
+violation contains msg if {
+    not input.cm_controls.security_impact_analysis.performed
+    msg := "NIST CM-4: Security impact analysis not performed before changes are deployed"
+}
+
+violation contains msg if {
+    not input.cm_controls.access_restrictions_for_change.enforced
+    msg := "NIST CM-5: Access restrictions for change are not enforced"
+}
+
+violation contains msg if {
+    not input.cm_controls.configuration_settings.documented
+    msg := "NIST CM-6: Mandatory configuration settings not documented or applied"
+}
+
+violation contains msg if {
+    not input.cm_controls.least_functionality.enforced
+    msg := "NIST CM-7: Least functionality (disable unused services/ports) not enforced"
+}
+
+violation contains msg if {
+    not input.cm_controls.system_component_inventory.maintained
+    msg := "NIST CM-8: System component inventory not maintained or accurate"
+}
+
+violation contains msg if {
+    not input.cm_controls.config_management_plan.documented
+    msg := "NIST CM-9: Configuration management plan not documented"
+}
+
+violation contains msg if {
+    not input.cm_controls.software_usage_restrictions.enforced
+    msg := "NIST CM-10: Software usage restrictions (licensing/copy controls) not enforced"
+}
+
+violation contains msg if {
+    not input.cm_controls.user_installed_software.restricted
+    msg := "NIST CM-11: User-installed software is not restricted by policy"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "family": "CM",
+    "name":   "Configuration Management",
+    "controls_evaluated": 11,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/federal/nist/sp_800_53/identification_authentication/ia_controls.rego
+++ b/frameworks/federal/nist/sp_800_53/identification_authentication/ia_controls.rego
@@ -1,0 +1,79 @@
+package nist.sp800_53.identification_authentication
+
+import rego.v1
+
+# NIST SP 800-53 Rev 5 — Identification and Authentication (IA) Family
+# Identify and authenticate users, devices, processes acting on behalf of users.
+
+default compliant := false
+
+violation contains msg if {
+    not input.ia_controls.policy.documented
+    msg := "NIST IA-1: Identification and authentication policy not documented"
+}
+
+violation contains msg if {
+    not input.ia_controls.user_id_auth.uniquely_identified
+    msg := "NIST IA-2: Organizational users not uniquely identified and authenticated"
+}
+
+violation contains msg if {
+    not input.ia_controls.user_id_auth.mfa_for_privileged
+    msg := "NIST IA-2(1): Multi-factor authentication not required for privileged accounts"
+}
+
+violation contains msg if {
+    not input.ia_controls.user_id_auth.mfa_for_non_privileged
+    msg := "NIST IA-2(2): Multi-factor authentication not required for non-privileged accounts"
+}
+
+violation contains msg if {
+    not input.ia_controls.device_identification.implemented
+    msg := "NIST IA-3: Device identification and authentication not implemented"
+}
+
+violation contains msg if {
+    not input.ia_controls.identifier_management.unique_per_user
+    msg := "NIST IA-4: Identifier management does not assign unique IDs per user"
+}
+
+violation contains msg if {
+    not input.ia_controls.authenticator_management.complexity_enforced
+    msg := "NIST IA-5: Authenticator management lacks complexity/lifetime enforcement"
+}
+
+violation contains msg if {
+    not input.ia_controls.authenticator_management.encrypted_in_transit
+    msg := "NIST IA-5(1): Authenticators not protected in transit"
+}
+
+violation contains msg if {
+    not input.ia_controls.authenticator_management.encrypted_at_rest
+    msg := "NIST IA-5(1): Stored authenticators not cryptographically protected at rest"
+}
+
+violation contains msg if {
+    not input.ia_controls.authenticator_feedback.obscured
+    msg := "NIST IA-6: Authenticator feedback (e.g., password entry) is not obscured"
+}
+
+violation contains msg if {
+    not input.ia_controls.cryptographic_module_auth.fips_validated
+    msg := "NIST IA-7: Cryptographic module authentication not FIPS-validated"
+}
+
+violation contains msg if {
+    not input.ia_controls.non_organizational_users.identified
+    msg := "NIST IA-8: Non-organizational users not uniquely identified and authenticated"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "family": "IA",
+    "name":   "Identification and Authentication",
+    "controls_evaluated": 12,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/federal/nist/sp_800_53/incident_response/ir_controls.rego
+++ b/frameworks/federal/nist/sp_800_53/incident_response/ir_controls.rego
@@ -1,0 +1,64 @@
+package nist.sp800_53.incident_response
+
+import rego.v1
+
+# NIST SP 800-53 Rev 5 — Incident Response (IR) Family
+# Detect, analyze, contain, eradicate, and recover from incidents.
+
+default compliant := false
+
+violation contains msg if {
+    not input.ir_controls.policy.documented
+    msg := "NIST IR-1: Incident response policy and procedures not documented"
+}
+
+violation contains msg if {
+    not input.ir_controls.training.completed_within_year
+    msg := "NIST IR-2: Incident response training not completed within the last year"
+}
+
+violation contains msg if {
+    not input.ir_controls.testing.exercised_within_year
+    msg := "NIST IR-3: Incident response plan not tested/exercised within the last year"
+}
+
+violation contains msg if {
+    not input.ir_controls.handling.process_defined
+    msg := "NIST IR-4: Incident handling process (preparation/detection/analysis/containment/eradication/recovery) not defined"
+}
+
+violation contains msg if {
+    not input.ir_controls.monitoring.continuous
+    msg := "NIST IR-5: Continuous incident monitoring not in place"
+}
+
+violation contains msg if {
+    not input.ir_controls.reporting.timely
+    msg := "NIST IR-6: Incident reporting to internal/external parties not timely"
+}
+
+violation contains msg if {
+    not input.ir_controls.assistance.available
+    msg := "NIST IR-7: Incident response assistance/coordination resources not available"
+}
+
+violation contains msg if {
+    not input.ir_controls.plan.documented
+    msg := "NIST IR-8: Documented incident response plan does not exist"
+}
+
+violation contains msg if {
+    not input.ir_controls.information_spillage.process_defined
+    msg := "NIST IR-9: Information spillage response process not defined"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "family": "IR",
+    "name":   "Incident Response",
+    "controls_evaluated": 9,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/federal/nist/sp_800_53/nist_800_53_main.rego
+++ b/frameworks/federal/nist/sp_800_53/nist_800_53_main.rego
@@ -1,0 +1,89 @@
+package nist_800_53.main
+
+import rego.v1
+
+# NIST SP 800-53 Rev 5 — Master orchestrator.
+#
+# Aggregates violations from the per-family modules under
+# data.nist.sp800_53.* and exports the compliance_report shape
+# expected by ansible/playbooks/generic_framework_assessment.yml.
+#
+# OPA endpoint: POST <opa_security>/v1/data/nist_800_53/main/compliance_report
+#
+# Families currently aggregated (others may be added incrementally):
+#   AC — Access Control
+#   AU — Audit and Accountability
+#   CM — Configuration Management
+#   IA — Identification and Authentication
+#   IR — Incident Response
+#   SC — System and Communications Protection
+#   SI — System and Information Integrity
+
+import data.nist.sp800_53.access_control as ac
+import data.nist.sp800_53.audit_accountability as au
+import data.nist.sp800_53.configuration_management as cm
+import data.nist.sp800_53.identification_authentication as ia
+import data.nist.sp800_53.incident_response as ir
+import data.nist.sp800_53.system_communications as sc
+import data.nist.sp800_53.system_information_integrity as si
+
+default compliant := false
+
+ac_v := [v | some v in ac.violation]
+au_v := [v | some v in au.violation]
+cm_v := [v | some v in cm.violation]
+ia_v := [v | some v in ia.violation]
+ir_v := [v | some v in ir.violation]
+sc_v := [v | some v in sc.violation]
+si_v := [v | some v in si.violation]
+
+# Nested 2-arg array.concat per repo convention
+_ac_au       := array.concat(ac_v, au_v)
+_ac_au_cm    := array.concat(_ac_au, cm_v)
+_acm_ia      := array.concat(_ac_au_cm, ia_v)
+_acm_ia_ir   := array.concat(_acm_ia, ir_v)
+_acm_ia_ir_sc := array.concat(_acm_ia_ir, sc_v)
+all_violations := array.concat(_acm_ia_ir_sc, si_v)
+
+violations := all_violations
+
+# Controls evaluated across all aggregated families. Update when new
+# families are wired in.
+total_controls := 91   # AC(18) + AU(12) + CM(11) + IA(12) + IR(9) + SC(17) + SI(13) — minus 1
+
+compliant if { count(violations) == 0 }
+
+# Default for fields supplied via input. Without a default, an undefined
+# reference inside the object literal would make the whole report undefined
+# (and the OPA endpoint would return {}).
+default assessed_at := "unknown"
+assessed_at := input.assessment_date
+
+compliance_report := {
+    "framework":       "NIST SP 800-53 Rev 5",
+    "version":         "Rev 5",
+    "regulation":      "FISMA / FedRAMP baseline reference catalog",
+    "assessed_at":     assessed_at,
+    "total_controls":  total_controls,
+    "violations":      violations,
+    "violation_count": count(violations),
+    "compliant":       compliant,
+    "families_evaluated": {
+        "AC": ac.compliance_report.family,
+        "AU": au.compliance_report.family,
+        "CM": cm.compliance_report.family,
+        "IA": ia.compliance_report.family,
+        "IR": ir.compliance_report.family,
+        "SC": sc.compliance_report.family,
+        "SI": si.compliance_report.family,
+    },
+    "family_summary": {
+        "AC": {"violations": count(ac_v), "compliant": count(ac_v) == 0},
+        "AU": {"violations": count(au_v), "compliant": count(au_v) == 0},
+        "CM": {"violations": count(cm_v), "compliant": count(cm_v) == 0},
+        "IA": {"violations": count(ia_v), "compliant": count(ia_v) == 0},
+        "IR": {"violations": count(ir_v), "compliant": count(ir_v) == 0},
+        "SC": {"violations": count(sc_v), "compliant": count(sc_v) == 0},
+        "SI": {"violations": count(si_v), "compliant": count(si_v) == 0},
+    },
+}

--- a/frameworks/federal/nist/sp_800_53/nist_800_53_main.rego
+++ b/frameworks/federal/nist/sp_800_53/nist_800_53_main.rego
@@ -49,7 +49,7 @@ violations := all_violations
 
 # Controls evaluated across all aggregated families. Update when new
 # families are wired in.
-total_controls := 91   # AC(18) + AU(12) + CM(11) + IA(12) + IR(9) + SC(17) + SI(13) — minus 1
+total_controls := 91   # AC(18) + AU(12) + CM(11) + IA(12) + IR(9) + SC(17) + SI(12)
 
 compliant if { count(violations) == 0 }
 

--- a/frameworks/federal/nist/sp_800_53/system_communications/sc_controls.rego
+++ b/frameworks/federal/nist/sp_800_53/system_communications/sc_controls.rego
@@ -1,0 +1,104 @@
+package nist.sp800_53.system_communications
+
+import rego.v1
+
+# NIST SP 800-53 Rev 5 — System and Communications Protection (SC) Family
+# Boundary protection, transmission confidentiality/integrity, key management.
+
+default compliant := false
+
+violation contains msg if {
+    not input.sc_controls.policy.documented
+    msg := "NIST SC-1: System and communications protection policy not documented"
+}
+
+violation contains msg if {
+    not input.sc_controls.app_partitioning.separated
+    msg := "NIST SC-2: User functionality is not separated from system management functionality"
+}
+
+violation contains msg if {
+    not input.sc_controls.security_function_isolation.implemented
+    msg := "NIST SC-3: Security functions not isolated from non-security functions"
+}
+
+violation contains msg if {
+    not input.sc_controls.denial_of_service.protections
+    msg := "NIST SC-5: Denial-of-service protections not in place"
+}
+
+violation contains msg if {
+    not input.sc_controls.boundary_protection.deployed
+    msg := "NIST SC-7: System boundary protection not deployed at managed interfaces"
+}
+
+violation contains msg if {
+    not input.sc_controls.transmission_confidentiality.encrypted
+    msg := "NIST SC-8: Transmission confidentiality not protected via cryptographic mechanisms"
+}
+
+violation contains msg if {
+    not input.sc_controls.transmission_integrity.protected
+    msg := "NIST SC-8(1): Transmission integrity not protected via cryptographic mechanisms"
+}
+
+violation contains msg if {
+    not input.sc_controls.network_disconnect.timeout_configured
+    msg := "NIST SC-10: Network session disconnect timeout not configured"
+}
+
+violation contains msg if {
+    not input.sc_controls.cryptographic_key_mgmt.documented
+    msg := "NIST SC-12: Cryptographic key management process not documented"
+}
+
+violation contains msg if {
+    not input.sc_controls.cryptographic_protection.fips_validated
+    msg := "NIST SC-13: Cryptographic mechanisms not FIPS-validated"
+}
+
+violation contains msg if {
+    not input.sc_controls.collaborative_devices.disabled_when_unused
+    msg := "NIST SC-15: Collaborative computing devices (mic/camera) not disabled when unused"
+}
+
+violation contains msg if {
+    not input.sc_controls.public_key_infrastructure.certificates_managed
+    msg := "NIST SC-17: Public key certificates not issued/managed by authorized PKI"
+}
+
+violation contains msg if {
+    not input.sc_controls.mobile_code.controls_enforced
+    msg := "NIST SC-18: Mobile code controls (allow/deny lists) not enforced"
+}
+
+violation contains msg if {
+    not input.sc_controls.voip.controls_enforced
+    msg := "NIST SC-19: VoIP usage restrictions and implementation guidance not enforced"
+}
+
+violation contains msg if {
+    not input.sc_controls.secure_dns.dnssec_enforced
+    msg := "NIST SC-20/21: Secure name/address resolution (DNSSEC) not enforced"
+}
+
+violation contains msg if {
+    not input.sc_controls.session_authenticity.protected
+    msg := "NIST SC-23: Session authenticity not protected (session ID randomness, timeouts)"
+}
+
+violation contains msg if {
+    not input.sc_controls.protection_of_info_at_rest.encrypted
+    msg := "NIST SC-28: Information at rest not protected via encryption"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "family": "SC",
+    "name":   "System and Communications Protection",
+    "controls_evaluated": 17,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/federal/nist/sp_800_53/system_information_integrity/si_controls.rego
+++ b/frameworks/federal/nist/sp_800_53/system_information_integrity/si_controls.rego
@@ -1,0 +1,79 @@
+package nist.sp800_53.system_information_integrity
+
+import rego.v1
+
+# NIST SP 800-53 Rev 5 — System and Information Integrity (SI) Family
+# Flaw remediation, malicious code protection, monitoring, integrity verification.
+
+default compliant := false
+
+violation contains msg if {
+    not input.si_controls.policy.documented
+    msg := "NIST SI-1: System and information integrity policy not documented"
+}
+
+violation contains msg if {
+    not input.si_controls.flaw_remediation.timely
+    msg := "NIST SI-2: Flaw remediation (patching) not performed within defined timeframes"
+}
+
+violation contains msg if {
+    not input.si_controls.malicious_code_protection.deployed
+    msg := "NIST SI-3: Malicious code protection (antivirus/EDR) not deployed at entry/exit points"
+}
+
+violation contains msg if {
+    not input.si_controls.system_monitoring.continuous
+    msg := "NIST SI-4: System monitoring (IDS/IPS, log review) not continuous"
+}
+
+violation contains msg if {
+    not input.si_controls.security_alerts.acted_upon
+    msg := "NIST SI-5: Security alerts/advisories not received and acted upon"
+}
+
+violation contains msg if {
+    not input.si_controls.security_function_verification.tested
+    msg := "NIST SI-6: Security function verification not periodically tested"
+}
+
+violation contains msg if {
+    not input.si_controls.software_firmware_integrity.verified
+    msg := "NIST SI-7: Software and firmware integrity not verified before execution"
+}
+
+violation contains msg if {
+    not input.si_controls.spam_protection.enabled
+    msg := "NIST SI-8: Spam protection not enabled at gateways or endpoints"
+}
+
+violation contains msg if {
+    not input.si_controls.input_validation.enforced
+    msg := "NIST SI-10: Information input validation not enforced"
+}
+
+violation contains msg if {
+    not input.si_controls.error_handling.no_info_disclosure
+    msg := "NIST SI-11: Error handling discloses sensitive information"
+}
+
+violation contains msg if {
+    not input.si_controls.information_management_retention.policy_enforced
+    msg := "NIST SI-12: Information management/retention policies not enforced"
+}
+
+violation contains msg if {
+    not input.si_controls.memory_protection.enabled
+    msg := "NIST SI-16: Memory protection (ASLR, DEP, NX) not enabled"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "family": "SI",
+    "name":   "System and Information Integrity",
+    "controls_evaluated": 13,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/federal/nist/sp_800_53/system_information_integrity/si_controls.rego
+++ b/frameworks/federal/nist/sp_800_53/system_information_integrity/si_controls.rego
@@ -72,7 +72,7 @@ compliant if { count(violation) == 0 }
 compliance_report := {
     "family": "SI",
     "name":   "System and Information Integrity",
-    "controls_evaluated": 13,
+    "controls_evaluated": 12,
     "violations": violation,
     "violation_count": count(violation),
     "compliant": compliant,

--- a/frameworks/federal/nist/sp_800_53/tests/test_nist_800_53_main.rego
+++ b/frameworks/federal/nist/sp_800_53/tests/test_nist_800_53_main.rego
@@ -1,0 +1,146 @@
+package nist_800_53.main_test
+
+import rego.v1
+
+import data.nist_800_53.main
+
+# Minimal "everything-passes" input — every required key set to true.
+fully_compliant_input := {
+    "assessment_date": "2026-06-26",
+    "ac_controls": {
+        "policy": {"documented": true, "disseminated": true, "reviewed_updated": true},
+        "procedures": {"implementation_documented": true},
+        "account_management": {"automated_tools": true, "approval_process": true, "regular_reviews": true, "timely_removal": true},
+        "access_enforcement": {"mandatory_access_control": true, "discretionary_access_control": true, "role_based_access_control": true},
+        "information_flow": {"security_labels": true, "flow_control_policies": true, "automated_enforcement": true},
+        "separation_duties": {"critical_functions_divided": true, "documented_assignments": true, "monitored_compliance": true},
+        "least_privilege": {"minimum_access_granted": true, "privileged_functions_authorized": true, "non_privileged_access_default": true},
+        "logon_attempts": {"lockout_configured": true, "maximum_attempts": 3, "lockout_duration": 30},
+        "use_notification": {"banner_displayed": true, "acknowledgment_required": true, "monitoring_consent": true},
+        "logon_notification": {"timestamp_displayed": true, "location_displayed": true, "unsuccessful_attempts_displayed": true},
+        "session_control": {"limits_configured": true, "per_account_limits": true, "per_device_limits": true},
+        "session_lock": {"inactivity_timeout": 600, "pattern_hiding": true, "authentication_required": true},
+        "session_termination": {"automatic_termination": true, "user_initiated": true, "administrative_termination": true},
+        "permitted_actions": {"unauthenticated_functions": ["system_status"]},
+        "automated_marking": {"security_labels": true, "classification_marking": true, "handling_caveats": true},
+        "security_attributes": {"attribute_binding": true, "attribute_association": true, "transmission_preservation": true},
+        "remote_access": {"authorized_only": true, "encrypted_connections": true, "monitored_controlled": true},
+        "wireless_access": {"authorized_only": true, "encrypted_authentication": true, "monitored_usage": true},
+        "mobile_devices": {"usage_restrictions": true, "connection_requirements": true, "configuration_requirements": true},
+        "external_systems": {"authorized_only": true, "security_requirements": true, "user_agreements": true},
+        "information_sharing": {"user_discretion_limited": true, "automated_guidance": true, "security_attributes_preserved": true},
+        "public_content": {"authorized_personnel_only": true, "review_process": true, "removal_procedures": true},
+        "data_mining": {"detection_techniques": true, "warning_notifications": true, "response_procedures": true},
+        "decisions": {"security_attributes_used": true, "consistent_enforcement": true, "documented_criteria": true},
+        "reference_monitor": {"tamper_proof": true, "always_invoked": true, "small_verifiable": true},
+    },
+    "au_controls": {
+        "policy": {"documented": true},
+        "event_logging": {"enabled": true},
+        "content_of_records": {"adequate": true},
+        "storage_capacity": {"adequate": true},
+        "response_to_failures": {"alerting": true},
+        "review_and_analysis": {"regular": true},
+        "reduction_and_reporting": {"tools_available": true},
+        "time_stamps": {"synchronized": true},
+        "protection_of_records": {"tamper_resistant": true},
+        "non_repudiation": {"implemented": true},
+        "retention_period_days": 365,
+        "generation": {"required_events_captured": true},
+    },
+    "cm_controls": {
+        "policy": {"documented": true},
+        "baseline_config": {"maintained": true},
+        "change_control": {"process_exists": true},
+        "security_impact_analysis": {"performed": true},
+        "access_restrictions_for_change": {"enforced": true},
+        "configuration_settings": {"documented": true},
+        "least_functionality": {"enforced": true},
+        "system_component_inventory": {"maintained": true},
+        "config_management_plan": {"documented": true},
+        "software_usage_restrictions": {"enforced": true},
+        "user_installed_software": {"restricted": true},
+    },
+    "ia_controls": {
+        "policy": {"documented": true},
+        "user_id_auth": {"uniquely_identified": true, "mfa_for_privileged": true, "mfa_for_non_privileged": true},
+        "device_identification": {"implemented": true},
+        "identifier_management": {"unique_per_user": true},
+        "authenticator_management": {"complexity_enforced": true, "encrypted_in_transit": true, "encrypted_at_rest": true},
+        "authenticator_feedback": {"obscured": true},
+        "cryptographic_module_auth": {"fips_validated": true},
+        "non_organizational_users": {"identified": true},
+    },
+    "ir_controls": {
+        "policy": {"documented": true},
+        "training": {"completed_within_year": true},
+        "testing": {"exercised_within_year": true},
+        "handling": {"process_defined": true},
+        "monitoring": {"continuous": true},
+        "reporting": {"timely": true},
+        "assistance": {"available": true},
+        "plan": {"documented": true},
+        "information_spillage": {"process_defined": true},
+    },
+    "sc_controls": {
+        "policy": {"documented": true},
+        "app_partitioning": {"separated": true},
+        "security_function_isolation": {"implemented": true},
+        "denial_of_service": {"protections": true},
+        "boundary_protection": {"deployed": true},
+        "transmission_confidentiality": {"encrypted": true},
+        "transmission_integrity": {"protected": true},
+        "network_disconnect": {"timeout_configured": true},
+        "cryptographic_key_mgmt": {"documented": true},
+        "cryptographic_protection": {"fips_validated": true},
+        "collaborative_devices": {"disabled_when_unused": true},
+        "public_key_infrastructure": {"certificates_managed": true},
+        "mobile_code": {"controls_enforced": true},
+        "voip": {"controls_enforced": true},
+        "secure_dns": {"dnssec_enforced": true},
+        "session_authenticity": {"protected": true},
+        "protection_of_info_at_rest": {"encrypted": true},
+    },
+    "si_controls": {
+        "policy": {"documented": true},
+        "flaw_remediation": {"timely": true},
+        "malicious_code_protection": {"deployed": true},
+        "system_monitoring": {"continuous": true},
+        "security_alerts": {"acted_upon": true},
+        "security_function_verification": {"tested": true},
+        "software_firmware_integrity": {"verified": true},
+        "spam_protection": {"enabled": true},
+        "input_validation": {"enforced": true},
+        "error_handling": {"no_info_disclosure": true},
+        "information_management_retention": {"policy_enforced": true},
+        "memory_protection": {"enabled": true},
+    },
+}
+
+test_compliance_report_returns_object if {
+    r := main.compliance_report with input as fully_compliant_input
+    r.framework == "NIST SP 800-53 Rev 5"
+    is_number(r.total_controls)
+}
+
+test_compliant_when_all_inputs_pass if {
+    main.compliant with input as fully_compliant_input
+}
+
+test_violations_empty_when_compliant if {
+    count(main.violations) == 0 with input as fully_compliant_input
+}
+
+test_non_compliant_with_empty_input if {
+    not main.compliant with input as {}
+}
+
+test_violations_non_empty_with_empty_input if {
+    count(main.violations) > 0 with input as {}
+}
+
+test_family_summary_present if {
+    r := main.compliance_report with input as fully_compliant_input
+    r.family_summary.AC.compliant == true
+    r.family_summary.SI.compliant == true
+}

--- a/frameworks/regulatory/cfr_part_11/cfr_part_11_main.rego
+++ b/frameworks/regulatory/cfr_part_11/cfr_part_11_main.rego
@@ -30,6 +30,17 @@ compliant if {
     count(violations) == 0
 }
 
+# Defaults — without these, an empty input makes compliance_report undefined
+# and the OPA endpoint returns null.
+default entity_name := "unknown"
+default entity_type := "unknown"
+default system_name := "unknown"
+default assessed_at := "unknown"
+entity_name := input.entity_name
+entity_type := input.entity_type
+system_name := input.system_name
+assessed_at := input.assessment_date
+
 # ── §11.10 — Controls for Closed Systems ──────────────────────────────────────
 
 # §11.10(a) — Validation
@@ -271,10 +282,10 @@ compliance_report := {
     "framework":       "FDA 21 CFR Part 11",
     "title":           "Electronic Records; Electronic Signatures",
     "regulation":      "21 Code of Federal Regulations Part 11",
-    "entity_name":     input.entity_name,
-    "entity_type":     input.entity_type,
-    "system_name":     input.system_name,
-    "assessed_at":     input.assessment_date,
+    "entity_name":     entity_name,
+    "entity_type":     entity_type,
+    "system_name":     system_name,
+    "assessed_at":     assessed_at,
     "compliant":       compliant,
     "total_controls":  43,
     "violations":      violations,

--- a/frameworks/regulatory/cfr_part_11/tests/test_cfr_part_11_main.rego
+++ b/frameworks/regulatory/cfr_part_11/tests/test_cfr_part_11_main.rego
@@ -1,0 +1,36 @@
+package cfr_part_11.main_test
+
+import rego.v1
+import data.cfr_part_11.main
+
+test_compliance_report_defined_on_empty_input if {
+    r := main.compliance_report with input as {}
+    r.framework == "FDA 21 CFR Part 11"
+    is_number(r.total_controls)
+    count(r.violations) >= 0
+}
+
+test_non_compliant_on_empty_input if {
+    not main.compliant with input as {}
+}
+
+test_violations_emitted_on_empty_input if {
+    count(main.violations) > 15 with input as {}
+}
+
+test_defaults_for_metadata if {
+    r := main.compliance_report with input as {}
+    r.entity_name == "unknown"
+    r.system_name == "unknown"
+}
+
+test_metadata_picked_up_from_input if {
+    r := main.compliance_report with input as {
+        "entity_name": "PharmaCo",
+        "entity_type": "pharmaceutical",
+        "system_name": "Trial-Master",
+        "assessment_date": "2026-06-26",
+    }
+    r.entity_name == "PharmaCo"
+    r.system_name == "Trial-Master"
+}


### PR DESCRIPTION
## Summary

Six frameworks in this library had policy content but were undiscoverable at the standard endpoint `/v1/data/<framework>/main/compliance_report` that `ansible/playbooks/generic_framework_assessment.yml` queries. This PR wires them all up.

| Framework | Endpoint | Was | Now |
|---|---|---|---|
| **NIST 800-53 Rev 5** | `nist_800_53/main` | 1 stub family (AC), no main | 7 families (AC/AU/CM/IA/IR/SC/SI) + main; 90 controls |
| **NIST CSF 2.0** | `nist_csf/main` | 2 of 6 functions, no main | All 6 functions (Govern/Identify/Protect/Detect/Respond/Recover) + main; 87 controls |
| **DORA** | `dora/main` | Already complete | No change — verified live on mac-aap opa-compliance |
| **NIS2** | `nis2/main` | Substantive rules but compliance_report undefined on empty input | Defaults added; report always defined |
| **CFR Part 11** | `cfr_part_11/main` | Same defect | Same fix |
| **FedRAMP** | `fedramp/main` | Wrong package (`fedramp`), no `compliance_report` contract | Thin adapter `fedramp.main` over the existing module; per-area summary computed locally; impact-level-driven `total_controls` (125/325/421) |
| **NIST AI RMF** | `nist_ai_rmf/main` | No main | Adapter `nist_ai_rmf.main` over the existing module; 70 controls |

**Not in this PR (separate scope):**

- **NIST RMF** (the categorize → select → implement → assess → authorize → monitor process framework) — only the categorize step exists, `nist_rmf` isn't in `opa_framework_map`, building the other 5 steps is its own effort.

## How the upstream-undefined-on-empty-input bug was fixed

Every orchestrator that read `input.assessment_date`, `input.entity_name`, etc. directly in its `compliance_report` object literal became undefined when those fields were absent — and an `undefined` inside an object literal makes the entire object `undefined`, so the OPA endpoint returns `null` / `{}`. The fix in each case is the Rego v1 pattern:

```rego
default assessed_at := "unknown"
assessed_at := input.assessment_date
```

The FedRAMP and NIST AI RMF adapters take it one step further — their upstream `*_compliance_report` rules embed input refs too, so the adapter computes the per-area/per-function summary itself from the upstream `violation_*` sets rather than referencing the upstream report.

## Test plan

- [x] `opa test .` — **75/75** passing (33 new + 42 pre-existing)
- [x] `opa check` clean on every modified module
- [x] Cross-repo `compliance/tests/comprehensive_test_suite.rego` still passes (preserved by appending violation shims to existing modules, not rewriting their boolean rules)
- [x] Live smoke test against mac-aap opa-security: `nist_800_53` returns 90 violations, `nist_csf` returns 87 violations, both with correct shape
- [x] DORA endpoint smoke-tested on opa-compliance (no change required)
- [ ] Reviewer verifies CI green
- [ ] After merge: bump `policies/` submodule in `ynotbhatc/compliance`, reload OPA containers on lab-aap / mac-aap / any active RHPDS

🤖 Generated with [Claude Code](https://claude.com/claude-code)