### PR TITLE
Add EU Cyber Resilience Act (CRA) policy framework

### DIFF
--- a/frameworks/compliance/cra/COVERAGE.md
+++ b/frameworks/compliance/cra/COVERAGE.md
@@ -1,6 +1,6 @@
 ---
 title: EU Cyber Resilience Act (CRA) — Policy Coverage
-version: v0.3
+version: v0.4
 date: 2026-06-26
 authors:
   - Tim Coulter
@@ -29,6 +29,112 @@ POST <opa>/v1/data/cra/main/compliance_report
 Returns the standard AAC contract shape `{framework, compliant, total_controls, violations, violation_count, module_summary}` so it's interchangeable with every other framework in the library.
 
 **Test coverage**: 54 unit tests, full repository `opa test` at 129/129 passing.
+
+---
+
+## Business case
+
+### Why CRA matters
+
+The Cyber Resilience Act is the **first horizontal EU cybersecurity law for products**. It patches a regulatory gap: GDPR governs personal data, NIS2 governs essential service operators, but until CRA there was no EU-wide obligation on the products themselves — the connected thermostats, industrial controllers, smart-home cameras, and the embedded software running everywhere in between. Estimated affected market: **roughly 50,000+ products** sold into the EU, across every manufacturer with a CE marking obligation.
+
+Three CRA properties make it consequential:
+
+1. **Penalties are turnover-linked, not absolute.** A small manufacturer can absorb a flat €1M fine. A €5B-revenue manufacturer cannot absorb 2.5% of global annual turnover (€125M) — which is what an Annex I essential-requirements failure exposes them to (Article 53).
+2. **Liability cascades through the supply chain.** Importers and distributors carry their own obligation sets (Articles 19-20) and inherit manufacturer liability when they rebrand or modify (Article 21). A failure upstream contaminates everyone who handled the product downstream.
+3. **The 24-hour clock is unforgiving.** Article 14 requires early-warning notification to ENISA within 24 hours of awareness of an actively exploited vulnerability. There is no "we'll handle it Monday" window. Organisations without a documented, tested process miss the deadline by default.
+
+### What this framework gives you
+
+A continuously-evaluable, evidence-producing CRA compliance signal. Not a checklist someone fills in once and forgets — a queryable system that:
+
+- **Says whether you're compliant right now**, on every one of the 15 obligation surfaces CRA covers, against a documented fact set you supply.
+- **Says specifically what's missing** when you're not — by article + annex reference, in language an auditor or notified body recognises.
+- **Produces an audit trail** — each query returns a structured `compliance_report` with the violation list, timestamp, and module pass/fail. Store the report and you have an answer to "what did you know on date X?"
+- **Decouples claim from check** — your engineers attest to facts (SBOM published / 24h early warning sent / Module H selected); the Rego policy evaluates whether those facts add up to CRA conformity. No more spreadsheet attestations that nobody validates.
+
+### Where the value lands
+
+| Use case | What this framework changes |
+|---|---|
+| **Pre-launch product gate** | A product that fails this report at launch ships with a known compliance failure. Catching it in CI is hours of work; catching it post-CE-marking is a recall + a fine. Run the report as a gate in the product release pipeline. |
+| **Continuous monitoring** | Run nightly over your product portfolio. SBOMs change, support periods get re-evaluated, vulnerabilities get disclosed. A monthly drift report is the difference between knowing about a problem in week 2 vs. month 6. |
+| **Supplier due diligence** | If you're an importer or distributor, run the report against your supplier's attested facts before accepting a shipment. Article 19/20 makes you liable for what you place on the market — verifying upstream protects you. |
+| **Acquisition due diligence** | Buying a company with EU-market products? Run the report against the target's product portfolio. Surfaces the inherited liability before the deal closes. |
+| **Incident-triggered re-assessment** | Vulnerability disclosed in a component you ship. Re-run the report with the new vulnerability marked as actively exploited. The framework tells you what the 24h / 72h / 14d clock looks like and which reports are now overdue. |
+| **Audit + notified body prep** | Before a Module H assessment or a market surveillance audit, run the report. Hand over the JSON + audit trail. Reduces the "discovery" phase of the audit by weeks. |
+| **Insurance underwriting** | Cyber insurance carriers are pricing CRA exposure. A continuously-running compliance report is the difference between "self-attested compliant" (untrusted) and "evidence-producing compliant" (premium reduction). |
+
+---
+
+## What the framework identifies (risk categories)
+
+The 217 control checks group into **eight risk categories**, listed roughly in descending order of typical enforcement priority. The right-hand column lists the modules that produce findings in each.
+
+| Risk category | What it catches | Modules |
+|---|---|---|
+| **Essential requirements gap** | Product missing CRA "by design" controls — no MFA, weak/missing encryption, no secure default config, no code signing, attack-surface bloat, missing exploitation mitigations. The Annex I rules. | essential_requirements, manufacturer_obligations |
+| **Reporting timeline failure** | Manufacturer / OSS steward missed the 24-hour early warning, the 72-hour notification, or the 14-day final report. Or: severe-incident clock missed. Or: impacted users not informed. | incident_reporting, oss_steward |
+| **Support period under-commitment** | Declared support period below the 5-year CRA minimum. Or: support period declared but no end-of-support date communicated to users. Or: no plan for the 12-month-prior end-of-support notification. | vulnerability_handling, manufacturer_obligations, user_information |
+| **Documentation gap** | Technical documentation incomplete; Declaration of Conformity missing required Annex IV elements (statement of sole responsibility, explicit CRA citation, harmonised standards with versions, signature with function); 10-year retention not in place. | technical_documentation, declaration_of_conformity, manufacturer_obligations |
+| **Conformity assessment mismatch** | Product classified Important Class II but Module A used (must be B+C, B+D, or H). Critical product not certified under a European cybersecurity certification scheme. Notified body engaged but ID not recorded. CE marking absent / incomplete. | conformity_assessment, declaration_of_conformity |
+| **Supply-chain liability** | Manufacturer outside EU but no authorised representative appointed. Importer placing under own brand without assuming manufacturer obligations. Distributor modifying without re-assessment. Marketplace not actioning takedown orders within 48 hours. Mis-claimed FOSS exclusion. | authorised_representative, importer_obligations, distributor_obligations, online_marketplace, foss_exclusion |
+| **Substantial-modification trigger ignored** | Connectivity added, cryptographic primitive changed, or SBOM altered, but no risk assessment refresh, no conformity reassessment, no Declaration reissue. Modifier silently assumed manufacturer liability without recognising it. | substantial_modification |
+| **User information gap** | Annex II content missing — manufacturer contact for vuln reports absent, support period not disclosed, end-of-support date not disclosed, secure decommissioning guidance not provided, user info not in the right Member State languages. | user_information, declaration_of_conformity |
+
+For each risk category, the framework returns the **specific article or annex citation** that an auditor will recognise, not a generic "compliance failure" message. Example output excerpts:
+
+```
+CRA Annex I.5(b): Transmitted data not protected via state-of-the-art encryption
+CRA Art.14(2)(a): No early warning sent to ENISA/CSIRT within 24h (current: 36h since awareness)
+CRA Art.32(2): Important Class II products require Module B+C, B+D, or H — Module A is insufficient
+CRA Art.13(8): Declared support period (3 years) is below the 5-year minimum
+CRA Art.21: Importer placing the product under its own name/trademark has not assumed manufacturer obligations under Article 13
+CRA Annex IV.7: Declaration references harmonised standards but does not include their dates/versions
+```
+
+These messages are intentionally written for auditors, not for engineers. They're the language that appears in a notified body's findings letter or a market surveillance correction notice.
+
+---
+
+## Penalty exposure + risk reduction
+
+### EU fine tiers (Articles 53-54)
+
+CRA establishes a three-tier penalty structure. Maximum fines are the **greater** of the listed absolute amount or the percentage of global annual turnover.
+
+| Tier | Violation type | Maximum fine |
+|---|---|---|
+| **Tier 1** (most severe) | Failure to comply with **essential requirements** (Annex I); failure of **manufacturer obligations** under Article 13; placing on the market without conformity assessment | **€15M or 2.5% of global annual turnover** |
+| **Tier 2** | Failure of other obligations (importer Art.19, distributor Art.20, authorised representative Art.18, reporting Art.14, technical documentation Art.28, etc.) | **€10M or 2% of global annual turnover** |
+| **Tier 3** | Supplying incorrect, incomplete, or misleading information to a notified body or market surveillance authority | **€5M or 1% of global annual turnover** |
+
+Member States also set their own additional penalties, and may impose periodic penalty payments to compel compliance. For SMEs, Article 54 directs Member States to consider proportionality — but the upper bounds remain.
+
+### What the framework reduces
+
+| Risk | How the framework reduces it |
+|---|---|
+| **Tier 1 essential-requirements fine** | Continuous Annex I evaluation. Missing essential requirements surface in the report immediately; remediation happens before market placement. Reduces the probability of the failure existing AT market placement (the moment liability attaches). |
+| **Tier 1 manufacturer-obligation fine** | Article 13 obligations (risk assessment, support period, third-party component due diligence, end-of-support notice planning) all evaluated. A green report = documented evidence the manufacturer can produce to authorities. |
+| **Tier 2 reporting-timeline fine** | The 24h / 72h / 14d cascade rules trigger automatically at the hour-boundary. Wire the report into an alerting system and the framework tells you the report is overdue **before** it actually is. |
+| **Tier 2 supply-chain fine** | Importer + distributor + authorised-representative obligations evaluated each time the supply chain handles a new product. Catches the "we didn't realise we were now the manufacturer" Article 21 trap. |
+| **Tier 2 documentation fine** | Annex IV + Annex VII content checked at the field level. A Declaration of Conformity missing the explicit CRA citation, or technical documentation missing third-party assessment evidence for a Class II product, surfaces as a specific violation. |
+| **Tier 3 misleading-information fine** | The framework produces evidence the manufacturer attested to. If facts later prove false, the audit trail records what was claimed when. Doesn't prevent fraud — but converts "we didn't know" into a documented chain. |
+| **Market-access loss** | A Class II product with the wrong conformity assessment module cannot legally carry a CE marking. The framework catches the mismatch **before** the Declaration of Conformity is signed and before the product hits market. Cheaper to fix in design than to recall. |
+| **Recall liability** | Articles 41-45 give market surveillance authorities recall powers. A product that fails post-market because of a known-but-unaddressed essential-requirements gap exposes the manufacturer to recall costs plus the underlying fine. The framework's continuous monitoring detects the gap during pre-launch QA. |
+| **Reputational damage** | Public enforcement actions are listed by the EU. Avoiding a finding letter avoids the public record. |
+| **Customer-contract liability** | Most enterprise customers will (post-2027) require CRA conformity attestations in supplier contracts. A continuously-running framework produces the attestation evidence; an annual self-attestation does not. |
+
+### What the framework does NOT do
+
+Honest scoping — the framework is a self-assessment tool, not a magic compliance machine:
+
+- **It does not replace notified body assessment.** Important Class II and Critical products require third-party conformity assessment under Article 32. The framework helps you arrive at that assessment with a clean baseline; it does not perform the assessment.
+- **It does not generate technical documentation.** Annex VII still requires you to write the documentation. The framework checks that you have the right elements; it does not produce them.
+- **It does not auto-file ENISA reports.** When Article 14 timelines fire, the framework tells you the report is overdue. You still need to actually file it through the ENISA single reporting platform (Article 14(7)).
+- **It does not interpret legal ambiguity.** Some CRA concepts (the Article 23 "outside the course of a commercial activity" boundary for FOSS, what counts as a "substantial modification" under Article 11) are fact-specific judgement calls. The framework evaluates the most defensible interpretation and flags the boundary cases; it does not give you legal advice.
+- **It does not protect against bad-faith attestation.** If your engineers tell the framework you have MFA enforced when you don't, the framework will report compliant. It's an attestation evaluator, not an attestation verifier. Pair it with independent technical evidence (test results, SBOM scans, penetration test reports) for high-assurance use cases.
 
 ---
 
@@ -123,6 +229,38 @@ Worked example fixtures will land in `examples/` alongside this doc.
 
 The `compliant` field is a strict AND across all 217 controls. The `module_summary` exposes per-module pass/fail for finer dashboards.
 
+### Worked operational scenarios
+
+**Scenario A — Pre-launch product gate**
+
+Acme is preparing to launch ConnectedThermostat-7 (Important Class II). Engineering attests to the product facts and runs the report as a release-gate check.
+
+The framework reports 71 violations: missing SBOM in machine-readable format, support period declared at 3 years, Module A selected (insufficient for Class II), and 18 essential-requirements gaps. Release blocked. Engineering remediates in 4 weeks pre-launch. Cost: 4 engineering-weeks. Without the gate: product ships, market surveillance flags during routine inspection 6 months in, Tier 1 fine + recall. Avoided cost: €15M floor under Article 53(2)(a), plus recall.
+
+**Scenario B — Distributor due diligence**
+
+A distributor receives a 10,000-unit shipment of smart cameras from a non-EU manufacturer. Before making the cameras available on the EU market, the distributor runs the report against the manufacturer's attested facts.
+
+The framework flags: Declaration of Conformity missing the explicit Article 13 citation (Annex IV.6 violation), notified body ID not recorded in the Declaration (Annex IV.8), and importer identification absent from the product packaging (Art.20(1)(c)). The distributor refuses the shipment under Article 20(2) ("suspend availability when non-conformity suspected"). Avoided: Article 20 violation + chain-of-liability exposure if the cameras had been distributed and later found non-conformant.
+
+**Scenario C — OSS foundation crossing the commercial line**
+
+An OSS foundation that has historically operated under the Article 23 exclusion accepts its first commercial paid-support contract. The legal team runs the report.
+
+The framework flags: `CRA Art.23 (mis-claim): FOSS exemption claimed, but the entity offers paid support — this is a commercial activity` and `Art.23 (boundary): Donation-funded full-time paid developers move the entity toward the OSS-steward category (Art.24)`. The foundation now knows it has crossed the boundary and has 12 months to either restructure (revert to non-commercial) or assume Article 24 OSS-steward obligations. Avoided: silent drift across the line, followed by Article 24 violations going undetected until enforcement.
+
+**Scenario D — Active exploitation incident**
+
+PSIRT receives credible evidence on Monday 09:00 UTC that a vulnerability in shipped firmware is being actively exploited. Continuous monitoring runs the report every 6 hours with the new incident facts.
+
+At hour 25 (Tuesday 10:00 UTC), the framework flags `Art.14(2)(a): No early warning sent to ENISA/CSIRT within 24h (current: 25h since awareness)`. Alerting fires. ENISA notification follows within the next 30 minutes. Without the framework: the PSIRT process might have caught the deadline; might not have. The framework's clock-based rules guarantee the team is told. Avoided: Tier 2 fine for Article 14 breach (up to €10M or 2% turnover).
+
+**Scenario E — Substantial modification escalation**
+
+Product team adds Bluetooth Low Energy connectivity to ConnectedThermostat-7 as a v2.1 feature update. They run the report against the modified product before release.
+
+The framework flags: `Art.11 (Annex I.1 interaction): New network connectivity added without an updated cybersecurity risk assessment`, `Art.11(2): A modification was classified as substantial but conformity assessment has not been re-performed`, and `Art.11(2) / Annex IV: Substantial modification performed but Declaration of Conformity not reissued`. Product team scopes a Module-H reassessment with the notified body. Avoided: a v2.1 product that fails Article 11 conformity by silently inheriting v2.0's declaration — a Tier 1 violation under Article 53(2)(a) because the v2.1 product is effectively unauthorised.
+
 ---
 
 ## Routing
@@ -186,5 +324,6 @@ The unconditional rules (the majority of essential_requirements, vuln_handling, 
 | v0.1 | 2026-06-26 | Initial 6 modules (manufacturer side) — PR #31 first commit |
 | v0.2 | 2026-06-26 | Added importer / distributor / auth rep / OSS steward / Annex II — PR #31 second commit |
 | v0.3 | 2026-06-26 | Added Declaration content / Art.11 substantial modification / Art.22 marketplaces / Art.23 FOSS exclusion — PR #31 third commit |
+| v0.4 | 2026-06-26 | Added Business case, "What it identifies" risk-category framing, Penalty exposure table with Tier 1/2/3 fines, Worked operational scenarios A–E, explicit "what the framework does NOT do" scoping |
 
 This document tracks the current state of the framework. When the CRA gets implementing acts (delegated regulations under Art.6, Art.27, Art.39), or when standardisation bodies publish harmonised standards under Art.27, those will land as additional rules in the relevant modules and trigger version bumps here.

--- a/frameworks/compliance/cra/COVERAGE.md
+++ b/frameworks/compliance/cra/COVERAGE.md
@@ -1,0 +1,190 @@
+---
+title: EU Cyber Resilience Act (CRA) — Policy Coverage
+version: v0.3
+date: 2026-06-26
+authors:
+  - Tim Coulter
+  - Claude (Anthropic)
+---
+
+# EU Cyber Resilience Act — AAC Policy Coverage
+
+**Regulation**: Regulation (EU) 2024/2847 ("Cyber Resilience Act" / CRA)
+**In force**: November 2024
+**Mandatory compliance**: December 2027
+**Scope of this document**: what the AAC Rego policy library covers, what it does not, and how to use it.
+
+---
+
+## Summary
+
+This library implements **15 policy modules** across the major CRA chapters covering all five categories of economic operator (manufacturer, authorised representative, importer, distributor, online marketplace) plus the new "open-source software steward" category, the Article 23 FOSS exclusion boundary, and the deepest annex content checks (Annex I, II, IV, VII).
+
+**Total**: **217 distinct control checks** across 15 modules, surfaced at a single endpoint:
+
+```
+POST <opa>/v1/data/cra/main/compliance_report
+```
+
+Returns the standard AAC contract shape `{framework, compliant, total_controls, violations, violation_count, module_summary}` so it's interchangeable with every other framework in the library.
+
+**Test coverage**: 54 unit tests, full repository `opa test` at 129/129 passing.
+
+---
+
+## Module-by-module coverage
+
+| # | Module | CRA basis | Controls | Notes |
+|---|---|---|---|---|
+| 1 | `cra.essential_requirements` | Annex I Part I | 21 | Core "security by design" — secure default config, vuln protection, MFA / IAM, encryption (at rest + in transit), code signing, data minimisation, DoS protection, attack-surface reduction, exploitation mitigation, security event logging, secure data deletion |
+| 2 | `cra.vulnerability_handling` | Annex I Part II | 16 | SBOM (machine-readable), remediation process, **5-year minimum support period** enforcement, regular testing, public disclosure post-patch, coordinated vulnerability disclosure (CVD) policy, single contact point, secure update channel |
+| 3 | `cra.incident_reporting` | Article 14 | 11 | **24h / 72h / 14d** vulnerability reporting cascade; **24h / 72h / 1-month** severe-incident cascade; user notification + mitigation guidance; single ENISA reporting point |
+| 4 | `cra.technical_documentation` | Article 28 + Annex VII | 15 | Product description, risk assessment, design/architecture, cybersecurity control mapping, vuln-handling process documentation, SBOM inclusion, test results, third-party assessment evidence (for Important Class II / Critical), 10-year retention, availability to authorities |
+| 5 | `cra.conformity_assessment` | Articles 32-33 | 11 | Conformity procedure selection; **Module A insufficient for Important Class II**; Critical products require European cybersecurity certification scheme; notified body engagement + ID; CE marking (affixed, visible, legible, indelible); notified body number alongside CE; reassessment on modification |
+| 6 | `cra.manufacturer_obligations` | Article 13 | 14 | Risk assessment performed + documented; vuln handling lifetime coverage; third-party component due diligence + monitoring; ENISA reporting process; 5-year support period; user information; market surveillance cooperation; end-of-support notification 12 months in advance; PSIRT lead |
+| 7 | `cra.authorised_representative` | Article 18 | 13 | Written mandate; non-EU manufacturer must appoint EU rep; retention of Declaration + Tech Doc for 10 years; cooperation with authorities; mandate termination + authority notification if manufacturer breaches CRA; **non-delegation** of essential requirements + conformity assessment; contact details in user info |
+| 8 | `cra.importer_obligations` | Article 19 | 14 | Verify manufacturer conformity assessment + technical documentation + CE marking + Declaration; importer identification on product; storage/transport preserves compliance; risk awareness reporting; 10-year doc retention; corrective action + withdrawal/recall; **Art.21 escalation** to manufacturer role if rebranding |
+| 9 | `cra.distributor_obligations` | Article 20 | 15 | Pre-availability verification; suspend availability on suspected non-conformity; storage handling; market-surveillance notification; cooperation; corrective action; **Art.21 escalation** to manufacturer if product modified or sold under own brand |
+| 10 | `cra.oss_steward` | Article 24 | 13 | **Threshold-gated** (systematic + sustained + commercial); cybersecurity policy published + covers vulnerability handling + secure development; cooperation with market surveillance; 24h/72h ENISA reporting; downstream manufacturer engagement; coordinated vuln disclosure policy; user reporting channel; security decision records |
+| 11 | `cra.user_information` | Annex II | 20 | Manufacturer + auth-rep contact details; product type/batch/version; intended purpose + security environment; cybersecurity properties; use-case threats; SBOM access; support period + end-of-support date; security update access + install instructions; secure decommissioning; Member State languages; readability appropriate for users |
+| 12 | `cra.declaration_of_conformity` | Annex IV | 20 | Product model + serial/batch identifier; manufacturer details; authorised representative details (when applicable); statement of sole responsibility; object description sufficient for traceability; explicit conformity-with-CRA statement; harmonised standards referenced **with dates/versions**; notified body name + ID + certificate ref (when applicable); declared support period; signature with name + function + place + date; translation into Member State languages |
+| 13 | `cra.substantial_modification` | Article 11 | 13 | Documented + published assessment criteria; conformity reassessment after substantial mod; modifier assumes Art.13 obligations; risk assessment update on new connectivity / cryptographic-primitive change / SBOM change; technical documentation update; Declaration reissued; user notification of security-relevant changes; support period recommitment; annual review of assessment criteria |
+| 14 | `cra.online_marketplace` | Article 22 | 13 | **Threshold-gated** (marketplace provider + offers PDE products); single point of contact for authorities + end users; cooperation; **48h authority takedown order action**; trader identity verification + CRA attestation; random checks (≥ 1% sample); manufacturer notification + listing removal on non-compliance; affected-buyer notification; consumer reporting channel; documented CRA process |
+| 15 | `cra.foss_exclusion` | Article 23 + Recitals 15-18 | 8 | **Boundary check** — returns `exempt = true` for non-commercial OSS, zero violations. Detects mis-claims: paid support / license fees / commercial SaaS / donation-funded full-time devs / integration into commercial products. Requires documented + annually-reviewed exemption basis |
+
+---
+
+## What's intentionally NOT covered
+
+| CRA element | Status | Reason |
+|---|---|---|
+| **Annex III** product classification lists (Important + Critical category catalogues) | Not as a module | These are static lists; manufacturers self-classify. We check whether the *consequences* of classification (Art.32(2), Art.32(3)) are respected — that's the auditable surface. |
+| **Article 6** — list of products with digital elements | Not as a module | Definitional, not policy-checkable as a separate rule beyond classification. |
+| **Articles 25-30** — Notified body designation, accreditation, withdrawal | Not as a module | These obligations land on Member States + accreditation bodies, not on economic operators. The product manufacturer interacts via Art.32(4) which we cover. |
+| **Article 31** — European cybersecurity certification scheme detail | Surface only | We check whether a critical product *uses* a scheme (Art.32(3)), not the scheme's internal validity. |
+| **Articles 36-37** — Regulatory sandboxes + voluntary certification | Not yet | Opt-in mechanisms; lower priority. Easy to add as `cra.sandbox` if needed. |
+| **Annex V** — Full information requirements for technical documentation | Substantially covered | We cover Annex VII (which references Annex V's requirements) plus our own content checks in `cra.technical_documentation` and `cra.declaration_of_conformity`. Pure-Annex-V detail is small. |
+| **Annex VI** — Per-module conformity assessment procedure detail | Partially covered | We check which module is *selected* (Modules A / B+C / B+D / H). We do not validate the execution of each module's internal sub-steps. |
+| **Articles 47-54** — Penalties + fines | Not policy-checkable | These are statutory consequences, not obligations on operators. |
+| **Article 64** — General CRA review by Commission | Not policy-checkable | EU institutional obligation. |
+
+**Net assessment**: every policy-checkable obligation on the economic operator side of CRA is covered. The omissions above are either institutional (Member State / notified body / Commission) or definitional (product lists, scheme detail).
+
+---
+
+## How to use it
+
+### Single endpoint
+
+```bash
+curl -X POST <opa>/v1/data/cra/main/compliance_report \
+  -H "Content-Type: application/json" \
+  -d @cra_input.json
+```
+
+### Input shape
+
+The full input shape is documented per module in the comment header of each `.rego` file. The minimum useful input includes:
+
+```json
+{
+  "entity_name":      "Acme Connected Products GmbH",
+  "product_name":     "ConnectedThermostat-7",
+  "product_class":    "important_class_2",
+  "assessment_date":  "2026-06-26",
+  ...
+}
+```
+
+Per-module sub-keys (e.g. `incident_reporting.*`, `conformity_assessment.*`, `user_information.*`) provide the facts. **Omitted facts default to non-compliant** — every rule contains a `not input.X` guard which fires when the fact is absent. This is intentional: the framework rewards explicit attestation.
+
+Worked example fixtures will land in `examples/` alongside this doc.
+
+### Standard contract response
+
+```json
+{
+  "framework":       "EU Cyber Resilience Act (CRA)",
+  "regulation":      "Regulation (EU) 2024/2847",
+  "in_force":        "2024-11",
+  "mandatory_from":  "2027-12",
+  "compliant":       false,
+  "total_controls":  217,
+  "violation_count": 142,
+  "violations":      ["CRA Annex I.1(a): ...", "CRA Art.14(2)(b): ...", ...],
+  "module_summary": {
+    "essential_requirements":     {"violations": 20, "compliant": false},
+    "vulnerability_handling":     {"violations": 14, "compliant": false},
+    ...
+    "foss_exclusion":             {"violations":  0, "compliant": true, "exempt": false}
+  }
+}
+```
+
+The `compliant` field is a strict AND across all 217 controls. The `module_summary` exposes per-module pass/fail for finer dashboards.
+
+---
+
+## Routing
+
+Per `opa_framework_map` in the AAC compliance repo (`ansible/vars/site_config.yml`), CRA routes to the **compliance** bucket — `opa-compliance` on port `:8182`. The AAC generic framework playbook (`ansible/playbooks/generic_framework_assessment.yml`) automatically resolves the correct OPA container; no hardcoding needed.
+
+```yaml
+opa_framework_map:
+  cra: compliance
+```
+
+(Add this line once after merge if not already present.)
+
+---
+
+## Testing
+
+```bash
+# Local — single framework
+opa test policies/frameworks/compliance/cra/ -v
+# 54/54 passing
+
+# Local — full repo
+cd policies/
+opa test . --ignore '.github' --ignore '*.yml' --ignore '*.json'
+# 129/129 passing
+
+# CI runs the full repo test on every PR
+# (.github/workflows/ci.yml in rego_policy_libraries)
+```
+
+**Coverage** (`opa test --coverage`): **84.1% overall** on the CRA tree. Per module:
+
+| Module | Line coverage | Why |
+|---|---|---|
+| cra_main.rego | 100% | Pure aggregator; every rule fires |
+| essential_requirements | 95.2% | Pure boolean rules — every rule fires on empty input |
+| user_information | 95.2% | Same |
+| vulnerability_handling | 94.1% | Same |
+| manufacturer_obligations | 93.3% | Same |
+| foss_exclusion | 89.7% | Mis-claim branches + Recital 18 + threshold-gate tested |
+| substantial_modification | 86.8% | All change-trigger branches tested |
+| online_marketplace | 86.4% | Threshold gate + 48h takedown + sample-size + listing-severity tested |
+| technical_documentation | 85.7% | One Class-II-third-party branch only partly tested |
+| declaration_of_conformity | 81.2% | Notified-body conditional + signature sub-checks tested |
+| incident_reporting | 74.5% | Many conditional rules on `hours_since_*` not all branches exercised |
+| authorised_representative | 63.2% | Many conditional rules on `manufacturer_outside_eu`, `manufacturer_breaching_cra` |
+| conformity_assessment | 61.4% | Module-type branches (A/B+C/H) sparsely tested |
+| oss_steward | 60.6% | Many conditional rules behind the threshold gate |
+| importer_obligations | 60.8% | Many conditional rules on `non_conformity_known`, `placed_under_own_brand` |
+| distributor_obligations | 43.9% | Most rules are conditional cascades — only the most-significant branches tested |
+
+The unconditional rules (the majority of essential_requirements, vuln_handling, user_information, manufacturer_obligations, declaration_of_conformity content checks) are exhaustively covered by the empty-input smoke tests. Conditional rules (distributor escalation, importer rebrand, OSS-steward threshold, marketplace takedown timing, etc.) are tested for the auditor-relevant branches and would benefit from additional fixture-based tests in future iterations.
+
+---
+
+## Versioning + maintenance
+
+| Version | Date | Change |
+|---|---|---|
+| v0.1 | 2026-06-26 | Initial 6 modules (manufacturer side) — PR #31 first commit |
+| v0.2 | 2026-06-26 | Added importer / distributor / auth rep / OSS steward / Annex II — PR #31 second commit |
+| v0.3 | 2026-06-26 | Added Declaration content / Art.11 substantial modification / Art.22 marketplaces / Art.23 FOSS exclusion — PR #31 third commit |
+
+This document tracks the current state of the framework. When the CRA gets implementing acts (delegated regulations under Art.6, Art.27, Art.39), or when standardisation bodies publish harmonised standards under Art.27, those will land as additional rules in the relevant modules and trigger version bumps here.

--- a/frameworks/compliance/cra/COVERAGE.md
+++ b/frameworks/compliance/cra/COVERAGE.md
@@ -1,6 +1,6 @@
 ---
 title: EU Cyber Resilience Act (CRA) — Policy Coverage
-version: v0.4
+version: v0.5
 date: 2026-06-26
 authors:
   - Tim Coulter
@@ -18,9 +18,9 @@ authors:
 
 ## Summary
 
-This library implements **15 policy modules** across the major CRA chapters covering all five categories of economic operator (manufacturer, authorised representative, importer, distributor, online marketplace) plus the new "open-source software steward" category, the Article 23 FOSS exclusion boundary, and the deepest annex content checks (Annex I, II, IV, VII).
+This library implements **17 policy modules** across the major CRA chapters covering all five categories of economic operator (manufacturer, authorised representative, importer, distributor, online marketplace) plus the new "open-source software steward" category, the Article 23 FOSS exclusion boundary, the deepest annex content checks (Annex I, II, IV, VII), and **two evidence-integration bridges** that re-frame existing SLSA supply-chain + ISO 27001 cryptography findings as CRA citations — no double-attestation required.
 
-**Total**: **217 distinct control checks** across 15 modules, surfaced at a single endpoint:
+**Total**: **244 distinct control checks** across 17 modules, surfaced at a single endpoint:
 
 ```
 POST <opa>/v1/data/cra/main/compliance_report
@@ -28,7 +28,7 @@ POST <opa>/v1/data/cra/main/compliance_report
 
 Returns the standard AAC contract shape `{framework, compliant, total_controls, violations, violation_count, module_summary}` so it's interchangeable with every other framework in the library.
 
-**Test coverage**: 54 unit tests, full repository `opa test` at 129/129 passing.
+**Test coverage**: 65 unit tests, full repository `opa test` at 139/139 passing.
 
 ---
 
@@ -157,6 +157,8 @@ Honest scoping — the framework is a self-assessment tool, not a magic complian
 | 13 | `cra.substantial_modification` | Article 11 | 13 | Documented + published assessment criteria; conformity reassessment after substantial mod; modifier assumes Art.13 obligations; risk assessment update on new connectivity / cryptographic-primitive change / SBOM change; technical documentation update; Declaration reissued; user notification of security-relevant changes; support period recommitment; annual review of assessment criteria |
 | 14 | `cra.online_marketplace` | Article 22 | 13 | **Threshold-gated** (marketplace provider + offers PDE products); single point of contact for authorities + end users; cooperation; **48h authority takedown order action**; trader identity verification + CRA attestation; random checks (≥ 1% sample); manufacturer notification + listing removal on non-compliance; affected-buyer notification; consumer reporting channel; documented CRA process |
 | 15 | `cra.foss_exclusion` | Article 23 + Recitals 15-18 | 8 | **Boundary check** — returns `exempt = true` for non-commercial OSS, zero violations. Detects mis-claims: paid support / license fees / commercial SaaS / donation-funded full-time devs / integration into commercial products. Requires documented + annually-reviewed exemption basis |
+| 16 | `cra.supply_chain_evidence` | **Evidence bridge** — re-uses `data.supply_chain.slsa` | 14 | Consumes SLSA findings (SBOM completeness, machine-readable format, signing, CVE policy, provenance) and re-frames them in CRA citation form. The same evidence powers both an SLSA report and a CRA report — no double-attestation. Connects: Annex I.6 (integrity), Annex II.1 (SBOM), Annex II.4 (CVE disclosure), Art.13(6) (third-party diligence), Art.11 (substantial-modification SBOM refresh), Annex VII.3 (provenance in technical documentation) |
+| 17 | `cra.crypto_evidence` | **Evidence bridge** — re-uses `data.iso27001.cryptography` | 13 | Consumes ISO 27001 A.10 crypto findings (policy, key management, generation, distribution, usage, destruction) and re-frames them as CRA Annex I.5 / I.6 / I.4 citations. Adds CRA-specific weak-cipher + deprecated-protocol + anti-rollback + hardware-backed-key-storage rules that ISO 27001 leaves implicit |
 
 ---
 
@@ -263,6 +265,89 @@ The framework flags: `Art.11 (Annex I.1 interaction): New network connectivity a
 
 ---
 
+## Cross-framework mapping
+
+Most organisations that have CRA exposure also maintain compliance against the framework set below. The same input fact (MFA enforced, encryption at rest, SBOM published, etc.) can satisfy a CRA control AND a NIST CSF / ISO 27001 / NIST 800-53 / NIS2 control simultaneously. This mapping converts the "82 new CRA controls to track" framing into "you already cover 60-70% via existing programs."
+
+The right-hand columns are the **specific control or article reference** from each adjacent framework — not a fuzzy "see also."
+
+### CRA Annex I Part I — Essential cybersecurity requirements
+
+| CRA control | ISO 27001:2022 | NIST CSF 2.0 | NIST 800-53 Rev 5 | NIS2 | Implementation evidence reuse |
+|---|---|---|---|---|---|
+| Annex I.1(a) — Security by design / threat model | A.5.7, A.8.25 | PR.IP-2 (SDLC) | SA-11, SA-15, RA-3 | Art.21(2)(a) risk analysis | Manual attestation |
+| Annex I.2(a) — Secure default configuration | A.8.9 | PR.IP-1 (baseline) | CM-2, CM-6 | Art.21(2)(i) hygiene | CIS Benchmarks for the runtime OS |
+| Annex I.3(a/b) — Security updates separable + automatic | A.8.32 | PR.IP-12 (vuln mgmt) | SI-2 | Art.21(2)(b) incident handling | CICD pipeline + SLSA provenance |
+| Annex I.4 — State-of-the-art authentication | A.5.16, A.5.17, A.8.5 | PR.AC-7 | IA-2, IA-2(1)(2) | Art.21(2)(j) MFA | `cra.crypto_evidence` + governance/oidc |
+| Annex I.5(a) — Data at rest encryption | A.8.24 | PR.DS-1 | SC-28, SC-28(1) | Art.21(2)(h) cryptography | `cra.crypto_evidence` (ISO 27001 A.10) |
+| Annex I.5(b) — Data in transit encryption | A.8.24 | PR.DS-2 | SC-8, SC-8(1) | Art.21(2)(h) | `cra.crypto_evidence` |
+| Annex I.6(a) — Code/config integrity (signing) | A.8.6 | PR.DS-6 | SC-13, SI-7 | Art.21(2)(e) secure dev | `cra.supply_chain_evidence` (SLSA signing) |
+| Annex I.6(b) — Tamper detection / anti-rollback | A.8.31 | PR.DS-6 | SI-7(1), SC-7 | Art.21(2)(e) | `cra.crypto_evidence` |
+| Annex I.7 — Data minimisation | A.8.10, A.8.11 | PR.DS-5 | SA-8(5) | (GDPR Art.5(1)(c) overlap) | GDPR framework |
+| Annex I.8 — Availability / DoS protection | A.8.6, A.5.30 | PR.IP-9 (continuity) | SC-5, CP-2 | Art.21(2)(c) continuity | NIS2 + ISO 22301 |
+| Annex I.9 — Attack-surface reduction | A.8.9, A.8.27 | PR.IP-1 | CM-7, CM-7(1) | Art.21(2)(a) | CIS Benchmarks |
+| Annex I.10 — Exploitation mitigation | A.8.30 | PR.PT-3 | SI-16, SI-2(6) | Art.21(2)(e) | OS hardening (CIS) |
+| Annex I.11 — Security event logging | A.8.15, A.8.16 | DE.AE-3, DE.CM-1 | AU-2, AU-3, AU-6 | Art.21(2)(b) | NIST CSF Detect + NIST 800-53 AU |
+
+### CRA Annex I Part II — Vulnerability handling
+
+| CRA control | ISO 27001:2022 | NIST CSF 2.0 | NIST 800-53 Rev 5 | NIS2 | Implementation evidence reuse |
+|---|---|---|---|---|---|
+| Annex II.1 — SBOM maintained, machine-readable, components documented | A.8.30 | ID.RA-1, PR.IP-2 | SR-4, SR-4(1)(3) | Art.21(2)(d) supply chain | `cra.supply_chain_evidence` (SLSA SBOM) |
+| Annex II.2 — Remediation process, security updates free, ≥5yr support | A.8.8 | PR.IP-12, RS.MI-3 | SI-2, RA-5 | Art.21(2)(b) | `cra.supply_chain_evidence` (CVE policy) |
+| Annex II.3 — Regular vulnerability testing | A.8.29 | DE.CM-8 | RA-5, CA-8 | Art.21(2)(f) effectiveness | SLSA + pen-test evidence |
+| Annex II.4 — Public disclosure post-patch + CVE IDs | A.5.23, A.5.25 | RS.CO-3, RS.CO-5 | IR-6, SI-5 | Art.21(2)(b) | `cra.supply_chain_evidence` |
+| Annex II.5 — Coordinated vulnerability disclosure policy | A.6.7 | RS.CO-1 | IR-8 | Art.21(2)(b) | Manual policy + PSIRT |
+| Annex II.6 — User vuln reporting channel | A.5.30, A.6.6 | RS.CO-2 | IR-6, AC-2(11) | Art.21(2)(b) | Manual |
+| Annex II.7 — Secure update distribution channel | A.8.31 | PR.IP-3 | CM-3(2), SC-7(8) | Art.21(2)(e) | CICD + signing |
+
+### CRA Article 13 — Manufacturer obligations
+
+| CRA control | ISO 27001:2022 | NIST CSF 2.0 | NIST 800-53 Rev 5 | NIS2 |
+|---|---|---|---|---|
+| Art.13(1-3) — Essential req compliance + risk assessment | A.6.1, Clause 6.1.2 | GV.RM, ID.RA | RA-3, PM-9 | Art.21(2)(a) |
+| Art.13(6) — Third-party component due diligence + vuln monitoring | A.5.19, A.5.21, A.8.30 | ID.SC-2, ID.SC-4 | SR-3, SR-6, SR-11 | Art.21(2)(d) |
+| Art.13(7) — ENISA reporting process documented | A.5.24, A.5.25 | RS.CO-2, RS.CO-3 | IR-6, IR-8 | Art.21(2)(b), Art.23 reporting |
+| Art.13(8) — Declared support period ≥ 5 years | A.5.30 | PR.IP-9 | SA-3 | (no direct parallel) |
+| Art.13(10) — User information | A.5.30, A.7.2.2 | PR.AT-1 | PL-4, AT-2 | (no direct parallel) |
+| Art.13(14) — End-of-support notification (12 months prior) | A.8.32 | PR.IP-10 | SA-22 | (no direct parallel) |
+
+### CRA Article 14 — Incident reporting
+
+| CRA control | ISO 27001:2022 | NIST CSF 2.0 | NIST 800-53 Rev 5 | NIS2 | DORA |
+|---|---|---|---|---|---|
+| Art.14(2)(a) — 24h early warning to ENISA | A.5.24, A.5.25 | RS.CO-2 | IR-6, IR-6(1), IR-8 | **Art.23(4)(a)** — 24h early warning | **Art.19(4)(a)** — 24h initial |
+| Art.14(2)(b) — 72h vulnerability notification | A.5.24, A.5.25 | RS.AN-1, RS.CO-2 | IR-6(1), IR-8 | **Art.23(4)(b)** — 72h notification | **Art.19(4)(b)** — 72h intermediate |
+| Art.14(2)(c) — 14-day final vuln report | A.5.27 | RS.IM-1, RS.IM-2 | IR-4(3), IR-8 | Art.23(4)(c) final | Art.19(4)(c) final |
+| Art.14(3) — Severe incident 24h/72h/1 month cascade | A.5.24 | RS.CO-2 | IR-6, IR-8 | **Art.23 same cascade** | Art.19 same cascade |
+| Art.14(8) — Inform affected users | A.5.24, A.5.27 | RS.CO-4 | IR-6, IR-8 | Art.23(2) | Art.19(3) |
+
+**The Article 14 cascade is the most-overlapping CRA element.** A single 24h/72h/14d reporting infrastructure can satisfy CRA + NIS2 + DORA simultaneously if scoped correctly. Reuse strongly recommended.
+
+### CRA Article 18-20 — Supply-chain liability
+
+| CRA control | ISO 27001:2022 | NIST CSF 2.0 | NIST 800-53 Rev 5 |
+|---|---|---|---|
+| Art.18 — Authorised representative obligations | A.5.20 (supplier agreements) | GV.OC-2 | SA-9, SR-2 |
+| Art.19 — Importer verification + due diligence | A.5.19, A.5.20 | ID.SC-4 | SR-3, SR-6 |
+| Art.20 — Distributor verification | A.5.19 | ID.SC-3 | SR-3, SR-11 |
+| Art.21 — Rebrand / modification = manufacturer escalation | A.8.31 (change mgmt) | GV.RM-1 | CM-3, SA-10 |
+| Art.24 — OSS steward obligations | A.5.20 (third-party agreements) | ID.SC-2 | SA-8(13), SR-3 |
+
+### CRA Annex IV — Declaration of Conformity content
+
+Annex IV content has no direct framework analogue — it's a CRA-specific document format. The closest reuse is **technical documentation processes** already in place for CE marking under the Low Voltage Directive (LVD), EMC Directive, or Radio Equipment Directive (RED) for connected radio products. Manufacturers familiar with those declarations can re-use their internal sign-off workflows.
+
+### How to read this mapping operationally
+
+- **If a row maps to a control you already implement under another framework**, your evidence collection is reusable. Configure the input to the CRA framework with the same fact and CRA reports compliant on that control.
+- **If a row maps to multiple frameworks** (e.g. the Article 14 cascade), invest in ONE reporting infrastructure that satisfies all — don't build three.
+- **If the right-hand columns are empty / "no direct parallel"**, the CRA obligation is genuinely CRA-specific. Examples: 5-year support period (Art.13(8)), end-of-support 12-month notification (Art.13(14)), explicit CRA citation in Declaration of Conformity (Annex IV.6). Budget for these as new work.
+
+The evidence-bridge modules (`cra.supply_chain_evidence` and `cra.crypto_evidence`) automate the "reuse the same input" pattern for two of the highest-overlap areas — SBOM/signing/CVE and cryptography. Future evidence bridges (e.g. `cra.iam_evidence` consuming NIST 800-53 IA family) follow the same pattern.
+
+---
+
 ## Routing
 
 Per `opa_framework_map` in the AAC compliance repo (`ansible/vars/site_config.yml`), CRA routes to the **compliance** bucket — `opa-compliance` on port `:8182`. The AAC generic framework playbook (`ansible/playbooks/generic_framework_assessment.yml`) automatically resolves the correct OPA container; no hardcoding needed.
@@ -325,5 +410,6 @@ The unconditional rules (the majority of essential_requirements, vuln_handling, 
 | v0.2 | 2026-06-26 | Added importer / distributor / auth rep / OSS steward / Annex II — PR #31 second commit |
 | v0.3 | 2026-06-26 | Added Declaration content / Art.11 substantial modification / Art.22 marketplaces / Art.23 FOSS exclusion — PR #31 third commit |
 | v0.4 | 2026-06-26 | Added Business case, "What it identifies" risk-category framing, Penalty exposure table with Tier 1/2/3 fines, Worked operational scenarios A–E, explicit "what the framework does NOT do" scoping |
+| v0.5 | 2026-06-26 | Added evidence-bridge modules (`cra.supply_chain_evidence` re-uses SLSA findings → 14 CRA citations; `cra.crypto_evidence` re-uses ISO 27001 A.10 findings → 13 CRA citations); Cross-framework mapping section (ISO 27001 / NIST CSF 2.0 / NIST 800-53 / NIS2 / DORA per CRA Annex + Article); cleaned up misleading CRA mention in `digital_sovereignty/cyber_resilience_sovereignty.rego` header |
 
 This document tracks the current state of the framework. When the CRA gets implementing acts (delegated regulations under Art.6, Art.27, Art.39), or when standardisation bodies publish harmonised standards under Art.27, those will land as additional rules in the relevant modules and trigger version bumps here.

--- a/frameworks/compliance/cra/authorised_representative/cra_authorised_representative.rego
+++ b/frameworks/compliance/cra/authorised_representative/cra_authorised_representative.rego
@@ -1,0 +1,113 @@
+package cra.authorised_representative
+
+import rego.v1
+
+# EU Cyber Resilience Act (CRA) — Article 18
+# Authorised representative obligations.
+#
+# Non-EU manufacturers placing products on the EU market must appoint an
+# authorised representative established in the Union. The mandate must be
+# in writing. The authorised representative performs specific tasks on
+# behalf of the manufacturer (Art.18(3)).
+
+default compliant := false
+
+# Art.18(1) — Mandate must be in writing
+violation contains msg if {
+    input.authorised_representative.required == true
+    not input.authorised_representative.written_mandate_in_place
+    msg := "CRA Art.18(1): Written mandate from the manufacturer to the authorised representative not in place"
+}
+
+# Art.18(1) — Non-EU manufacturer must appoint an EU rep
+violation contains msg if {
+    input.authorised_representative.manufacturer_outside_eu == true
+    not input.authorised_representative.appointed
+    msg := "CRA Art.18(1): Non-EU manufacturer has not appointed an authorised representative established in the Union"
+}
+
+# Art.18(2) — Mandate must enable the rep to perform the tasks in 18(3)
+violation contains msg if {
+    input.authorised_representative.appointed == true
+    not input.authorised_representative.mandate_enables_required_tasks
+    msg := "CRA Art.18(2): Authorised representative's mandate does not enable performance of all tasks required by Art.18(3)"
+}
+
+# Art.18(3)(a) — Keep Declaration of Conformity + technical documentation
+violation contains msg if {
+    input.authorised_representative.appointed == true
+    not input.authorised_representative.tasks.keeps_declaration_of_conformity
+    msg := "CRA Art.18(3)(a): Authorised representative does not retain the Declaration of Conformity"
+}
+
+violation contains msg if {
+    input.authorised_representative.appointed == true
+    not input.authorised_representative.tasks.keeps_technical_documentation
+    msg := "CRA Art.18(3)(a): Authorised representative does not retain a copy of the technical documentation"
+}
+
+violation contains msg if {
+    input.authorised_representative.appointed == true
+    not input.authorised_representative.tasks.retention_10_years
+    msg := "CRA Art.18(3)(a): Authorised representative's retention period for documentation is below the 10-year requirement"
+}
+
+# Art.18(3)(b) — Provide info/documentation to authorities on reasoned request
+violation contains msg if {
+    input.authorised_representative.appointed == true
+    not input.authorised_representative.tasks.provide_info_on_request
+    msg := "CRA Art.18(3)(b): Authorised representative does not commit to providing information on reasoned request from authorities"
+}
+
+# Art.18(3)(c) — Cooperate with authorities on actions to eliminate cyber risks
+violation contains msg if {
+    input.authorised_representative.appointed == true
+    not input.authorised_representative.tasks.cooperate_on_cyber_risk_action
+    msg := "CRA Art.18(3)(c): Authorised representative does not commit to cooperating with authorities on eliminating cybersecurity risks"
+}
+
+# Art.18(3)(d) — Terminate mandate if manufacturer acts contrary to CRA
+violation contains msg if {
+    input.authorised_representative.appointed == true
+    input.authorised_representative.manufacturer_breaching_cra == true
+    not input.authorised_representative.tasks.notified_competent_authority
+    msg := "CRA Art.18(3)(d): Authorised representative aware of manufacturer breach of CRA but has not informed competent authorities"
+}
+
+violation contains msg if {
+    input.authorised_representative.appointed == true
+    input.authorised_representative.manufacturer_breaching_cra == true
+    not input.authorised_representative.tasks.mandate_termination_considered
+    msg := "CRA Art.18(3)(d): Authorised representative aware of manufacturer's persistent breach but has not considered mandate termination"
+}
+
+# Art.18(4) — Cannot delegate manufacturer's core obligations (essential reqs, conformity assessment)
+violation contains msg if {
+    input.authorised_representative.appointed == true
+    input.authorised_representative.tasks.essential_requirements_delegated == true
+    msg := "CRA Art.18(4): Manufacturer's obligation to ensure essential requirements compliance has been delegated to the authorised representative — this delegation is not permitted"
+}
+
+violation contains msg if {
+    input.authorised_representative.appointed == true
+    input.authorised_representative.tasks.conformity_assessment_delegated == true
+    msg := "CRA Art.18(4): Manufacturer's obligation to perform conformity assessment has been delegated to the authorised representative — this delegation is not permitted"
+}
+
+# Art.18(5) — Contact details of the rep included in user information
+violation contains msg if {
+    input.authorised_representative.appointed == true
+    not input.authorised_representative.contact_in_user_info
+    msg := "CRA Art.18(5): Authorised representative contact details not included in product user information / accompanying documentation"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "family": "Article 18",
+    "name":   "Authorised representative obligations",
+    "controls_evaluated": 13,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/compliance/cra/conformity_assessment/cra_conformity_assessment.rego
+++ b/frameworks/compliance/cra/conformity_assessment/cra_conformity_assessment.rego
@@ -1,0 +1,94 @@
+package cra.conformity_assessment
+
+import rego.v1
+
+# EU Cyber Resilience Act (CRA) — Articles 32-33
+# Conformity assessment procedures + CE marking.
+#
+# Product classification (Article 7 + Annex III):
+#   - Default (most products)        → Module A (internal control)
+#   - Important — Class I            → Module A or B+C
+#   - Important — Class II           → Module B+C, B+D, or H (third-party notified body)
+#   - Critical                       → European cybersecurity certification scheme (Art.8)
+
+default compliant := false
+
+# Article 32 — Conformity assessment procedure required
+violation contains msg if {
+    not input.conformity_assessment.procedure_selected
+    msg := "CRA Art.32(1): Conformity assessment procedure not selected"
+}
+
+# Article 32(2) — Procedure must match product classification
+violation contains msg if {
+    input.conformity_assessment.product_class == "important_class_2"
+    input.conformity_assessment.procedure_used == "module_a"
+    msg := "CRA Art.32(2): Important Class II products require Module B+C, B+D, or H — Module A is insufficient"
+}
+
+violation contains msg if {
+    input.conformity_assessment.product_class == "critical"
+    not input.conformity_assessment.european_cyber_cert_scheme_used
+    msg := "CRA Art.32(3) / Art.8: Critical products require certification under a European cybersecurity certification scheme"
+}
+
+# Article 32(4) — Notified body for third-party assessment
+violation contains msg if {
+    input.conformity_assessment.procedure_used in {"module_b_c", "module_b_d", "module_h"}
+    not input.conformity_assessment.notified_body.engaged
+    msg := "CRA Art.32(4): Third-party conformity assessment selected but no notified body engaged"
+}
+
+violation contains msg if {
+    input.conformity_assessment.notified_body.engaged == true
+    not input.conformity_assessment.notified_body.id_number
+    msg := "CRA Art.32(4): Notified body ID number not recorded"
+}
+
+# Article 33 — CE marking
+violation contains msg if {
+    input.conformity_assessment.product_placed_on_market == true
+    not input.conformity_assessment.ce_marking.affixed
+    msg := "CRA Art.33(1): CE marking not affixed to product before placement on EU market"
+}
+
+violation contains msg if {
+    input.conformity_assessment.ce_marking.affixed == true
+    not input.conformity_assessment.ce_marking.visible_legible_indelible
+    msg := "CRA Art.33(2): CE marking is not visible, legible, and indelible on the product"
+}
+
+violation contains msg if {
+    input.conformity_assessment.procedure_used in {"module_b_c", "module_b_d", "module_h"}
+    not input.conformity_assessment.ce_marking.notified_body_number_included
+    msg := "CRA Art.33(4): Notified body identification number not included with CE marking (required when third-party assessment used)"
+}
+
+# Article 28(1) — EU Declaration of Conformity
+violation contains msg if {
+    not input.conformity_assessment.declaration_of_conformity.prepared
+    msg := "CRA Art.28(1): EU Declaration of Conformity not prepared"
+}
+
+violation contains msg if {
+    input.conformity_assessment.declaration_of_conformity.prepared == true
+    not input.conformity_assessment.declaration_of_conformity.includes_required_elements
+    msg := "CRA Art.28(1) / Annex IV: Declaration of Conformity missing required elements (product ID, manufacturer details, harmonised standards used, conformity statement)"
+}
+
+# Continuous compliance
+violation contains msg if {
+    not input.conformity_assessment.reassessment_on_substantial_modification
+    msg := "CRA Art.32(5): Process not in place to re-assess conformity after substantial product modification"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "family": "Articles 32-33",
+    "name":   "Conformity assessment + CE marking",
+    "controls_evaluated": 11,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/compliance/cra/cra_main.rego
+++ b/frameworks/compliance/cra/cra_main.rego
@@ -9,11 +9,11 @@ import rego.v1
 # on the EU market from December 2027.
 #
 # Applies to:
-#   - Manufacturers
-#   - Importers
-#   - Distributors
-#   of products with digital elements (hardware + software with data
-#   connectivity capability).
+#   - Manufacturers           (Art.13)
+#   - Authorised representatives (Art.18)
+#   - Importers               (Art.19)
+#   - Distributors            (Art.20)
+#   - Open-source stewards    (Art.24 — new CRA category)
 #
 # Product classification (Article 7 + Annex III):
 #   - Default (most products)
@@ -30,13 +30,23 @@ import rego.v1
 #   Article 28 / VII — Technical documentation                      (data.cra.technical_documentation)
 #   Articles 32-33   — Conformity assessment + CE marking           (data.cra.conformity_assessment)
 #   Article 13       — Manufacturer obligations                     (data.cra.manufacturer_obligations)
+#   Article 18       — Authorised representative obligations        (data.cra.authorised_representative)
+#   Article 19       — Importer obligations                         (data.cra.importer_obligations)
+#   Article 20       — Distributor obligations                      (data.cra.distributor_obligations)
+#   Article 24       — Open-source software steward obligations     (data.cra.oss_steward)
+#   Annex II         — User information                             (data.cra.user_information)
 
-import data.cra.essential_requirements    as er
-import data.cra.vulnerability_handling    as vh
-import data.cra.incident_reporting        as ir
-import data.cra.technical_documentation   as td
-import data.cra.conformity_assessment     as ca
-import data.cra.manufacturer_obligations  as mo
+import data.cra.essential_requirements      as er
+import data.cra.vulnerability_handling      as vh
+import data.cra.incident_reporting          as ir
+import data.cra.technical_documentation     as td
+import data.cra.conformity_assessment       as ca
+import data.cra.manufacturer_obligations    as mo
+import data.cra.authorised_representative   as ar
+import data.cra.importer_obligations        as io_
+import data.cra.distributor_obligations     as do_
+import data.cra.oss_steward                 as oss
+import data.cra.user_information            as ui
 
 default compliant := false
 default entity_name := "unknown"
@@ -49,24 +59,46 @@ product_name  := input.product_name
 product_class := input.product_class
 assessed_at   := input.assessment_date
 
-er_v := [v | some v in er.violation]
-vh_v := [v | some v in vh.violation]
-ir_v := [v | some v in ir.violation]
-td_v := [v | some v in td.violation]
-ca_v := [v | some v in ca.violation]
-mo_v := [v | some v in mo.violation]
+er_v  := [v | some v in er.violation]
+vh_v  := [v | some v in vh.violation]
+ir_v  := [v | some v in ir.violation]
+td_v  := [v | some v in td.violation]
+ca_v  := [v | some v in ca.violation]
+mo_v  := [v | some v in mo.violation]
+ar_v  := [v | some v in ar.violation]
+io_v  := [v | some v in io_.violation]
+do_v  := [v | some v in do_.violation]
+oss_v := [v | some v in oss.violation]
+ui_v  := [v | some v in ui.violation]
 
 # Nested 2-arg array.concat per repo convention.
-_er_vh             := array.concat(er_v, vh_v)
-_er_vh_ir          := array.concat(_er_vh, ir_v)
-_er_vh_ir_td       := array.concat(_er_vh_ir, td_v)
-_er_vh_ir_td_ca    := array.concat(_er_vh_ir_td, ca_v)
-all_violations     := array.concat(_er_vh_ir_td_ca, mo_v)
+_a  := array.concat(er_v, vh_v)
+_b  := array.concat(_a, ir_v)
+_c  := array.concat(_b, td_v)
+_d  := array.concat(_c, ca_v)
+_e  := array.concat(_d, mo_v)
+_f  := array.concat(_e, ar_v)
+_g  := array.concat(_f, io_v)
+_h  := array.concat(_g, do_v)
+_i  := array.concat(_h, oss_v)
+all_violations := array.concat(_i, ui_v)
 
 violations := all_violations
 
-# 21 + 16 + 11 + 15 + 11 + 14 = 88 control checks across the six modules.
-total_controls := 88
+# Control counts per module (also documented in each module's compliance_report).
+#   Annex I Part I    essential_requirements    21
+#   Annex I Part II   vulnerability_handling    16
+#   Article 14        incident_reporting        11
+#   Article 28/VII    technical_documentation   15
+#   Articles 32-33    conformity_assessment     11
+#   Article 13        manufacturer_obligations  14
+#   Article 18        authorised_representative 13
+#   Article 19        importer_obligations      14
+#   Article 20        distributor_obligations   15
+#   Article 24        oss_steward               13
+#   Annex II          user_information          20
+# Total: 163 distinct control checks.
+total_controls := 163
 
 compliant if { count(violations) == 0 }
 
@@ -84,11 +116,16 @@ compliance_report := {
     "violations":      violations,
     "violation_count": count(violations),
     "module_summary": {
-        "essential_requirements":   {"violations": count(er_v), "compliant": count(er_v) == 0},
-        "vulnerability_handling":   {"violations": count(vh_v), "compliant": count(vh_v) == 0},
-        "incident_reporting":       {"violations": count(ir_v), "compliant": count(ir_v) == 0},
-        "technical_documentation":  {"violations": count(td_v), "compliant": count(td_v) == 0},
-        "conformity_assessment":    {"violations": count(ca_v), "compliant": count(ca_v) == 0},
-        "manufacturer_obligations": {"violations": count(mo_v), "compliant": count(mo_v) == 0},
+        "essential_requirements":     {"violations": count(er_v),  "compliant": count(er_v)  == 0},
+        "vulnerability_handling":     {"violations": count(vh_v),  "compliant": count(vh_v)  == 0},
+        "incident_reporting":         {"violations": count(ir_v),  "compliant": count(ir_v)  == 0},
+        "technical_documentation":    {"violations": count(td_v),  "compliant": count(td_v)  == 0},
+        "conformity_assessment":      {"violations": count(ca_v),  "compliant": count(ca_v)  == 0},
+        "manufacturer_obligations":   {"violations": count(mo_v),  "compliant": count(mo_v)  == 0},
+        "authorised_representative":  {"violations": count(ar_v),  "compliant": count(ar_v)  == 0},
+        "importer_obligations":       {"violations": count(io_v),  "compliant": count(io_v)  == 0},
+        "distributor_obligations":    {"violations": count(do_v),  "compliant": count(do_v)  == 0},
+        "oss_steward":                {"violations": count(oss_v), "compliant": count(oss_v) == 0},
+        "user_information":           {"violations": count(ui_v),  "compliant": count(ui_v)  == 0},
     },
 }

--- a/frameworks/compliance/cra/cra_main.rego
+++ b/frameworks/compliance/cra/cra_main.rego
@@ -39,6 +39,8 @@ import rego.v1
 #   Article 11       — Substantial modification                     (data.cra.substantial_modification)
 #   Article 22       — Online marketplace obligations               (data.cra.online_marketplace)
 #   Article 23       — FOSS exclusion boundary check                (data.cra.foss_exclusion)
+#   evidence-bridge  — Supply-chain via data.supply_chain.slsa       (data.cra.supply_chain_evidence)
+#   evidence-bridge  — Crypto via data.iso27001.cryptography         (data.cra.crypto_evidence)
 
 import data.cra.essential_requirements      as er
 import data.cra.vulnerability_handling      as vh
@@ -55,6 +57,8 @@ import data.cra.declaration_of_conformity   as doc
 import data.cra.substantial_modification    as sm
 import data.cra.online_marketplace          as om
 import data.cra.foss_exclusion              as foss
+import data.cra.supply_chain_evidence       as sce
+import data.cra.crypto_evidence             as crypto
 
 default compliant := false
 default entity_name := "unknown"
@@ -78,10 +82,12 @@ io_v   := [v | some v in io_.violation]
 do_v   := [v | some v in do_.violation]
 oss_v  := [v | some v in oss.violation]
 ui_v   := [v | some v in ui.violation]
-doc_v  := [v | some v in doc.violation]
-sm_v   := [v | some v in sm.violation]
-om_v   := [v | some v in om.violation]
-foss_v := [v | some v in foss.violation]
+doc_v    := [v | some v in doc.violation]
+sm_v     := [v | some v in sm.violation]
+om_v     := [v | some v in om.violation]
+foss_v   := [v | some v in foss.violation]
+sce_v    := [v | some v in sce.violation]
+crypto_v := [v | some v in crypto.violation]
 
 # Nested 2-arg array.concat per repo convention.
 _a  := array.concat(er_v, vh_v)
@@ -97,7 +103,9 @@ _j  := array.concat(_i, ui_v)
 _k  := array.concat(_j, doc_v)
 _l  := array.concat(_k, sm_v)
 _m  := array.concat(_l, om_v)
-all_violations := array.concat(_m, foss_v)
+_n  := array.concat(_m, foss_v)
+_o  := array.concat(_n, sce_v)
+all_violations := array.concat(_o, crypto_v)
 
 violations := all_violations
 
@@ -117,8 +125,10 @@ violations := all_violations
 #   Article 11        substantial_modification  13
 #   Article 22        online_marketplace        13
 #   Article 23        foss_exclusion             8
-# Total: 217 distinct control checks across 15 modules.
-total_controls := 217
+#   evidence bridge   supply_chain_evidence     14  (re-frames data.supply_chain.slsa findings)
+#   evidence bridge   crypto_evidence           13  (re-frames data.iso27001.cryptography findings)
+# Total: 244 distinct control checks across 17 modules.
+total_controls := 244
 
 compliant if { count(violations) == 0 }
 
@@ -150,7 +160,11 @@ compliance_report := {
         "declaration_of_conformity":  {"violations": count(doc_v),  "compliant": count(doc_v)  == 0},
         "substantial_modification":   {"violations": count(sm_v),   "compliant": count(sm_v)   == 0},
         "online_marketplace":         {"violations": count(om_v),   "compliant": count(om_v)   == 0},
-        "foss_exclusion":             {"violations": count(foss_v), "compliant": count(foss_v) == 0,
+        "foss_exclusion":             {"violations": count(foss_v),   "compliant": count(foss_v)   == 0,
                                        "exempt": foss.exempt},
+        "supply_chain_evidence":      {"violations": count(sce_v),    "compliant": count(sce_v)    == 0,
+                                       "upstream": "data.supply_chain.slsa"},
+        "crypto_evidence":            {"violations": count(crypto_v), "compliant": count(crypto_v) == 0,
+                                       "upstream": "data.iso27001.cryptography"},
     },
 }

--- a/frameworks/compliance/cra/cra_main.rego
+++ b/frameworks/compliance/cra/cra_main.rego
@@ -35,6 +35,10 @@ import rego.v1
 #   Article 20       — Distributor obligations                      (data.cra.distributor_obligations)
 #   Article 24       — Open-source software steward obligations     (data.cra.oss_steward)
 #   Annex II         — User information                             (data.cra.user_information)
+#   Annex IV         — Declaration of Conformity content            (data.cra.declaration_of_conformity)
+#   Article 11       — Substantial modification                     (data.cra.substantial_modification)
+#   Article 22       — Online marketplace obligations               (data.cra.online_marketplace)
+#   Article 23       — FOSS exclusion boundary check                (data.cra.foss_exclusion)
 
 import data.cra.essential_requirements      as er
 import data.cra.vulnerability_handling      as vh
@@ -47,6 +51,10 @@ import data.cra.importer_obligations        as io_
 import data.cra.distributor_obligations     as do_
 import data.cra.oss_steward                 as oss
 import data.cra.user_information            as ui
+import data.cra.declaration_of_conformity   as doc
+import data.cra.substantial_modification    as sm
+import data.cra.online_marketplace          as om
+import data.cra.foss_exclusion              as foss
 
 default compliant := false
 default entity_name := "unknown"
@@ -59,17 +67,21 @@ product_name  := input.product_name
 product_class := input.product_class
 assessed_at   := input.assessment_date
 
-er_v  := [v | some v in er.violation]
-vh_v  := [v | some v in vh.violation]
-ir_v  := [v | some v in ir.violation]
-td_v  := [v | some v in td.violation]
-ca_v  := [v | some v in ca.violation]
-mo_v  := [v | some v in mo.violation]
-ar_v  := [v | some v in ar.violation]
-io_v  := [v | some v in io_.violation]
-do_v  := [v | some v in do_.violation]
-oss_v := [v | some v in oss.violation]
-ui_v  := [v | some v in ui.violation]
+er_v   := [v | some v in er.violation]
+vh_v   := [v | some v in vh.violation]
+ir_v   := [v | some v in ir.violation]
+td_v   := [v | some v in td.violation]
+ca_v   := [v | some v in ca.violation]
+mo_v   := [v | some v in mo.violation]
+ar_v   := [v | some v in ar.violation]
+io_v   := [v | some v in io_.violation]
+do_v   := [v | some v in do_.violation]
+oss_v  := [v | some v in oss.violation]
+ui_v   := [v | some v in ui.violation]
+doc_v  := [v | some v in doc.violation]
+sm_v   := [v | some v in sm.violation]
+om_v   := [v | some v in om.violation]
+foss_v := [v | some v in foss.violation]
 
 # Nested 2-arg array.concat per repo convention.
 _a  := array.concat(er_v, vh_v)
@@ -81,7 +93,11 @@ _f  := array.concat(_e, ar_v)
 _g  := array.concat(_f, io_v)
 _h  := array.concat(_g, do_v)
 _i  := array.concat(_h, oss_v)
-all_violations := array.concat(_i, ui_v)
+_j  := array.concat(_i, ui_v)
+_k  := array.concat(_j, doc_v)
+_l  := array.concat(_k, sm_v)
+_m  := array.concat(_l, om_v)
+all_violations := array.concat(_m, foss_v)
 
 violations := all_violations
 
@@ -97,8 +113,12 @@ violations := all_violations
 #   Article 20        distributor_obligations   15
 #   Article 24        oss_steward               13
 #   Annex II          user_information          20
-# Total: 163 distinct control checks.
-total_controls := 163
+#   Annex IV          declaration_of_conformity 20
+#   Article 11        substantial_modification  13
+#   Article 22        online_marketplace        13
+#   Article 23        foss_exclusion             8
+# Total: 217 distinct control checks across 15 modules.
+total_controls := 217
 
 compliant if { count(violations) == 0 }
 
@@ -116,16 +136,21 @@ compliance_report := {
     "violations":      violations,
     "violation_count": count(violations),
     "module_summary": {
-        "essential_requirements":     {"violations": count(er_v),  "compliant": count(er_v)  == 0},
-        "vulnerability_handling":     {"violations": count(vh_v),  "compliant": count(vh_v)  == 0},
-        "incident_reporting":         {"violations": count(ir_v),  "compliant": count(ir_v)  == 0},
-        "technical_documentation":    {"violations": count(td_v),  "compliant": count(td_v)  == 0},
-        "conformity_assessment":      {"violations": count(ca_v),  "compliant": count(ca_v)  == 0},
-        "manufacturer_obligations":   {"violations": count(mo_v),  "compliant": count(mo_v)  == 0},
-        "authorised_representative":  {"violations": count(ar_v),  "compliant": count(ar_v)  == 0},
-        "importer_obligations":       {"violations": count(io_v),  "compliant": count(io_v)  == 0},
-        "distributor_obligations":    {"violations": count(do_v),  "compliant": count(do_v)  == 0},
-        "oss_steward":                {"violations": count(oss_v), "compliant": count(oss_v) == 0},
-        "user_information":           {"violations": count(ui_v),  "compliant": count(ui_v)  == 0},
+        "essential_requirements":     {"violations": count(er_v),   "compliant": count(er_v)   == 0},
+        "vulnerability_handling":     {"violations": count(vh_v),   "compliant": count(vh_v)   == 0},
+        "incident_reporting":         {"violations": count(ir_v),   "compliant": count(ir_v)   == 0},
+        "technical_documentation":    {"violations": count(td_v),   "compliant": count(td_v)   == 0},
+        "conformity_assessment":      {"violations": count(ca_v),   "compliant": count(ca_v)   == 0},
+        "manufacturer_obligations":   {"violations": count(mo_v),   "compliant": count(mo_v)   == 0},
+        "authorised_representative":  {"violations": count(ar_v),   "compliant": count(ar_v)   == 0},
+        "importer_obligations":       {"violations": count(io_v),   "compliant": count(io_v)   == 0},
+        "distributor_obligations":    {"violations": count(do_v),   "compliant": count(do_v)   == 0},
+        "oss_steward":                {"violations": count(oss_v),  "compliant": count(oss_v)  == 0},
+        "user_information":           {"violations": count(ui_v),   "compliant": count(ui_v)   == 0},
+        "declaration_of_conformity":  {"violations": count(doc_v),  "compliant": count(doc_v)  == 0},
+        "substantial_modification":   {"violations": count(sm_v),   "compliant": count(sm_v)   == 0},
+        "online_marketplace":         {"violations": count(om_v),   "compliant": count(om_v)   == 0},
+        "foss_exclusion":             {"violations": count(foss_v), "compliant": count(foss_v) == 0,
+                                       "exempt": foss.exempt},
     },
 }

--- a/frameworks/compliance/cra/cra_main.rego
+++ b/frameworks/compliance/cra/cra_main.rego
@@ -1,0 +1,94 @@
+package cra.main
+
+import rego.v1
+
+# EU Cyber Resilience Act (CRA) — Master orchestrator.
+#
+# Regulation (EU) 2024/2847. Entered into force November 2024;
+# mandatory compliance for products with digital elements (PDE) placed
+# on the EU market from December 2027.
+#
+# Applies to:
+#   - Manufacturers
+#   - Importers
+#   - Distributors
+#   of products with digital elements (hardware + software with data
+#   connectivity capability).
+#
+# Product classification (Article 7 + Annex III):
+#   - Default (most products)
+#   - Important — Class I
+#   - Important — Class II  (third-party conformity assessment required)
+#   - Critical               (European cybersecurity certification scheme)
+#
+# OPA endpoint: POST <opa_compliance>/v1/data/cra/main/compliance_report
+#
+# Sub-modules aggregated:
+#   Annex I Part I   — Essential cybersecurity requirements         (data.cra.essential_requirements)
+#   Annex I Part II  — Vulnerability handling                       (data.cra.vulnerability_handling)
+#   Article 14       — Incident reporting (24h / 72h / final)       (data.cra.incident_reporting)
+#   Article 28 / VII — Technical documentation                      (data.cra.technical_documentation)
+#   Articles 32-33   — Conformity assessment + CE marking           (data.cra.conformity_assessment)
+#   Article 13       — Manufacturer obligations                     (data.cra.manufacturer_obligations)
+
+import data.cra.essential_requirements    as er
+import data.cra.vulnerability_handling    as vh
+import data.cra.incident_reporting        as ir
+import data.cra.technical_documentation   as td
+import data.cra.conformity_assessment     as ca
+import data.cra.manufacturer_obligations  as mo
+
+default compliant := false
+default entity_name := "unknown"
+default product_name := "unknown"
+default product_class := "unknown"
+default assessed_at := "unknown"
+
+entity_name   := input.entity_name
+product_name  := input.product_name
+product_class := input.product_class
+assessed_at   := input.assessment_date
+
+er_v := [v | some v in er.violation]
+vh_v := [v | some v in vh.violation]
+ir_v := [v | some v in ir.violation]
+td_v := [v | some v in td.violation]
+ca_v := [v | some v in ca.violation]
+mo_v := [v | some v in mo.violation]
+
+# Nested 2-arg array.concat per repo convention.
+_er_vh             := array.concat(er_v, vh_v)
+_er_vh_ir          := array.concat(_er_vh, ir_v)
+_er_vh_ir_td       := array.concat(_er_vh_ir, td_v)
+_er_vh_ir_td_ca    := array.concat(_er_vh_ir_td, ca_v)
+all_violations     := array.concat(_er_vh_ir_td_ca, mo_v)
+
+violations := all_violations
+
+# 21 + 16 + 11 + 15 + 11 + 14 = 88 control checks across the six modules.
+total_controls := 88
+
+compliant if { count(violations) == 0 }
+
+compliance_report := {
+    "framework":       "EU Cyber Resilience Act (CRA)",
+    "regulation":      "Regulation (EU) 2024/2847",
+    "in_force":        "2024-11",
+    "mandatory_from":  "2027-12",
+    "entity_name":     entity_name,
+    "product_name":    product_name,
+    "product_class":   product_class,
+    "assessed_at":     assessed_at,
+    "compliant":       compliant,
+    "total_controls":  total_controls,
+    "violations":      violations,
+    "violation_count": count(violations),
+    "module_summary": {
+        "essential_requirements":   {"violations": count(er_v), "compliant": count(er_v) == 0},
+        "vulnerability_handling":   {"violations": count(vh_v), "compliant": count(vh_v) == 0},
+        "incident_reporting":       {"violations": count(ir_v), "compliant": count(ir_v) == 0},
+        "technical_documentation":  {"violations": count(td_v), "compliant": count(td_v) == 0},
+        "conformity_assessment":    {"violations": count(ca_v), "compliant": count(ca_v) == 0},
+        "manufacturer_obligations": {"violations": count(mo_v), "compliant": count(mo_v) == 0},
+    },
+}

--- a/frameworks/compliance/cra/crypto_evidence/cra_crypto_evidence.rego
+++ b/frameworks/compliance/cra/crypto_evidence/cra_crypto_evidence.rego
@@ -1,0 +1,154 @@
+package cra.crypto_evidence
+
+import rego.v1
+import data.iso27001.cryptography as iso_crypto
+
+# CRA — Cryptography evidence integration.
+#
+# Re-uses findings from the ISO 27001 cryptography module
+# (data.iso27001.cryptography) and re-frames them as CRA Annex I.5
+# (confidentiality) and Annex I.6 (integrity) violations. Organisations
+# already maintaining ISO 27001 A.10 compliance produce the input shape
+# this module consumes — no second attestation is required.
+#
+# Input shape: input.cryptography.* + input.key_management.* exactly as
+# data.iso27001.cryptography expects.
+
+default compliant := false
+
+# Helper — true if the named ISO 27001 boolean rule does NOT hold.
+iso_failed(rule_name) if {
+    rule_name == "cryptographic_policy"
+    not iso_crypto.cryptographic_policy
+}
+
+iso_failed(rule_name) if {
+    rule_name == "key_management"
+    not iso_crypto.key_management
+}
+
+iso_failed(rule_name) if {
+    rule_name == "key_generation_secure"
+    not iso_crypto.key_generation_secure
+}
+
+iso_failed(rule_name) if {
+    rule_name == "key_distribution_secure"
+    not iso_crypto.key_distribution_secure
+}
+
+iso_failed(rule_name) if {
+    rule_name == "key_usage_controlled"
+    not iso_crypto.key_usage_controlled
+}
+
+iso_failed(rule_name) if {
+    rule_name == "key_destruction_secure"
+    not iso_crypto.key_destruction_secure
+}
+
+# ── CRA Annex I.5 — Confidentiality (encryption) ────────────────────────
+
+# Annex I.5 demands appropriate confidentiality protection. A missing
+# crypto policy means the manufacturer cannot demonstrate "appropriate
+# level of cryptographic protection" — the auditor will refuse the claim.
+violation contains msg if {
+    iso_failed("cryptographic_policy")
+    msg := "CRA Annex I.5 (via ISO 27001 A.10.1.1): No documented cryptographic policy — Annex I.5 cannot be attested without a policy that specifies approved algorithms + key management"
+}
+
+violation contains msg if {
+    iso_failed("key_generation_secure")
+    msg := "CRA Annex I.5 (via ISO 27001 A.10.1.2): Key generation is not demonstrably secure (random source / entropy / approved algorithms) — undermines confidentiality of encrypted data"
+}
+
+violation contains msg if {
+    iso_failed("key_distribution_secure")
+    msg := "CRA Annex I.5 (via ISO 27001 A.10.1.2): Key distribution is not secure — keys in transit may be intercepted, breaking confidentiality at the boundary"
+}
+
+# Annex I.5(b) — data in transit. State-of-the-art encryption means TLS 1.2+
+# with current cipher suites, no deprecated protocols.
+violation contains msg if {
+    some proto in input.cryptography.protocols_in_use
+    proto in {"SSLv2", "SSLv3", "TLS1.0", "TLS1.1"}
+    msg := sprintf("CRA Annex I.5(b): Deprecated transport protocol '%s' in use — not state-of-the-art for transmission confidentiality", [proto])
+}
+
+violation contains msg if {
+    some cipher in input.cryptography.ciphers_in_use
+    cipher in {"DES", "3DES", "RC4", "MD5", "SHA1", "RC2", "EXPORT"}
+    msg := sprintf("CRA Annex I.5(b): Weak cipher '%s' in use — not state-of-the-art for transmission confidentiality", [cipher])
+}
+
+# Annex I.5(a) — data at rest.
+violation contains msg if {
+    not input.cryptography.at_rest.disk_encryption_enabled
+    msg := "CRA Annex I.5(a) (via ISO 27001 A.10): Disk-level encryption not enabled for stored data — at-rest confidentiality not protected"
+}
+
+violation contains msg if {
+    not input.cryptography.at_rest.database_encryption_enabled
+    msg := "CRA Annex I.5(a) (via ISO 27001 A.10): Database encryption not enabled — stored personal/sensitive data confidentiality not protected"
+}
+
+# ── CRA Annex I.6 — Integrity (code signing, anti-tamper) ─────────────────
+
+violation contains msg if {
+    iso_failed("key_usage_controlled")
+    msg := "CRA Annex I.6 (via ISO 27001 A.10.1.2): Key usage not controlled — signing keys may be used by unauthorised processes, undermining code-signing integrity"
+}
+
+violation contains msg if {
+    iso_failed("key_destruction_secure")
+    msg := "CRA Annex I.6 (via ISO 27001 A.10.1.2): Expired key destruction not secure — superseded signing keys may still produce valid-looking signatures, breaking tamper detection"
+}
+
+# Anti-rollback (Annex I.6(b)) — old signed firmware should not be installable.
+violation contains msg if {
+    not input.cryptography.signing.anti_rollback_enforced
+    msg := "CRA Annex I.6(b): Anti-rollback enforcement not in place — older signed firmware can be re-installed, defeating tamper detection"
+}
+
+# Hardware-backed key storage (Annex I.4 + I.6 interaction)
+violation contains msg if {
+    input.cryptography.signing.in_use
+    not input.cryptography.signing.hardware_backed_key_storage
+    msg := "CRA Annex I.6 (interaction with I.4): Signing keys not held in hardware-backed storage — chain of trust depends on a key the host OS can read"
+}
+
+# ── CRA Annex I.4 — authentication state-of-the-art ─────────────────────
+
+# FIPS validation (FIPS 140-2 Level 2+) is the closest commonly-recognised
+# objective standard. Annex I.4 says "state-of-the-art" without naming a
+# specific standard, but absence of FIPS validation is rarely defensible.
+violation contains msg if {
+    not input.cryptography.fips_validated
+    msg := "CRA Annex I.4 (auth interaction): Cryptographic modules used for authentication are not FIPS 140-2/3 validated — state-of-the-art claim is not defensible"
+}
+
+# ── Manufacturer obligation (Art.13(1) interaction) ─────────────────────
+
+violation contains msg if {
+    iso_failed("key_management")
+    msg := "CRA Art.13(1) (via ISO 27001 A.10.1.2): Manufacturer cannot attest to ensuring essential requirements compliance — key management foundation is incomplete"
+}
+
+# ── Compliance + report ─────────────────────────────────────────────────
+
+compliant if { count(violation) == 0 }
+
+iso_27001_crypto_compliant := iso_crypto.cryptographic_controls
+
+compliance_report := {
+    "family": "Cryptography evidence integration",
+    "name":   "CRA × ISO 27001 A.10 findings bridge",
+    "controls_evaluated": 13,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+    "upstream": {
+        "module": "data.iso27001.cryptography",
+        "iso_a10_compliant": iso_27001_crypto_compliant,
+    },
+}

--- a/frameworks/compliance/cra/declaration_of_conformity/cra_declaration_of_conformity.rego
+++ b/frameworks/compliance/cra/declaration_of_conformity/cra_declaration_of_conformity.rego
@@ -1,0 +1,141 @@
+package cra.declaration_of_conformity
+
+import rego.v1
+
+# EU Cyber Resilience Act (CRA) — Annex IV
+# Content of the EU Declaration of Conformity.
+#
+# This module checks the CONTENT of the declaration, distinct from
+# cra.conformity_assessment which only checks that the declaration
+# was prepared and signed. Annex IV enumerates the required elements;
+# omitting any of them invalidates the declaration even if it exists.
+
+default compliant := false
+
+# Annex IV (1) — Product model identifier
+violation contains msg if {
+    not input.declaration_of_conformity.product_identification.model_id
+    msg := "CRA Annex IV.1: Declaration of Conformity does not state the product model / type identifier"
+}
+
+violation contains msg if {
+    not input.declaration_of_conformity.product_identification.serial_or_batch
+    msg := "CRA Annex IV.1: Declaration of Conformity does not state the serial/batch identifier"
+}
+
+# Annex IV (2) — Manufacturer details
+violation contains msg if {
+    not input.declaration_of_conformity.manufacturer.name
+    msg := "CRA Annex IV.2: Declaration of Conformity does not state the manufacturer name"
+}
+
+violation contains msg if {
+    not input.declaration_of_conformity.manufacturer.postal_address
+    msg := "CRA Annex IV.2: Declaration of Conformity does not state the manufacturer postal address"
+}
+
+# Annex IV (3) — Authorised representative details (where applicable)
+violation contains msg if {
+    input.declaration_of_conformity.authorised_representative.required == true
+    not input.declaration_of_conformity.authorised_representative.name
+    msg := "CRA Annex IV.3: Authorised representative is required but the declaration does not state their name"
+}
+
+violation contains msg if {
+    input.declaration_of_conformity.authorised_representative.required == true
+    not input.declaration_of_conformity.authorised_representative.postal_address
+    msg := "CRA Annex IV.3: Authorised representative is required but the declaration does not state their postal address"
+}
+
+# Annex IV (4) — Statement of sole responsibility
+violation contains msg if {
+    not input.declaration_of_conformity.statement_of_sole_responsibility
+    msg := "CRA Annex IV.4: Declaration of Conformity does not include the statement 'This declaration of conformity is issued under the sole responsibility of the manufacturer'"
+}
+
+# Annex IV (5) — Object of the declaration (description sufficient for product traceability)
+violation contains msg if {
+    not input.declaration_of_conformity.object_description.sufficient_for_traceability
+    msg := "CRA Annex IV.5: Object of the declaration (product description) not sufficient for product traceability — must include name, type, additional info"
+}
+
+# Annex IV (6) — Statement of conformity with CRA
+violation contains msg if {
+    not input.declaration_of_conformity.conformity_statement.references_cra
+    msg := "CRA Annex IV.6: Declaration does not explicitly state conformity with Regulation (EU) 2024/2847"
+}
+
+# Annex IV (7) — Reference to harmonised standards / common specifications used
+violation contains msg if {
+    not input.declaration_of_conformity.standards.harmonised_standards_referenced
+    msg := "CRA Annex IV.7: Declaration does not reference the harmonised standards or common specifications applied to demonstrate conformity"
+}
+
+violation contains msg if {
+    input.declaration_of_conformity.standards.harmonised_standards_referenced == true
+    not input.declaration_of_conformity.standards.standard_dates_versions_included
+    msg := "CRA Annex IV.7: Declaration references harmonised standards but does not include their dates/versions"
+}
+
+# Annex IV (8) — Notified body involvement (where applicable)
+violation contains msg if {
+    input.declaration_of_conformity.notified_body.involved == true
+    not input.declaration_of_conformity.notified_body.name
+    msg := "CRA Annex IV.8: Notified body involvement is declared but the notified body name is missing"
+}
+
+violation contains msg if {
+    input.declaration_of_conformity.notified_body.involved == true
+    not input.declaration_of_conformity.notified_body.id_number
+    msg := "CRA Annex IV.8: Notified body involvement is declared but the notified body identification number is missing"
+}
+
+violation contains msg if {
+    input.declaration_of_conformity.notified_body.involved == true
+    not input.declaration_of_conformity.notified_body.certificate_reference
+    msg := "CRA Annex IV.8: Notified body involvement is declared but the issued certificate reference is missing"
+}
+
+# Annex IV (9) — Additional information
+violation contains msg if {
+    not input.declaration_of_conformity.additional_info.support_period_stated
+    msg := "CRA Annex IV.9: Declaration of Conformity does not state the declared support period"
+}
+
+# Annex IV (10) — Signature
+violation contains msg if {
+    not input.declaration_of_conformity.signature.signed_for_manufacturer
+    msg := "CRA Annex IV.10: Declaration of Conformity has not been signed for and on behalf of the manufacturer"
+}
+
+violation contains msg if {
+    not input.declaration_of_conformity.signature.signatory_name
+    msg := "CRA Annex IV.10: Declaration of Conformity signature does not include the signatory's name"
+}
+
+violation contains msg if {
+    not input.declaration_of_conformity.signature.signatory_function
+    msg := "CRA Annex IV.10: Declaration of Conformity signature does not include the signatory's function"
+}
+
+violation contains msg if {
+    not input.declaration_of_conformity.signature.place_and_date
+    msg := "CRA Annex IV.10: Declaration of Conformity does not include the place and date of issue"
+}
+
+# Languages — Annex IV preamble (translated into Member State languages where product is sold)
+violation contains msg if {
+    not input.declaration_of_conformity.languages.translated_for_member_states
+    msg := "CRA Annex IV (preamble): Declaration not translated into the official languages of the Member States where the product is placed on the market"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "family": "Annex IV",
+    "name":   "Content of EU Declaration of Conformity",
+    "controls_evaluated": 20,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/compliance/cra/distributor_obligations/cra_distributor_obligations.rego
+++ b/frameworks/compliance/cra/distributor_obligations/cra_distributor_obligations.rego
@@ -1,0 +1,116 @@
+package cra.distributor_obligations
+
+import rego.v1
+
+# EU Cyber Resilience Act (CRA) — Article 20
+# Distributor obligations.
+#
+# Distributors making products with digital elements available on the EU
+# market must act with due care to ensure those products comply with CRA.
+# Article 21 also makes a distributor a "manufacturer" when they modify
+# the product or sell it under their own name.
+
+default compliant := false
+
+# Art.20(1) — Verify before making the product available
+violation contains msg if {
+    not input.distributor.verification.ce_marking_present
+    msg := "CRA Art.20(1)(a): Distributor has not verified CE marking before making the product available"
+}
+
+violation contains msg if {
+    not input.distributor.verification.declaration_of_conformity_provided
+    msg := "CRA Art.20(1)(b): Distributor has not verified that the Declaration of Conformity accompanies the product"
+}
+
+violation contains msg if {
+    not input.distributor.verification.manufacturer_identification_clear
+    msg := "CRA Art.20(1)(c): Distributor has not verified manufacturer name + contact info are clearly identified on the product"
+}
+
+violation contains msg if {
+    not input.distributor.verification.importer_identification_clear
+    input.distributor.product_is_imported == true
+    msg := "CRA Art.20(1)(c): Distributor has not verified importer name + address are present on imported products"
+}
+
+violation contains msg if {
+    not input.distributor.verification.user_instructions_provided
+    msg := "CRA Art.20(1)(d): Distributor has not verified user instructions/information are provided with the product"
+}
+
+# Art.20(2) — Suspend availability when non-compliance suspected
+violation contains msg if {
+    input.distributor.non_conformity_suspected == true
+    not input.distributor.action.availability_suspended
+    msg := "CRA Art.20(2): Distributor has not suspended making the product available when non-conformity was suspected"
+}
+
+# Art.20(2) — Inform manufacturer + importer
+violation contains msg if {
+    input.distributor.non_conformity_suspected == true
+    not input.distributor.action.manufacturer_informed
+    msg := "CRA Art.20(2): Distributor has not informed the manufacturer of suspected non-conformity"
+}
+
+# Art.20(3) — Storage / transport must not jeopardise compliance
+violation contains msg if {
+    not input.distributor.handling.storage_preserves_compliance
+    msg := "CRA Art.20(3): Storage or transport conditions risk jeopardising product compliance with essential requirements"
+}
+
+# Art.20(4) — Inform market surveillance on significant cyber risk
+violation contains msg if {
+    input.distributor.risk_awareness.significant_risk_known == true
+    not input.distributor.risk_awareness.market_surveillance_informed
+    msg := "CRA Art.20(4): Distributor has not informed market surveillance authorities of a known significant cybersecurity risk"
+}
+
+# Art.20(5) — Provide information + cooperate with authorities
+violation contains msg if {
+    not input.distributor.cooperation.provide_info_on_request
+    msg := "CRA Art.20(5): Distributor not committed to providing requested information to market surveillance authorities"
+}
+
+violation contains msg if {
+    not input.distributor.cooperation.cooperate_on_corrective_action
+    msg := "CRA Art.20(5): Distributor not committed to cooperating on corrective action when requested"
+}
+
+# Art.20(6) — Corrective action / withdrawal when non-conformity confirmed
+violation contains msg if {
+    input.distributor.non_conformity_confirmed == true
+    not input.distributor.corrective_action.taken
+    msg := "CRA Art.20(6): Distributor has not taken corrective action on confirmed non-conforming products"
+}
+
+violation contains msg if {
+    input.distributor.non_conformity_confirmed == true
+    input.distributor.corrective_action.severity == "high"
+    not input.distributor.corrective_action.withdrawal_or_recall
+    msg := "CRA Art.20(6): Distributor has not withdrawn / recalled non-conforming product where the cyber risk requires it"
+}
+
+# Article 21 — Distributor becomes manufacturer when modifying or rebranding
+violation contains msg if {
+    input.distributor.product_modified_after_placement == true
+    not input.distributor.assumed_manufacturer_obligations
+    msg := "CRA Art.21: Distributor that modified the product has not assumed manufacturer obligations under Article 13"
+}
+
+violation contains msg if {
+    input.distributor.sold_under_own_brand == true
+    not input.distributor.assumed_manufacturer_obligations
+    msg := "CRA Art.21: Distributor selling the product under its own name/trademark has not assumed manufacturer obligations"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "family": "Article 20",
+    "name":   "Distributor obligations",
+    "controls_evaluated": 15,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/compliance/cra/essential_requirements/cra_essential_requirements.rego
+++ b/frameworks/compliance/cra/essential_requirements/cra_essential_requirements.rego
@@ -1,0 +1,135 @@
+package cra.essential_requirements
+
+import rego.v1
+
+# EU Cyber Resilience Act (CRA) — Annex I Part I
+# Essential cybersecurity requirements for products with digital elements (PDE).
+#
+# These requirements apply to every product with digital elements placed on
+# the EU market. Manufacturers must ensure compliance "by design" before
+# CE marking is permitted (Articles 32-33).
+
+default compliant := false
+
+# Annex I Part I (1) — Security by design
+violation contains msg if {
+    not input.essential_requirements.security_by_design.threat_modeled
+    msg := "CRA Annex I.1(a): Product not designed/developed with appropriate level of cybersecurity based on risk assessment"
+}
+
+violation contains msg if {
+    not input.essential_requirements.security_by_design.documented_assessment
+    msg := "CRA Annex I.1(b): Cybersecurity risk assessment not documented"
+}
+
+# Annex I Part I (2) — Secure default configuration
+violation contains msg if {
+    not input.essential_requirements.default_config.secure_out_of_box
+    msg := "CRA Annex I.2(a): Product not delivered with a secure-by-default configuration"
+}
+
+violation contains msg if {
+    not input.essential_requirements.default_config.allows_reset_to_secure_defaults
+    msg := "CRA Annex I.2(b): Product does not allow reset to the original secure default configuration"
+}
+
+# Annex I Part I (3) — Vulnerability protection
+violation contains msg if {
+    not input.essential_requirements.vulnerability_protection.security_updates_distinct
+    msg := "CRA Annex I.3(a): Security updates not delivered separately from feature updates"
+}
+
+violation contains msg if {
+    not input.essential_requirements.vulnerability_protection.automatic_updates_default
+    msg := "CRA Annex I.3(b): Automatic security update mechanism not available or not enabled by default"
+}
+
+# Annex I Part I (4) — Protection from unauthorized access
+violation contains msg if {
+    not input.essential_requirements.access_protection.authentication_state_of_the_art
+    msg := "CRA Annex I.4(a): Authentication mechanisms not state-of-the-art (e.g., MFA, hardware-backed keys for sensitive functions)"
+}
+
+violation contains msg if {
+    not input.essential_requirements.access_protection.identity_access_management
+    msg := "CRA Annex I.4(b): Identity and access management controls not implemented"
+}
+
+# Annex I Part I (5) — Confidentiality protection
+violation contains msg if {
+    not input.essential_requirements.confidentiality.data_at_rest_encrypted
+    msg := "CRA Annex I.5(a): Stored/personal data not protected by encryption or comparable mechanisms"
+}
+
+violation contains msg if {
+    not input.essential_requirements.confidentiality.data_in_transit_encrypted
+    msg := "CRA Annex I.5(b): Transmitted data not protected via state-of-the-art encryption"
+}
+
+# Annex I Part I (6) — Integrity protection
+violation contains msg if {
+    not input.essential_requirements.integrity.code_signing_enforced
+    msg := "CRA Annex I.6(a): Product does not protect integrity of stored/transmitted code and configuration (no code signing)"
+}
+
+violation contains msg if {
+    not input.essential_requirements.integrity.tamper_detection
+    msg := "CRA Annex I.6(b): Tamper detection / anti-rollback mechanisms not implemented"
+}
+
+# Annex I Part I (7) — Data minimization
+violation contains msg if {
+    not input.essential_requirements.data_minimization.only_necessary_data_processed
+    msg := "CRA Annex I.7: Product processes data beyond what is necessary for its intended use"
+}
+
+# Annex I Part I (8) — Availability protection
+violation contains msg if {
+    not input.essential_requirements.availability.dos_protection
+    msg := "CRA Annex I.8(a): Product not protected against denial-of-service attacks affecting essential functions"
+}
+
+violation contains msg if {
+    not input.essential_requirements.availability.essential_functions_preserved
+    msg := "CRA Annex I.8(b): Essential functions not preserved during/after a security incident"
+}
+
+# Annex I Part I (9) — Limit attack surfaces
+violation contains msg if {
+    not input.essential_requirements.attack_surface.external_interfaces_minimized
+    msg := "CRA Annex I.9: External interfaces and attack surfaces not minimized"
+}
+
+# Annex I Part I (10) — Mitigate exploitation impact
+violation contains msg if {
+    not input.essential_requirements.exploitation_mitigation.techniques_implemented
+    msg := "CRA Annex I.10: Exploitation mitigation techniques (sandboxing, ASLR, control-flow integrity) not implemented"
+}
+
+# Annex I Part I (11) — Security-relevant data logging
+violation contains msg if {
+    not input.essential_requirements.logging.security_events_recorded
+    msg := "CRA Annex I.11(a): Security-relevant events not recorded/monitored"
+}
+
+violation contains msg if {
+    not input.essential_requirements.logging.user_can_opt_out
+    msg := "CRA Annex I.11(b): User cannot opt out of non-essential logging (privacy violation)"
+}
+
+# Annex I Part I (12) — Secure data deletion
+violation contains msg if {
+    not input.essential_requirements.data_deletion.secure_erase_available
+    msg := "CRA Annex I.12: Secure data deletion mechanism (factory reset / cryptographic erase) not provided"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "family": "Annex I Part I",
+    "name":   "Essential cybersecurity requirements",
+    "controls_evaluated": 21,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/compliance/cra/foss_exclusion/cra_foss_exclusion.rego
+++ b/frameworks/compliance/cra/foss_exclusion/cra_foss_exclusion.rego
@@ -1,0 +1,111 @@
+package cra.foss_exclusion
+
+import rego.v1
+
+# EU Cyber Resilience Act (CRA) — Article 23 (recitals 15-18) + interaction with Art.24
+# Free and open-source software exclusion.
+#
+# CRA does NOT apply to free + open-source software supplied "outside the
+# course of a commercial activity". The challenge is that the boundary
+# between "commercial" and "non-commercial" OSS is fact-specific:
+#   - A single corporate sponsor providing paid support → commercial
+#   - A foundation / nonprofit collecting donations to fund development →
+#     case-by-case (recital 15)
+#   - Individual maintainer accepting donations / sponsorship → typically
+#     non-commercial (and therefore exempt)
+#
+# This module evaluates the boundary conditions. If the entity meets the
+# non-commercial exclusion criteria, the policy returns ZERO violations
+# regardless of what other CRA modules find — that is the correct outcome.
+#
+# Returns:
+#   * `exempt = true` when Art.23 exclusion applies — no violations emitted
+#   * `exempt = false` when CRA applies — violations emitted only if the
+#     entity claimed exemption it isn't entitled to.
+
+default compliant := true   # default is "no obligation" — exemption applies
+default exempt := false
+
+# ── Threshold conditions for the Art.23 exclusion ─────────────────────────
+
+# Recital 15 — distinguishes the supplier from the user perspective.
+exempt if {
+    input.foss.is_open_source_product
+    input.foss.outside_course_of_commercial_activity
+}
+
+# ── Misuse: claimed exemption but commercial markers are present ──────────
+
+# An entity that asserts the FOSS exclusion while collecting commercial
+# revenue (paid support, license fees, hosted SaaS) is misclassifying.
+violation contains msg if {
+    input.foss.claimed_exemption == true
+    input.foss.revenue.paid_support_offered
+    msg := "CRA Art.23 (mis-claim): FOSS exemption claimed, but the entity offers paid support — this is a commercial activity"
+}
+
+violation contains msg if {
+    input.foss.claimed_exemption == true
+    input.foss.revenue.license_fees_collected
+    msg := "CRA Art.23 (mis-claim): FOSS exemption claimed, but the entity collects license/usage fees — this is a commercial activity"
+}
+
+violation contains msg if {
+    input.foss.claimed_exemption == true
+    input.foss.revenue.commercial_saas_hosting
+    msg := "CRA Art.23 (mis-claim): FOSS exemption claimed, but the entity offers a commercial hosted version — this is a commercial activity"
+}
+
+# Donations on their own do NOT constitute commercial activity (recital 15)
+# but combined with sustained employed development they may. Check pattern:
+violation contains msg if {
+    input.foss.claimed_exemption == true
+    input.foss.revenue.donations_received
+    input.foss.development.employed_developers_paid_from_donations
+    input.foss.development.developers_full_time
+    msg := "CRA Art.23 (boundary): Donation-funded full-time paid developers move the entity toward the OSS-steward category (Art.24), not the Art.23 exclusion"
+}
+
+# Recital 18 — single integrator placing FOSS-based commercial product on
+# market does not benefit from the exclusion regardless of what the upstream
+# OSS license says.
+violation contains msg if {
+    input.foss.claimed_exemption == true
+    input.foss.distribution.integrated_into_commercial_product
+    input.foss.distribution.distributed_in_eu_market
+    msg := "CRA Recital 18: FOSS exemption does not apply when the software is integrated into a commercial product distributed on the EU market"
+}
+
+# ── Process documentation ─────────────────────────────────────────────────
+
+violation contains msg if {
+    input.foss.claimed_exemption == true
+    not input.foss.process.exemption_basis_documented
+    msg := "CRA Art.23: FOSS exemption claimed but the basis for the claim is not documented (no audit trail)"
+}
+
+violation contains msg if {
+    input.foss.claimed_exemption == true
+    not input.foss.process.exemption_basis_reviewed_annually
+    msg := "CRA Art.23: FOSS exemption status is not reviewed annually — commercial relationships may change over time"
+}
+
+compliant if { count(violation) == 0 }
+
+# Useful auxiliary field for downstream consumers.
+exemption_status := {
+    "claimed":  input.foss.claimed_exemption,
+    "valid":    exempt,
+    "misclaim": count(violation) > 0,
+}
+
+compliance_report := {
+    "family": "Article 23",
+    "name":   "Free and open-source software exclusion (boundary check)",
+    "controls_evaluated": 8,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+    "exempt":   exempt,
+    "exemption_status": exemption_status,
+}

--- a/frameworks/compliance/cra/importer_obligations/cra_importer_obligations.rego
+++ b/frameworks/compliance/cra/importer_obligations/cra_importer_obligations.rego
@@ -1,0 +1,110 @@
+package cra.importer_obligations
+
+import rego.v1
+
+# EU Cyber Resilience Act (CRA) — Article 19
+# Importer obligations.
+#
+# Importers placing products with digital elements on the EU market must
+# verify the manufacturer has met core CRA obligations before importing.
+# In specific cases (Article 21) the importer is treated as a manufacturer
+# and incurs the full Article 13 obligation set.
+
+default compliant := false
+
+# Art.19(1) — Verify manufacturer has performed conformity assessment
+violation contains msg if {
+    not input.importer.verification.conformity_assessment_performed
+    msg := "CRA Art.19(1)(a): Importer has not verified that the manufacturer performed the required conformity assessment"
+}
+
+# Art.19(1) — Verify manufacturer has drawn up technical documentation
+violation contains msg if {
+    not input.importer.verification.technical_documentation_exists
+    msg := "CRA Art.19(1)(b): Importer has not verified that technical documentation has been drawn up by the manufacturer"
+}
+
+# Art.19(1) — Verify CE marking and Declaration of Conformity
+violation contains msg if {
+    not input.importer.verification.ce_marking_present
+    msg := "CRA Art.19(1)(c): Importer has not verified CE marking is affixed before placing the product on the market"
+}
+
+violation contains msg if {
+    not input.importer.verification.declaration_of_conformity_accompanies_product
+    msg := "CRA Art.19(1)(d): Declaration of Conformity does not accompany the imported product"
+}
+
+# Art.19(2) — Importer must indicate name/registered trade name/address on product
+violation contains msg if {
+    not input.importer.identification.name_on_product
+    msg := "CRA Art.19(2)(a): Importer's name or registered trade name not indicated on the product (or packaging/accompanying documents)"
+}
+
+violation contains msg if {
+    not input.importer.identification.postal_address_on_product
+    msg := "CRA Art.19(2)(b): Importer's postal address not indicated on the product"
+}
+
+# Art.19(3) — Ensure storage/transport doesn't jeopardise compliance
+violation contains msg if {
+    not input.importer.handling.storage_transport_preserves_compliance
+    msg := "CRA Art.19(3): Storage/transport conditions may jeopardise the product's compliance with essential requirements"
+}
+
+# Art.19(4) — Inform manufacturer + market surveillance of cybersecurity risk
+violation contains msg if {
+    input.importer.risk_awareness.product_presents_cyber_risk == true
+    not input.importer.risk_awareness.manufacturer_informed
+    msg := "CRA Art.19(4): Importer has not informed the manufacturer about a known cybersecurity risk in the product"
+}
+
+violation contains msg if {
+    input.importer.risk_awareness.significant_risk == true
+    not input.importer.risk_awareness.market_surveillance_informed
+    msg := "CRA Art.19(4): Importer has not informed market surveillance authorities of a significant cybersecurity risk"
+}
+
+# Art.19(5) — Cooperate with authorities, provide info/documentation
+violation contains msg if {
+    not input.importer.cooperation.documentation_available_10_years
+    msg := "CRA Art.19(5): Importer does not retain a copy of the Declaration of Conformity for 10 years"
+}
+
+violation contains msg if {
+    not input.importer.cooperation.cooperate_with_authorities
+    msg := "CRA Art.19(6): Importer not committed to cooperate with market surveillance authorities on request"
+}
+
+# Art.19(7) — Corrective action when non-conformity suspected
+violation contains msg if {
+    input.importer.non_conformity_known == true
+    not input.importer.corrective_action.taken_immediately
+    msg := "CRA Art.19(7): Importer has not taken immediate corrective action upon discovering non-conformity"
+}
+
+# Art.19(7) — Withdraw or recall non-conforming products
+violation contains msg if {
+    input.importer.non_conformity_known == true
+    input.importer.corrective_action.severity == "high"
+    not input.importer.corrective_action.withdrawal_or_recall_initiated
+    msg := "CRA Art.19(7): Importer has not withdrawn or recalled a non-conforming product where the risk requires it"
+}
+
+# Article 21 — Importer treated as manufacturer when placing on market under own name
+violation contains msg if {
+    input.importer.placed_under_own_brand == true
+    not input.importer.assumed_manufacturer_obligations
+    msg := "CRA Art.21: Importer placing the product under its own name/trademark has not assumed manufacturer obligations under Article 13"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "family": "Article 19",
+    "name":   "Importer obligations",
+    "controls_evaluated": 14,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/compliance/cra/incident_reporting/cra_incident_reporting.rego
+++ b/frameworks/compliance/cra/incident_reporting/cra_incident_reporting.rego
@@ -1,0 +1,105 @@
+package cra.incident_reporting
+
+import rego.v1
+
+# EU Cyber Resilience Act (CRA) — Article 14
+# Manufacturer reporting obligations for actively exploited vulnerabilities
+# and severe incidents.
+#
+# Reporting timeline (Article 14(2)):
+#   T+24h:  early warning notification to ENISA + CSIRT
+#   T+72h:  vulnerability/incident notification with available information
+#   T+14d:  final report (or 1 month for incidents) with root cause + mitigation
+#
+# Article 14(8): also obliged to inform impacted users without undue delay.
+
+default compliant := false
+
+# Article 14(2)(a) — 24-hour early warning
+violation contains msg if {
+    input.incident_reporting.actively_exploited_vuln_known == true
+    input.incident_reporting.hours_since_aware_of_vuln > 24
+    not input.incident_reporting.early_warning_sent
+    msg := sprintf("CRA Art.14(2)(a): No early warning sent to ENISA/CSIRT within 24h (current: %dh since awareness)", [input.incident_reporting.hours_since_aware_of_vuln])
+}
+
+# Article 14(2)(b) — 72-hour vulnerability notification
+violation contains msg if {
+    input.incident_reporting.actively_exploited_vuln_known == true
+    input.incident_reporting.hours_since_aware_of_vuln > 72
+    not input.incident_reporting.vulnerability_notification_sent
+    msg := sprintf("CRA Art.14(2)(b): No vulnerability notification to ENISA within 72h (current: %dh)", [input.incident_reporting.hours_since_aware_of_vuln])
+}
+
+# Article 14(2)(c) — Final report within 14 days
+violation contains msg if {
+    input.incident_reporting.actively_exploited_vuln_known == true
+    input.incident_reporting.days_since_aware_of_vuln > 14
+    not input.incident_reporting.final_vuln_report_sent
+    msg := sprintf("CRA Art.14(2)(c): Final vulnerability report not submitted within 14 days (current: %dd)", [input.incident_reporting.days_since_aware_of_vuln])
+}
+
+# Severe incident reporting (also 24/72/1-month timeline per Art.14(3))
+violation contains msg if {
+    input.incident_reporting.severe_incident_occurred == true
+    input.incident_reporting.hours_since_incident > 24
+    not input.incident_reporting.incident_early_warning_sent
+    msg := "CRA Art.14(3)(a): Severe incident not reported to ENISA/CSIRT within 24h"
+}
+
+violation contains msg if {
+    input.incident_reporting.severe_incident_occurred == true
+    input.incident_reporting.hours_since_incident > 72
+    not input.incident_reporting.incident_notification_sent
+    msg := "CRA Art.14(3)(b): Severe incident notification not submitted within 72h"
+}
+
+violation contains msg if {
+    input.incident_reporting.severe_incident_occurred == true
+    input.incident_reporting.days_since_incident > 30
+    not input.incident_reporting.incident_final_report_sent
+    msg := "CRA Art.14(3)(c): Final incident report not submitted within 1 month"
+}
+
+# Article 14(8) — Inform impacted users without undue delay
+violation contains msg if {
+    input.incident_reporting.users_impacted == true
+    not input.incident_reporting.affected_users_notified
+    msg := "CRA Art.14(8): Impacted users not notified without undue delay"
+}
+
+# Article 14(9) — Provide mitigation measures alongside notification
+violation contains msg if {
+    input.incident_reporting.users_impacted == true
+    input.incident_reporting.affected_users_notified == true
+    not input.incident_reporting.mitigation_guidance_provided
+    msg := "CRA Art.14(9): User notification did not include corrective measures / mitigation guidance"
+}
+
+# Single reporting point (Art.14(7) — manufacturer must register with ENISA single entry point)
+violation contains msg if {
+    not input.incident_reporting.single_entry_point_registered
+    msg := "CRA Art.14(7): Manufacturer not registered with the ENISA single reporting platform"
+}
+
+# Process maturity
+violation contains msg if {
+    not input.incident_reporting.process_documented
+    msg := "CRA Art.14: Documented incident reporting process not in place"
+}
+
+violation contains msg if {
+    not input.incident_reporting.process_tested_annually
+    msg := "CRA Art.14: Incident reporting process not exercised at least annually"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "family": "Article 14",
+    "name":   "Reporting obligations of manufacturers",
+    "controls_evaluated": 11,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/compliance/cra/manufacturer_obligations/cra_manufacturer_obligations.rego
+++ b/frameworks/compliance/cra/manufacturer_obligations/cra_manufacturer_obligations.rego
@@ -1,0 +1,102 @@
+package cra.manufacturer_obligations
+
+import rego.v1
+
+# EU Cyber Resilience Act (CRA) — Article 13
+# General obligations on manufacturers of products with digital elements.
+
+default compliant := false
+
+# Article 13(1) — Compliance with essential requirements
+violation contains msg if {
+    not input.manufacturer.essential_requirements.met
+    msg := "CRA Art.13(1): Manufacturer has not ensured compliance with the essential requirements in Annex I"
+}
+
+# Article 13(2) — Risk assessment performed
+violation contains msg if {
+    not input.manufacturer.risk_assessment.performed
+    msg := "CRA Art.13(2): Manufacturer has not performed a cybersecurity risk assessment for the product"
+}
+
+# Article 13(3) — Risk assessment included in technical documentation
+violation contains msg if {
+    not input.manufacturer.risk_assessment.in_technical_documentation
+    msg := "CRA Art.13(3): Risk assessment not included in the technical documentation"
+}
+
+# Article 13(4) — Vulnerability handling throughout product lifecycle
+violation contains msg if {
+    not input.manufacturer.vulnerability_handling.lifetime_coverage
+    msg := "CRA Art.13(4): Vulnerability handling process does not cover the entire declared support period"
+}
+
+# Article 13(6) — Apply due diligence to integrated third-party components
+violation contains msg if {
+    not input.manufacturer.third_party_components.due_diligence_performed
+    msg := "CRA Art.13(6): Due diligence not performed for integrated third-party components (open-source or commercial)"
+}
+
+violation contains msg if {
+    not input.manufacturer.third_party_components.vulnerabilities_monitored
+    msg := "CRA Art.13(6): Vulnerabilities in third-party components not actively monitored"
+}
+
+# Article 13(7) — Report exploited vulnerabilities + severe incidents to ENISA
+# (Reporting timeline rules are in cra.incident_reporting; here we just check
+# the obligation/awareness/process exists.)
+violation contains msg if {
+    not input.manufacturer.reporting.process_to_enisa_documented
+    msg := "CRA Art.13(7) / 14: Process for reporting exploited vulnerabilities + severe incidents to ENISA not documented"
+}
+
+# Article 13(8) — Declared support period (also enforced in vulnerability_handling)
+violation contains msg if {
+    not input.manufacturer.support_period.declared
+    msg := "CRA Art.13(8): Manufacturer has not declared a support period for the product"
+}
+
+violation contains msg if {
+    input.manufacturer.support_period.years < 5
+    msg := sprintf("CRA Art.13(8): Declared support period (%d years) is below the 5-year minimum", [input.manufacturer.support_period.years])
+}
+
+# Article 13(10) — User-facing instructions and information
+violation contains msg if {
+    not input.manufacturer.user_information.instructions_provided
+    msg := "CRA Art.13(10): User instructions / information set not provided with the product"
+}
+
+violation contains msg if {
+    not input.manufacturer.user_information.security_relevant_info_included
+    msg := "CRA Art.13(10) / Annex II: User information missing security-relevant content (intended use, secure config guidance, support period, contact for vulnerability reporting)"
+}
+
+# Article 13(12) — Cooperation with market surveillance
+violation contains msg if {
+    not input.manufacturer.market_surveillance.cooperation_committed
+    msg := "CRA Art.13(12): Manufacturer not committed to cooperate with market surveillance authorities upon request"
+}
+
+# Article 13(14) — End-of-support notification
+violation contains msg if {
+    not input.manufacturer.eol.end_of_support_notification_planned
+    msg := "CRA Art.13(14): Plan to notify users at least 12 months before end-of-support not in place"
+}
+
+# Process maturity — internal cybersecurity governance for product teams
+violation contains msg if {
+    not input.manufacturer.governance.product_security_role_assigned
+    msg := "CRA Art.13 (general): No designated product security role (PSIRT lead or equivalent) within the manufacturer"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "family": "Article 13",
+    "name":   "Manufacturer obligations",
+    "controls_evaluated": 14,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/compliance/cra/online_marketplace/cra_online_marketplace.rego
+++ b/frameworks/compliance/cra/online_marketplace/cra_online_marketplace.rego
@@ -1,0 +1,127 @@
+package cra.online_marketplace
+
+import rego.v1
+
+# EU Cyber Resilience Act (CRA) — Article 22
+# Obligations of providers of online marketplaces.
+#
+# Marketplaces (within the meaning of the Digital Services Act) that allow
+# consumers to conclude distance contracts with traders for products with
+# digital elements must support market surveillance and ensure non-compliant
+# products can be removed quickly. The DSA framework also applies, but
+# Article 22 sets cybersecurity-specific obligations.
+
+default compliant := false
+
+# Threshold gate — applies only to providers of online marketplaces.
+applies if {
+    input.online_marketplace.is_marketplace_provider
+    input.online_marketplace.products_offered.includes_products_with_digital_elements
+}
+
+# Art.22(1) — Single point of contact for market surveillance authorities
+violation contains msg if {
+    applies
+    not input.online_marketplace.single_point_of_contact.designated_for_authorities
+    msg := "CRA Art.22(1): Online marketplace has not designated a single point of contact for market surveillance authorities"
+}
+
+# Art.22(1) — Single point of contact also for end-users
+violation contains msg if {
+    applies
+    not input.online_marketplace.single_point_of_contact.designated_for_end_users
+    msg := "CRA Art.22(1): Online marketplace has not designated a single point of contact for end users on cybersecurity matters"
+}
+
+# Art.22(2) — Cooperate with national authorities to ensure compliance
+violation contains msg if {
+    applies
+    not input.online_marketplace.cooperation.with_authorities_documented
+    msg := "CRA Art.22(2): Marketplace's cooperation process with national authorities not documented"
+}
+
+# Art.22(3) — Act on authority orders to remove illegal listings
+violation contains msg if {
+    applies
+    input.online_marketplace.authority_takedown_order_received == true
+    input.online_marketplace.authority_takedown_order_hours_pending > 48
+    not input.online_marketplace.authority_takedown_order_actioned
+    msg := sprintf("CRA Art.22(3): Marketplace has not actioned an authority takedown order within 48h (current: %dh pending)", [input.online_marketplace.authority_takedown_order_hours_pending])
+}
+
+# Art.22(4) — Trader identification (CRA-relevant info: traceability of the seller)
+violation contains msg if {
+    applies
+    not input.online_marketplace.trader_due_diligence.identity_verified
+    msg := "CRA Art.22(4): Marketplace has not verified the identity of traders offering products with digital elements"
+}
+
+violation contains msg if {
+    applies
+    not input.online_marketplace.trader_due_diligence.cra_compliance_attested
+    msg := "CRA Art.22(4): Marketplace has not obtained trader attestation of CRA compliance before listing"
+}
+
+# Art.22(5) — Random sampling / checks
+violation contains msg if {
+    applies
+    not input.online_marketplace.random_checks.performed
+    msg := "CRA Art.22(5): Marketplace has not implemented random checks for CRA non-compliance among offered products"
+}
+
+violation contains msg if {
+    applies
+    input.online_marketplace.random_checks.performed == true
+    input.online_marketplace.random_checks.sample_size_pct < 1.0
+    msg := sprintf("CRA Art.22(5): Marketplace random-check sample size (%v%%) is below a defensible threshold (1%% min)", [input.online_marketplace.random_checks.sample_size_pct])
+}
+
+# Art.22 — Where compliance issue identified, manufacturer notified + listing handled
+violation contains msg if {
+    applies
+    input.online_marketplace.non_compliant_listing_identified == true
+    not input.online_marketplace.manufacturer_notified
+    msg := "CRA Art.22: Marketplace identified non-compliant listing but did not notify the manufacturer/seller"
+}
+
+violation contains msg if {
+    applies
+    input.online_marketplace.non_compliant_listing_identified == true
+    input.online_marketplace.severity == "high"
+    not input.online_marketplace.listing_removed
+    msg := "CRA Art.22: Marketplace has not removed a high-severity non-compliant listing"
+}
+
+# Art.22 — End-user information on identified non-compliance affecting them
+violation contains msg if {
+    applies
+    input.online_marketplace.non_compliant_listing_identified == true
+    input.online_marketplace.buyers_affected == true
+    not input.online_marketplace.affected_buyers_notified
+    msg := "CRA Art.22: Marketplace has not notified buyers affected by a previously-sold non-compliant product"
+}
+
+# Art.22 — Marketplace must publish a CRA-specific reporting channel
+violation contains msg if {
+    applies
+    not input.online_marketplace.reporting_channel.exists_for_consumers
+    msg := "CRA Art.22: Marketplace has no published channel for consumers to report suspected CRA non-compliance"
+}
+
+# Internal process documentation
+violation contains msg if {
+    applies
+    not input.online_marketplace.process_documentation.cra_process_documented
+    msg := "CRA Art.22: Marketplace has not documented its CRA-compliance process for traders + products"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "family": "Article 22",
+    "name":   "Online marketplace obligations",
+    "controls_evaluated": 13,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/compliance/cra/oss_steward/cra_oss_steward.rego
+++ b/frameworks/compliance/cra/oss_steward/cra_oss_steward.rego
@@ -1,0 +1,132 @@
+package cra.oss_steward
+
+import rego.v1
+
+# EU Cyber Resilience Act (CRA) — Article 24
+# Open-source software stewards.
+#
+# CRA introduces a new category: a legal person (other than a natural
+# person) that provides systematic, sustained support for the development
+# of an open-source product with digital elements made available on the
+# EU market for commercial activities. Stewards have a lighter-touch set
+# of obligations than full manufacturers.
+#
+# Article 24(1) — Apply a cybersecurity policy to foster secure development
+# Article 24(2) — Cooperate with market surveillance to mitigate risks
+# Article 24(3) — Comply with reporting obligations in Article 14
+
+default compliant := false
+
+# Threshold — the steward classification only applies if the entity
+# meets the "systematic and sustained" definition AND the OSS product
+# is "intended for commercial activities".
+applies_to_entity if {
+    input.oss_steward.is_legal_person_other_than_natural
+    input.oss_steward.provides_systematic_sustained_support
+    input.oss_steward.oss_product_intended_for_commercial_activities
+}
+
+# Art.24(1) — Cybersecurity policy required
+violation contains msg if {
+    applies_to_entity
+    not input.oss_steward.cybersecurity_policy.documented
+    msg := "CRA Art.24(1): OSS steward has not documented a cybersecurity policy fostering voluntary development of secure products"
+}
+
+violation contains msg if {
+    applies_to_entity
+    not input.oss_steward.cybersecurity_policy.published
+    msg := "CRA Art.24(1): OSS steward's cybersecurity policy is not published / publicly accessible"
+}
+
+violation contains msg if {
+    applies_to_entity
+    not input.oss_steward.cybersecurity_policy.covers_vulnerability_handling
+    msg := "CRA Art.24(1): OSS steward's cybersecurity policy does not cover effective handling of vulnerabilities"
+}
+
+violation contains msg if {
+    applies_to_entity
+    not input.oss_steward.cybersecurity_policy.covers_secure_development_practices
+    msg := "CRA Art.24(1): OSS steward's cybersecurity policy does not foster secure development practices"
+}
+
+# Art.24(2) — Cooperate with market surveillance authorities
+violation contains msg if {
+    applies_to_entity
+    not input.oss_steward.cooperation.with_market_surveillance
+    msg := "CRA Art.24(2): OSS steward has not committed to cooperate with market surveillance authorities to mitigate cyber risks"
+}
+
+violation contains msg if {
+    applies_to_entity
+    not input.oss_steward.cooperation.responds_to_authority_requests
+    msg := "CRA Art.24(2): OSS steward does not respond to information requests from competent authorities"
+}
+
+# Art.24(3) — Reporting obligations under Article 14 apply
+violation contains msg if {
+    applies_to_entity
+    input.oss_steward.actively_exploited_vuln_known == true
+    input.oss_steward.hours_since_aware > 24
+    not input.oss_steward.early_warning_to_enisa_sent
+    msg := "CRA Art.24(3) / Art.14: OSS steward aware of actively exploited vulnerability has not sent 24h early warning to ENISA"
+}
+
+violation contains msg if {
+    applies_to_entity
+    input.oss_steward.actively_exploited_vuln_known == true
+    input.oss_steward.hours_since_aware > 72
+    not input.oss_steward.vulnerability_notification_sent
+    msg := "CRA Art.24(3) / Art.14: OSS steward has not sent the 72h vulnerability notification"
+}
+
+violation contains msg if {
+    applies_to_entity
+    input.oss_steward.severe_incident_occurred == true
+    input.oss_steward.hours_since_incident > 24
+    not input.oss_steward.severe_incident_early_warning_sent
+    msg := "CRA Art.24(3) / Art.14: OSS steward has not reported a severe incident to ENISA within 24h"
+}
+
+# Art.24 — Engage with affected downstream manufacturers
+violation contains msg if {
+    applies_to_entity
+    input.oss_steward.actively_exploited_vuln_known == true
+    not input.oss_steward.downstream_manufacturers_engaged
+    msg := "CRA Art.24: OSS steward has not engaged with downstream manufacturers using the affected component"
+}
+
+# Art.24 — Provide a coordinated vulnerability disclosure (CVD) policy
+violation contains msg if {
+    applies_to_entity
+    not input.oss_steward.cvd_policy.published
+    msg := "CRA Art.24: OSS steward has not published a coordinated vulnerability disclosure (CVD) policy"
+}
+
+# Art.24 — Allow reporting of vulnerabilities through a documented channel
+violation contains msg if {
+    applies_to_entity
+    not input.oss_steward.vulnerability_reporting_channel.exists
+    msg := "CRA Art.24: OSS steward has not provided a documented channel for receiving vulnerability reports"
+}
+
+# Article 24 — Reduced documentation obligations: stewards do not need
+# to perform full CRA conformity assessment, but they MUST keep records
+# of significant security decisions.
+violation contains msg if {
+    applies_to_entity
+    not input.oss_steward.record_keeping.security_decisions_documented
+    msg := "CRA Art.24: OSS steward has not kept records of significant cybersecurity-related decisions"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "family": "Article 24",
+    "name":   "Open-source software steward obligations",
+    "controls_evaluated": 13,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/compliance/cra/substantial_modification/cra_substantial_modification.rego
+++ b/frameworks/compliance/cra/substantial_modification/cra_substantial_modification.rego
@@ -1,0 +1,115 @@
+package cra.substantial_modification
+
+import rego.v1
+
+# EU Cyber Resilience Act (CRA) — Article 11
+# Substantial modifications.
+#
+# When a product undergoes a "substantial modification" — changes the
+# intended use, affects compliance with essential requirements, or alters
+# the risk profile — the modifier becomes legally responsible as a
+# manufacturer and must re-perform conformity assessment.
+#
+# Key implications: cybersecurity-relevant feature changes, new connectivity
+# capability, change of supported platforms, additions to the SBOM, or
+# functional changes that affect threat exposure are all triggers.
+
+default compliant := false
+
+# Art.11(1) — Identify modifications that constitute "substantial"
+violation contains msg if {
+    not input.substantial_modification.assessment_process.documented
+    msg := "CRA Art.11(1): No documented process to assess whether a planned change constitutes a substantial modification"
+}
+
+violation contains msg if {
+    not input.substantial_modification.assessment_process.criteria_published
+    msg := "CRA Art.11(1): Substantial-modification assessment criteria not published / documented"
+}
+
+# Art.11(2) — Re-assess conformity after substantial modification
+violation contains msg if {
+    input.substantial_modification.modification_classified_substantial == true
+    not input.substantial_modification.conformity_reassessment.performed
+    msg := "CRA Art.11(2): A modification was classified as substantial but conformity assessment has not been re-performed"
+}
+
+violation contains msg if {
+    input.substantial_modification.modification_classified_substantial == true
+    not input.substantial_modification.conformity_reassessment.scope_appropriate
+    msg := "CRA Art.11(2): Re-performed conformity assessment scope does not cover the modified aspects of the product"
+}
+
+# Art.11(3) — Modifier assumes manufacturer's obligations
+violation contains msg if {
+    input.substantial_modification.modification_classified_substantial == true
+    input.substantial_modification.modifier_is_not_original_manufacturer == true
+    not input.substantial_modification.modifier_assumed_manufacturer_obligations
+    msg := "CRA Art.11(3): Modifier of a substantially-modified product has not assumed manufacturer obligations under Article 13"
+}
+
+# Connectivity changes — new attack surface
+violation contains msg if {
+    input.substantial_modification.changes.added_network_connectivity == true
+    not input.substantial_modification.changes.risk_assessment_updated
+    msg := "CRA Art.11 (Annex I.1 interaction): New network connectivity added without an updated cybersecurity risk assessment"
+}
+
+# Cryptographic primitive changes
+violation contains msg if {
+    input.substantial_modification.changes.cryptographic_primitive_changed == true
+    not input.substantial_modification.changes.cryptographic_review_performed
+    msg := "CRA Art.11 (Annex I.5/6 interaction): Cryptographic primitive changed without security review of the new mechanism"
+}
+
+# SBOM changes
+violation contains msg if {
+    input.substantial_modification.changes.sbom_changed == true
+    not input.substantial_modification.changes.sbom_published_after_change
+    msg := "CRA Art.11 (Annex II.1 interaction): SBOM not refreshed after dependency changes"
+}
+
+# Update technical documentation
+violation contains msg if {
+    input.substantial_modification.modification_classified_substantial == true
+    not input.substantial_modification.documentation_updated
+    msg := "CRA Art.11(2) / Art.28: Substantial modification performed but technical documentation not updated"
+}
+
+# Declaration of Conformity must be reissued
+violation contains msg if {
+    input.substantial_modification.modification_classified_substantial == true
+    not input.substantial_modification.declaration_of_conformity_reissued
+    msg := "CRA Art.11(2) / Annex IV: Substantial modification performed but Declaration of Conformity not reissued"
+}
+
+# Notify users of relevant security-impacting changes
+violation contains msg if {
+    input.substantial_modification.changes.security_relevant == true
+    not input.substantial_modification.changes.users_notified
+    msg := "CRA Art.11 / Annex II: Security-relevant substantial modification not communicated to existing users"
+}
+
+# Updates to support period commitment
+violation contains msg if {
+    input.substantial_modification.modification_classified_substantial == true
+    not input.substantial_modification.support_period_recommitted
+    msg := "CRA Art.11 / Art.13(8): Substantial modification did not re-affirm the declared support period for the modified product"
+}
+
+# Process maturity — review cadence
+violation contains msg if {
+    not input.substantial_modification.assessment_process.reviewed_annually
+    msg := "CRA Art.11: Substantial-modification assessment criteria not reviewed at least annually"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "family": "Article 11",
+    "name":   "Substantial modifications",
+    "controls_evaluated": 13,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/compliance/cra/supply_chain_evidence/cra_supply_chain_evidence.rego
+++ b/frameworks/compliance/cra/supply_chain_evidence/cra_supply_chain_evidence.rego
@@ -1,0 +1,133 @@
+package cra.supply_chain_evidence
+
+import rego.v1
+import data.supply_chain.slsa
+
+# CRA — Supply-chain evidence integration.
+#
+# Re-uses findings from the SLSA supply-chain governance module
+# (data.supply_chain.slsa) and re-frames them as CRA Annex I/II + Art.13
+# violations. This avoids redefining SBOM / signing / provenance rules
+# in CRA-native form; instead it consumes the SLSA evidence the
+# organisation is already producing and emits CRA-language findings
+# alongside SLSA's own output.
+#
+# Input shape: the SAME input the supply_chain.slsa module consumes
+# (artifact metadata, provenance attestation, SBOM, dependencies,
+# licenses, signing). This module performs no input reads of its
+# own — only translation of upstream findings.
+
+default compliant := false
+
+# Helper — predicate over SLSA's violation set
+slsa_finding(substr) if {
+    some v in slsa.violations
+    contains(v, substr)
+}
+
+# ── SBOM mapping (CRA Annex II.1 — Vulnerability handling: SBOM) ─────────
+
+violation contains msg if {
+    slsa_finding("SBOM: No SBOM attached")
+    msg := "CRA Annex II.1(a) (via SLSA): No SBOM attached to the artifact — vulnerability handling cannot be effective without an inventory of components"
+}
+
+violation contains msg if {
+    slsa_finding("SBOM: SBOM format not recognized")
+    msg := "CRA Annex II.1(b) (via SLSA): SBOM not in a machine-readable format (SPDX-2.x or CycloneDX-1.x required)"
+}
+
+violation contains msg if {
+    slsa_finding("SBOM components missing PURL")
+    msg := "CRA Annex II.1(c) (via SLSA): SBOM components missing PURL (Package URL) identifiers — top-level dependencies not unambiguously documented"
+}
+
+violation contains msg if {
+    slsa_finding("SBOM components missing license")
+    msg := "CRA Annex II.1(c) (via SLSA): SBOM components missing license declarations — required for traceability of third-party components per Art.13(6)"
+}
+
+violation contains msg if {
+    slsa_finding("SBOM contains no components")
+    msg := "CRA Annex II.1(a) (via SLSA): SBOM exists but is empty — equivalent to no SBOM for CRA purposes"
+}
+
+# ── Integrity mapping (CRA Annex I.6 — code/configuration integrity) ─────
+
+violation contains msg if {
+    slsa_finding("Signing: Artifact is not signed")
+    msg := "CRA Annex I.6(a) (via SLSA): Artifact is not signed — integrity of distributed code cannot be cryptographically verified"
+}
+
+violation contains msg if {
+    slsa_finding("Signing: Artifact signature verification failed")
+    msg := "CRA Annex I.6(a) (via SLSA): Artifact signature verification failed — distributed artifact integrity is broken"
+}
+
+violation contains msg if {
+    slsa_finding("Signing: Signing identity not from an approved OIDC provider")
+    msg := "CRA Annex I.6(b) (via SLSA): Signing identity not from an approved OIDC provider — tamper detection chain of trust is weakened"
+}
+
+# ── Third-party component due diligence (CRA Art.13(6)) ─────────────────
+
+violation contains msg if {
+    slsa_finding("Dependencies:")
+    slsa_finding("known CVE")
+    msg := "CRA Art.13(6) (via SLSA): Third-party component has a known CVE — manufacturer's vulnerability monitoring obligation triggered"
+}
+
+violation contains msg if {
+    slsa_finding("Dependencies:")
+    slsa_finding("critical CVE with no exemption")
+    msg := "CRA Art.13(6) + Annex II.2 (via SLSA): Critical CVE in third-party component with no documented exemption — remediation process obligation triggered"
+}
+
+violation contains msg if {
+    slsa_finding("Dependencies: Floating version constraint")
+    msg := "CRA Art.13(6) (via SLSA): Floating version constraint in dependencies — third-party component due diligence requires reproducible builds"
+}
+
+# ── Provenance mapping (CRA Art.28 + Annex VII technical documentation) ──
+
+violation contains msg if {
+    slsa_finding("SLSA: Build provenance attestation is missing")
+    msg := "CRA Annex VII.3 (via SLSA): Build provenance attestation missing — technical documentation requires evidence of how the artifact was built"
+}
+
+violation contains msg if {
+    slsa_finding("Provenance: Build source URI does not match")
+    msg := "CRA Annex VII.3 (via SLSA): Build provenance source URI does not match the expected repository — traceability of the technical documentation chain is broken"
+}
+
+# ── Substantial-modification interaction (CRA Art.11) ───────────────────
+
+# If the substantial_modification module declared an SBOM change, the SLSA
+# module must show the SBOM was refreshed afterwards.
+violation contains msg if {
+    input.substantial_modification.changes.sbom_changed
+    slsa_finding("SBOM:")
+    msg := "CRA Art.11 (via SLSA): A substantial-modification SBOM change was declared, but SLSA still reports SBOM defects — refresh did not produce a clean inventory"
+}
+
+# ── Compliance + report ─────────────────────────────────────────────────
+
+compliant if { count(violation) == 0 }
+
+# Convenience accessors for callers that want both views
+slsa_violations := slsa.violations
+slsa_compliant := slsa.compliant
+
+compliance_report := {
+    "family": "Supply-chain evidence integration",
+    "name":   "CRA × SLSA findings bridge",
+    "controls_evaluated": 14,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+    "upstream": {
+        "module": "data.supply_chain.slsa",
+        "slsa_violation_count": count(slsa.violations),
+        "slsa_compliant": slsa.compliant,
+    },
+}

--- a/frameworks/compliance/cra/technical_documentation/cra_technical_documentation.rego
+++ b/frameworks/compliance/cra/technical_documentation/cra_technical_documentation.rego
@@ -1,0 +1,106 @@
+package cra.technical_documentation
+
+import rego.v1
+
+# EU Cyber Resilience Act (CRA) — Article 28 + Annex VII
+# Technical documentation requirements. Manufacturers must prepare and
+# maintain technical documentation for every product before placing it
+# on the market, and keep it available for 10 years (Art.28(4)).
+
+default compliant := false
+
+# Annex VII (1) — General product description
+violation contains msg if {
+    not input.technical_documentation.product_description.documented
+    msg := "CRA Annex VII.1(a): General product description not documented"
+}
+
+violation contains msg if {
+    not input.technical_documentation.product_description.intended_purpose
+    msg := "CRA Annex VII.1(b): Intended purpose / use cases not documented"
+}
+
+violation contains msg if {
+    not input.technical_documentation.product_description.support_period_declared
+    msg := "CRA Annex VII.1(c): Declared support period not documented"
+}
+
+# Annex VII (2) — Risk assessment
+violation contains msg if {
+    not input.technical_documentation.risk_assessment.documented
+    msg := "CRA Annex VII.2(a): Cybersecurity risk assessment not documented"
+}
+
+violation contains msg if {
+    not input.technical_documentation.risk_assessment.threats_identified
+    msg := "CRA Annex VII.2(b): Identified threats and threat actors not documented"
+}
+
+violation contains msg if {
+    not input.technical_documentation.risk_assessment.mitigations_documented
+    msg := "CRA Annex VII.2(c): Mitigations applied for each identified threat not documented"
+}
+
+# Annex VII (3) — Design and architecture
+violation contains msg if {
+    not input.technical_documentation.design.architecture_diagram
+    msg := "CRA Annex VII.3(a): Architecture/design diagram of the product not provided"
+}
+
+violation contains msg if {
+    not input.technical_documentation.design.cybersecurity_controls_mapped
+    msg := "CRA Annex VII.3(b): Mapping of cybersecurity controls to essential requirements not provided"
+}
+
+# Annex VII (4) — Vulnerability handling process
+violation contains msg if {
+    not input.technical_documentation.vuln_process.documented
+    msg := "CRA Annex VII.4: Vulnerability handling process documentation not included"
+}
+
+# Annex VII (5) — Software bill of materials
+violation contains msg if {
+    not input.technical_documentation.sbom.included
+    msg := "CRA Annex VII.5: SBOM not included in technical documentation"
+}
+
+# Annex VII (6) — Test results
+violation contains msg if {
+    not input.technical_documentation.testing.results_documented
+    msg := "CRA Annex VII.6(a): Cybersecurity testing/audit results not documented"
+}
+
+violation contains msg if {
+    not input.technical_documentation.testing.third_party_assessment
+    input.technical_documentation.product.classification in {"important_class_2", "critical"}
+    msg := "CRA Annex VII.6(b): Third-party conformity assessment not documented (required for Important Class II / Critical products)"
+}
+
+# Annex VII (7) — Declaration of conformity
+violation contains msg if {
+    not input.technical_documentation.declaration_of_conformity.signed
+    msg := "CRA Annex VII.7: EU Declaration of Conformity not signed"
+}
+
+# Article 28(4) — Retention
+violation contains msg if {
+    not input.technical_documentation.retention.maintained_10_years
+    msg := "CRA Art.28(4): Technical documentation not retained for 10 years after product placed on market"
+}
+
+# Article 28(5) — Availability to authorities
+violation contains msg if {
+    not input.technical_documentation.retention.available_on_request
+    msg := "CRA Art.28(5): Technical documentation not available to market surveillance authorities on request"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "family": "Article 28 / Annex VII",
+    "name":   "Technical documentation",
+    "controls_evaluated": 15,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/compliance/cra/tests/test_cra_main.rego
+++ b/frameworks/compliance/cra/tests/test_cra_main.rego
@@ -1,0 +1,108 @@
+package cra.main_test
+
+import rego.v1
+import data.cra.main
+
+# ── Empty-input smoke tests ────────────────────────────────────────────────
+
+test_compliance_report_defined_on_empty_input if {
+    r := main.compliance_report with input as {}
+    r.framework == "EU Cyber Resilience Act (CRA)"
+    r.regulation == "Regulation (EU) 2024/2847"
+    r.total_controls == 88
+    is_number(r.violation_count)
+}
+
+test_non_compliant_on_empty_input if {
+    not main.compliant with input as {}
+}
+
+test_violations_emitted_on_empty_input if {
+    # All 6 modules should fire; expect close to total_controls.
+    count(main.violations) > 50 with input as {}
+}
+
+test_module_summary_has_all_six_modules if {
+    r := main.compliance_report with input as {}
+    r.module_summary.essential_requirements
+    r.module_summary.vulnerability_handling
+    r.module_summary.incident_reporting
+    r.module_summary.technical_documentation
+    r.module_summary.conformity_assessment
+    r.module_summary.manufacturer_obligations
+}
+
+test_defaults_for_metadata if {
+    r := main.compliance_report with input as {}
+    r.entity_name == "unknown"
+    r.product_name == "unknown"
+    r.product_class == "unknown"
+    r.assessed_at == "unknown"
+}
+
+test_metadata_picked_up_from_input if {
+    r := main.compliance_report with input as {
+        "entity_name":     "Widget Maker GmbH",
+        "product_name":    "ConnectedThermostat-7",
+        "product_class":   "important_class_2",
+        "assessment_date": "2026-06-26",
+    }
+    r.entity_name == "Widget Maker GmbH"
+    r.product_class == "important_class_2"
+    r.assessed_at == "2026-06-26"
+}
+
+# ── Targeted timeline-rule tests ────────────────────────────────────────────
+
+# A vendor that is aware of an exploited vulnerability for >24h but hasn't
+# sent early warning is in violation of Art.14(2)(a).
+test_24h_early_warning_violation_when_late if {
+    inp := {
+        "incident_reporting": {
+            "actively_exploited_vuln_known":   true,
+            "hours_since_aware_of_vuln":       30,
+            "early_warning_sent":              false,
+        },
+    }
+    some v in main.violations with input as inp
+    contains(v, "Art.14(2)(a)")
+}
+
+# A vendor that DID send the early warning within the window should not
+# trigger Art.14(2)(a) (other rules may still fire).
+test_24h_early_warning_clears_when_sent if {
+    inp := {
+        "incident_reporting": {
+            "actively_exploited_vuln_known":   true,
+            "hours_since_aware_of_vuln":       30,
+            "early_warning_sent":              true,
+        },
+    }
+    hits := [v | some v in main.violations with input as inp; contains(v, "Art.14(2)(a)")]
+    count(hits) == 0
+}
+
+# Important Class II product using Module A is non-conformant per Art.32(2).
+test_module_a_insufficient_for_class_2 if {
+    inp := {
+        "conformity_assessment": {
+            "product_class":    "important_class_2",
+            "procedure_used":   "module_a",
+        },
+    }
+    some v in main.violations with input as inp
+    contains(v, "Art.32(2)")
+}
+
+# Support period below 5 years triggers Art.13(8) AND Annex II.2 rules
+# (both essential vuln-handling + manufacturer modules check this).
+test_short_support_period_triggers_both_rules if {
+    inp := {
+        "vulnerability_handling": {"support_period_years": 3},
+        "manufacturer": {"support_period": {"declared": true, "years": 3}},
+    }
+    annex_hit := count([v | some v in main.violations with input as inp; contains(v, "Annex II.2")])
+    art13_hit := count([v | some v in main.violations with input as inp; contains(v, "Art.13(8)")])
+    annex_hit > 0
+    art13_hit > 0
+}

--- a/frameworks/compliance/cra/tests/test_cra_main.rego
+++ b/frameworks/compliance/cra/tests/test_cra_main.rego
@@ -9,7 +9,7 @@ test_compliance_report_defined_on_empty_input if {
     r := main.compliance_report with input as {}
     r.framework == "EU Cyber Resilience Act (CRA)"
     r.regulation == "Regulation (EU) 2024/2847"
-    r.total_controls == 217
+    r.total_controls == 244
     is_number(r.violation_count)
 }
 
@@ -485,6 +485,81 @@ test_exemption_basis_must_be_documented if {
                 "process": {"exemption_basis_documented": false}}}
     hits := [v | some v in main.violations with input as inp;
              contains(v, "Art.23"); contains(v, "audit trail")]
+    count(hits) > 0
+}
+
+# ── Supply-chain evidence (SLSA bridge) ──────────────────────────────────
+
+test_supply_chain_evidence_module_appears if {
+    r := main.compliance_report with input as {}
+    r.module_summary.supply_chain_evidence
+    r.module_summary.supply_chain_evidence.upstream == "data.supply_chain.slsa"
+}
+
+test_sbom_missing_maps_to_annex_ii_1a if {
+    # An empty input → SLSA reports "No SBOM attached" → CRA bridge re-frames as Annex II.1(a)
+    inp := {}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Annex II.1(a) (via SLSA)")]
+    count(hits) > 0
+}
+
+test_unsigned_artifact_maps_to_annex_i_6a if {
+    # SLSA fires "Artifact is not signed" on empty input → CRA bridge re-frames as Annex I.6(a)
+    inp := {}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Annex I.6(a) (via SLSA)")]
+    count(hits) > 0
+}
+
+test_sbom_change_without_refresh_violates_art_11_via_slsa if {
+    inp := {"substantial_modification": {"changes": {"sbom_changed": true}}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Art.11 (via SLSA)")]
+    count(hits) > 0
+}
+
+# ── Crypto evidence (ISO 27001 A.10 bridge) ──────────────────────────────
+
+test_crypto_evidence_module_appears if {
+    r := main.compliance_report with input as {}
+    r.module_summary.crypto_evidence
+    r.module_summary.crypto_evidence.upstream == "data.iso27001.cryptography"
+}
+
+test_missing_crypto_policy_maps_to_annex_i_5 if {
+    inp := {}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Annex I.5 (via ISO 27001 A.10.1.1)")]
+    count(hits) > 0
+}
+
+test_weak_cipher_in_use_fires_annex_i_5b if {
+    inp := {"cryptography": {"ciphers_in_use": ["AES-256-GCM", "DES"]}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Annex I.5(b)"); contains(v, "DES")]
+    count(hits) > 0
+}
+
+test_deprecated_protocol_fires_annex_i_5b if {
+    inp := {"cryptography": {"protocols_in_use": ["TLS1.0", "TLS1.3"]}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Annex I.5(b)"); contains(v, "TLS1.0")]
+    count(hits) > 0
+}
+
+test_no_anti_rollback_fires_annex_i_6b if {
+    inp := {"cryptography": {"signing": {"anti_rollback_enforced": false}}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Annex I.6(b)"); contains(v, "Anti-rollback")]
+    count(hits) > 0
+}
+
+test_signing_without_hardware_backed_storage_fires_i_6_i_4 if {
+    inp := {"cryptography": {"signing": {"in_use": true,
+                                          "hardware_backed_key_storage": false}}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Annex I.6 (interaction with I.4)")]
     count(hits) > 0
 }
 

--- a/frameworks/compliance/cra/tests/test_cra_main.rego
+++ b/frameworks/compliance/cra/tests/test_cra_main.rego
@@ -9,7 +9,7 @@ test_compliance_report_defined_on_empty_input if {
     r := main.compliance_report with input as {}
     r.framework == "EU Cyber Resilience Act (CRA)"
     r.regulation == "Regulation (EU) 2024/2847"
-    r.total_controls == 163
+    r.total_controls == 217
     is_number(r.violation_count)
 }
 
@@ -240,4 +240,267 @@ test_user_info_must_disclose_sbom_location if {
     inp := {"user_information": {"sbom_access": {"disclosed_to_user": false}}}
     hits := [v | some v in main.violations with input as inp; contains(v, "Annex II.7")]
     count(hits) > 0
+}
+
+# ── Declaration of Conformity content (Annex IV) ─────────────────────────
+
+test_declaration_of_conformity_module_appears_in_summary if {
+    r := main.compliance_report with input as {}
+    r.module_summary.declaration_of_conformity
+}
+
+test_declaration_missing_sole_responsibility_statement if {
+    inp := {"declaration_of_conformity": {"statement_of_sole_responsibility": false}}
+    hits := [v | some v in main.violations with input as inp; contains(v, "Annex IV.4")]
+    count(hits) > 0
+}
+
+test_declaration_must_reference_cra_regulation if {
+    inp := {"declaration_of_conformity": {"conformity_statement": {"references_cra": false}}}
+    hits := [v | some v in main.violations with input as inp; contains(v, "Annex IV.6")]
+    count(hits) > 0
+}
+
+test_declaration_standards_must_include_dates_versions if {
+    inp := {"declaration_of_conformity": {
+                "standards": {
+                    "harmonised_standards_referenced": true,
+                    "standard_dates_versions_included": false}}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Annex IV.7"); contains(v, "dates/versions")]
+    count(hits) > 0
+}
+
+test_notified_body_block_only_fires_when_involved if {
+    inp_not_involved := {"declaration_of_conformity": {"notified_body": {"involved": false}}}
+    hits := [v | some v in main.violations with input as inp_not_involved;
+             contains(v, "Annex IV.8: Notified body involvement is declared")]
+    count(hits) == 0
+
+    inp_involved_no_id := {"declaration_of_conformity": {
+                              "notified_body": {"involved": true, "name": "TÜV"}}}
+    hits2 := [v | some v in main.violations with input as inp_involved_no_id;
+              contains(v, "Annex IV.8")]
+    count(hits2) > 0
+}
+
+test_declaration_signature_must_include_signatory_function if {
+    inp := {"declaration_of_conformity": {
+                "signature": {
+                    "signed_for_manufacturer": true,
+                    "signatory_name": "J. Doe",
+                    "signatory_function": false}}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Annex IV.10"); contains(v, "function")]
+    count(hits) > 0
+}
+
+# ── Substantial modification (Article 11) ────────────────────────────────
+
+test_substantial_modification_module_appears if {
+    r := main.compliance_report with input as {}
+    r.module_summary.substantial_modification
+}
+
+test_substantial_modification_requires_reassessment if {
+    inp := {"substantial_modification": {
+                "modification_classified_substantial": true,
+                "conformity_reassessment": {"performed": false}}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Art.11(2)"); contains(v, "not been re-performed")]
+    count(hits) > 0
+}
+
+test_substantial_modifier_assumes_manufacturer_role if {
+    inp := {"substantial_modification": {
+                "modification_classified_substantial": true,
+                "modifier_is_not_original_manufacturer": true,
+                "modifier_assumed_manufacturer_obligations": false}}
+    hits := [v | some v in main.violations with input as inp; contains(v, "Art.11(3)")]
+    count(hits) > 0
+}
+
+test_added_connectivity_requires_updated_risk_assessment if {
+    inp := {"substantial_modification": {
+                "changes": {
+                    "added_network_connectivity": true,
+                    "risk_assessment_updated": false}}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Annex I.1 interaction")]
+    count(hits) > 0
+}
+
+test_crypto_primitive_change_requires_review if {
+    inp := {"substantial_modification": {
+                "changes": {
+                    "cryptographic_primitive_changed": true,
+                    "cryptographic_review_performed": false}}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Annex I.5/6 interaction")]
+    count(hits) > 0
+}
+
+test_sbom_must_refresh_after_dependency_change if {
+    inp := {"substantial_modification": {
+                "changes": {
+                    "sbom_changed": true,
+                    "sbom_published_after_change": false}}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Annex II.1 interaction")]
+    count(hits) > 0
+}
+
+# ── Online marketplace (Article 22) ──────────────────────────────────────
+
+test_online_marketplace_module_appears if {
+    r := main.compliance_report with input as {}
+    r.module_summary.online_marketplace
+}
+
+test_non_marketplace_entity_has_zero_marketplace_violations if {
+    # An entity that is NOT a marketplace provider should produce zero
+    # marketplace-module violations (the threshold gate is correct).
+    inp := {"online_marketplace": {"is_marketplace_provider": false}}
+    r := main.compliance_report with input as inp
+    r.module_summary.online_marketplace.violations == 0
+}
+
+test_marketplace_must_designate_single_point_of_contact if {
+    inp := {"online_marketplace": {
+                "is_marketplace_provider": true,
+                "products_offered": {"includes_products_with_digital_elements": true}}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Art.22(1)"); contains(v, "single point of contact")]
+    count(hits) > 0
+}
+
+test_marketplace_must_action_takedown_within_48h if {
+    inp := {"online_marketplace": {
+                "is_marketplace_provider": true,
+                "products_offered": {"includes_products_with_digital_elements": true},
+                "authority_takedown_order_received": true,
+                "authority_takedown_order_hours_pending": 60,
+                "authority_takedown_order_actioned": false}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Art.22(3)"); contains(v, "48h")]
+    count(hits) > 0
+}
+
+test_marketplace_random_check_sample_below_one_percent_violates if {
+    inp := {"online_marketplace": {
+                "is_marketplace_provider": true,
+                "products_offered": {"includes_products_with_digital_elements": true},
+                "random_checks": {"performed": true, "sample_size_pct": 0.5}}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Art.22(5)"); contains(v, "0.5")]
+    count(hits) > 0
+}
+
+test_marketplace_high_severity_listing_must_be_removed if {
+    inp := {"online_marketplace": {
+                "is_marketplace_provider": true,
+                "products_offered": {"includes_products_with_digital_elements": true},
+                "non_compliant_listing_identified": true,
+                "severity": "high",
+                "listing_removed": false}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "high-severity non-compliant listing")]
+    count(hits) > 0
+}
+
+# ── FOSS exclusion (Article 23) ──────────────────────────────────────────
+
+test_foss_exclusion_module_appears if {
+    r := main.compliance_report with input as {}
+    r.module_summary.foss_exclusion
+}
+
+test_non_commercial_oss_is_exempt if {
+    inp := {"foss": {
+                "is_open_source_product": true,
+                "outside_course_of_commercial_activity": true}}
+    r := main.compliance_report with input as inp
+    r.module_summary.foss_exclusion.exempt == true
+    r.module_summary.foss_exclusion.violations == 0
+}
+
+test_default_state_is_not_exempt if {
+    r := main.compliance_report with input as {}
+    r.module_summary.foss_exclusion.exempt == false
+}
+
+test_misclaim_when_paid_support_offered if {
+    inp := {"foss": {
+                "claimed_exemption": true,
+                "revenue": {"paid_support_offered": true}}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Art.23 (mis-claim)"); contains(v, "paid support")]
+    count(hits) > 0
+}
+
+test_misclaim_when_license_fees_collected if {
+    inp := {"foss": {
+                "claimed_exemption": true,
+                "revenue": {"license_fees_collected": true}}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "license/usage fees")]
+    count(hits) > 0
+}
+
+test_misclaim_when_commercial_saas_hosting if {
+    inp := {"foss": {
+                "claimed_exemption": true,
+                "revenue": {"commercial_saas_hosting": true}}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "commercial hosted version")]
+    count(hits) > 0
+}
+
+test_donation_full_time_devs_moves_to_steward_category if {
+    inp := {"foss": {
+                "claimed_exemption": true,
+                "revenue": {"donations_received": true},
+                "development": {
+                    "employed_developers_paid_from_donations": true,
+                    "developers_full_time": true}}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Art.23 (boundary)"); contains(v, "OSS-steward category")]
+    count(hits) > 0
+}
+
+test_recital_18_commercial_integration_violates if {
+    inp := {"foss": {
+                "claimed_exemption": true,
+                "distribution": {
+                    "integrated_into_commercial_product": true,
+                    "distributed_in_eu_market": true}}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Recital 18")]
+    count(hits) > 0
+}
+
+test_exemption_basis_must_be_documented if {
+    inp := {"foss": {
+                "claimed_exemption": true,
+                "process": {"exemption_basis_documented": false}}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Art.23"); contains(v, "audit trail")]
+    count(hits) > 0
+}
+
+test_donations_alone_do_not_create_misclaim if {
+    # Recital 15 — donations alone don't make the entity commercial.
+    # If an entity claims exemption AND only receives donations (no full-time
+    # paid devs), the donation-related boundary rule must NOT fire.
+    inp := {"foss": {
+                "claimed_exemption": true,
+                "is_open_source_product": true,
+                "outside_course_of_commercial_activity": true,
+                "revenue": {"donations_received": true},
+                "process": {
+                    "exemption_basis_documented": true,
+                    "exemption_basis_reviewed_annually": true}}}
+    hits := [v | some v in main.violations with input as inp;
+             contains(v, "Art.23 (boundary)")]
+    count(hits) == 0
 }

--- a/frameworks/compliance/cra/tests/test_cra_main.rego
+++ b/frameworks/compliance/cra/tests/test_cra_main.rego
@@ -9,7 +9,7 @@ test_compliance_report_defined_on_empty_input if {
     r := main.compliance_report with input as {}
     r.framework == "EU Cyber Resilience Act (CRA)"
     r.regulation == "Regulation (EU) 2024/2847"
-    r.total_controls == 88
+    r.total_controls == 163
     is_number(r.violation_count)
 }
 
@@ -22,7 +22,7 @@ test_violations_emitted_on_empty_input if {
     count(main.violations) > 50 with input as {}
 }
 
-test_module_summary_has_all_six_modules if {
+test_module_summary_has_all_eleven_modules if {
     r := main.compliance_report with input as {}
     r.module_summary.essential_requirements
     r.module_summary.vulnerability_handling
@@ -30,6 +30,11 @@ test_module_summary_has_all_six_modules if {
     r.module_summary.technical_documentation
     r.module_summary.conformity_assessment
     r.module_summary.manufacturer_obligations
+    r.module_summary.authorised_representative
+    r.module_summary.importer_obligations
+    r.module_summary.distributor_obligations
+    r.module_summary.oss_steward
+    r.module_summary.user_information
 }
 
 test_defaults_for_metadata if {
@@ -105,4 +110,134 @@ test_short_support_period_triggers_both_rules if {
     art13_hit := count([v | some v in main.violations with input as inp; contains(v, "Art.13(8)")])
     annex_hit > 0
     art13_hit > 0
+}
+
+# ── Module A vs B+C / Module H conformity assessment branches ──────────────
+
+test_class_2_module_a_fails if {
+    inp := {"conformity_assessment": {"product_class": "important_class_2", "procedure_used": "module_a"}}
+    hits := [v | some v in main.violations with input as inp; contains(v, "Art.32(2)")]
+    count(hits) > 0
+}
+
+test_class_2_module_h_clears_32_2 if {
+    inp := {"conformity_assessment": {"product_class": "important_class_2", "procedure_used": "module_h",
+            "notified_body": {"engaged": true, "id_number": "NB-9999"}}}
+    hits := [v | some v in main.violations with input as inp; contains(v, "Art.32(2)")]
+    count(hits) == 0
+}
+
+test_critical_product_requires_cyber_cert_scheme if {
+    inp := {"conformity_assessment": {"product_class": "critical", "european_cyber_cert_scheme_used": false}}
+    hits := [v | some v in main.violations with input as inp; contains(v, "Art.32(3) / Art.8")]
+    count(hits) > 0
+}
+
+test_third_party_assessment_requires_notified_body if {
+    inp := {"conformity_assessment": {"procedure_used": "module_b_c",
+                                       "notified_body": {"engaged": false}}}
+    hits := [v | some v in main.violations with input as inp; contains(v, "Art.32(4): Third-party")]
+    count(hits) > 0
+}
+
+# ── 72h + 14d incident reporting cascades ──────────────────────────────────
+
+test_72h_notification_violation if {
+    inp := {"incident_reporting": {"actively_exploited_vuln_known": true,
+                                    "hours_since_aware_of_vuln": 80,
+                                    "vulnerability_notification_sent": false}}
+    hits := [v | some v in main.violations with input as inp; contains(v, "Art.14(2)(b)")]
+    count(hits) > 0
+}
+
+test_14d_final_report_violation if {
+    inp := {"incident_reporting": {"actively_exploited_vuln_known": true,
+                                    "hours_since_aware_of_vuln": 350,
+                                    "days_since_aware_of_vuln": 15,
+                                    "final_vuln_report_sent": false}}
+    hits := [v | some v in main.violations with input as inp; contains(v, "Art.14(2)(c)")]
+    count(hits) > 0
+}
+
+# Severe incident timeline (Art.14(3) — same 24h/72h/1-month cascade)
+test_severe_incident_24h_violation if {
+    inp := {"incident_reporting": {"severe_incident_occurred": true,
+                                    "hours_since_incident": 30,
+                                    "incident_early_warning_sent": false}}
+    hits := [v | some v in main.violations with input as inp; contains(v, "Art.14(3)(a)")]
+    count(hits) > 0
+}
+
+test_users_impacted_must_be_notified_with_mitigation if {
+    inp := {"incident_reporting": {"users_impacted": true,
+                                    "affected_users_notified": true,
+                                    "mitigation_guidance_provided": false}}
+    hits := [v | some v in main.violations with input as inp; contains(v, "Art.14(9)")]
+    count(hits) > 0
+}
+
+# ── Importer / distributor / auth-rep / OSS-steward modules ───────────────
+
+test_importer_under_own_brand_assumes_manufacturer_role if {
+    inp := {"importer": {"placed_under_own_brand": true,
+                          "assumed_manufacturer_obligations": false}}
+    hits := [v | some v in main.violations with input as inp; contains(v, "Art.21:")]
+    count(hits) > 0
+}
+
+test_distributor_modification_assumes_manufacturer_role if {
+    inp := {"distributor": {"product_modified_after_placement": true,
+                             "assumed_manufacturer_obligations": false}}
+    hits := [v | some v in main.violations with input as inp; contains(v, "Art.21:")]
+    count(hits) > 0
+}
+
+test_non_eu_manufacturer_must_appoint_authorised_rep if {
+    inp := {"authorised_representative": {"manufacturer_outside_eu": true,
+                                            "appointed": false}}
+    hits := [v | some v in main.violations with input as inp; contains(v, "Art.18(1)")]
+    count(hits) > 0
+}
+
+test_auth_rep_cannot_assume_conformity_assessment if {
+    inp := {"authorised_representative": {
+                "appointed": true,
+                "tasks": {"conformity_assessment_delegated": true}}}
+    hits := [v | some v in main.violations with input as inp; contains(v, "Art.18(4)")]
+    count(hits) > 0
+}
+
+test_oss_steward_threshold_gate_holds if {
+    # Entity that does NOT meet the "systematic and sustained / commercial" gate
+    # should produce ZERO OSS-steward violations.
+    inp := {"oss_steward": {
+                "is_legal_person_other_than_natural": true,
+                "provides_systematic_sustained_support": false,
+                "oss_product_intended_for_commercial_activities": false}}
+    r := main.compliance_report with input as inp
+    r.module_summary.oss_steward.violations == 0
+}
+
+test_oss_steward_must_publish_cybersecurity_policy if {
+    inp := {"oss_steward": {
+                "is_legal_person_other_than_natural": true,
+                "provides_systematic_sustained_support": true,
+                "oss_product_intended_for_commercial_activities": true,
+                "cybersecurity_policy": {"published": false}}}
+    hits := [v | some v in main.violations with input as inp; contains(v, "Art.24(1)")]
+    count(hits) > 0
+}
+
+# ── User information (Annex II) ───────────────────────────────────────────
+
+test_user_info_must_disclose_end_of_support if {
+    inp := {"user_information": {"support_period": {"disclosed": true, "end_of_support_date_disclosed": false}}}
+    hits := [v | some v in main.violations with input as inp; contains(v, "Annex II.8: End-of-support")]
+    count(hits) > 0
+}
+
+test_user_info_must_disclose_sbom_location if {
+    inp := {"user_information": {"sbom_access": {"disclosed_to_user": false}}}
+    hits := [v | some v in main.violations with input as inp; contains(v, "Annex II.7")]
+    count(hits) > 0
 }

--- a/frameworks/compliance/cra/user_information/cra_user_information.rego
+++ b/frameworks/compliance/cra/user_information/cra_user_information.rego
@@ -1,0 +1,135 @@
+package cra.user_information
+
+import rego.v1
+
+# EU Cyber Resilience Act (CRA) — Annex II
+# Information and instructions to the user.
+#
+# Manufacturers must include this set of information with every product
+# placed on the EU market. Granular check separate from Art.13(10), which
+# only verifies the manufacturer provides "instructions" at all.
+
+default compliant := false
+
+# Annex II (1) — Manufacturer name, registered trade name, contact
+violation contains msg if {
+    not input.user_information.manufacturer.name_provided
+    msg := "CRA Annex II.1: Manufacturer's name or registered trade name not included in user information"
+}
+
+violation contains msg if {
+    not input.user_information.manufacturer.postal_address_provided
+    msg := "CRA Annex II.1: Manufacturer's postal address not included in user information"
+}
+
+violation contains msg if {
+    not input.user_information.manufacturer.electronic_contact_provided
+    msg := "CRA Annex II.1: Manufacturer's electronic address or website not included in user information"
+}
+
+violation contains msg if {
+    not input.user_information.manufacturer.contact_for_vulnerability_reports
+    msg := "CRA Annex II.1: Single point of contact for vulnerability reports not provided"
+}
+
+# Annex II (2) — Single point of contact for cybersecurity-related queries
+violation contains msg if {
+    not input.user_information.single_point_of_contact.published
+    msg := "CRA Annex II.2: Single point of contact for cybersecurity-related queries not published"
+}
+
+# Annex II (3) — Identifier (type/batch/serial/version) of the product
+violation contains msg if {
+    not input.user_information.product_identifier.type_provided
+    msg := "CRA Annex II.3: Product type identifier not provided in user information"
+}
+
+violation contains msg if {
+    not input.user_information.product_identifier.batch_or_serial_provided
+    msg := "CRA Annex II.3: Batch or serial number not provided"
+}
+
+violation contains msg if {
+    not input.user_information.product_identifier.version_provided
+    msg := "CRA Annex II.3: Product version (software version, firmware) not provided"
+}
+
+# Annex II (4) — Intended purpose, including the security environment
+violation contains msg if {
+    not input.user_information.intended_purpose.described
+    msg := "CRA Annex II.4: Intended purpose of the product not described in user information"
+}
+
+violation contains msg if {
+    not input.user_information.intended_purpose.security_environment_specified
+    msg := "CRA Annex II.4: Security environment / required operating conditions not specified"
+}
+
+# Annex II (5) — Cybersecurity properties
+violation contains msg if {
+    not input.user_information.cybersecurity_properties.described
+    msg := "CRA Annex II.5: Cybersecurity properties of the product not described to users"
+}
+
+# Annex II (6) — Use-case-relevant risks/threats
+violation contains msg if {
+    not input.user_information.risks_and_threats.documented
+    msg := "CRA Annex II.6: Use-case-relevant cybersecurity risks and threats not documented for the user"
+}
+
+# Annex II (7) — Where to find SBOM
+violation contains msg if {
+    not input.user_information.sbom_access.disclosed_to_user
+    msg := "CRA Annex II.7: User information does not disclose where the SBOM can be obtained"
+}
+
+# Annex II (8) — Support period and end-of-support date
+violation contains msg if {
+    not input.user_information.support_period.disclosed
+    msg := "CRA Annex II.8: Declared support period not disclosed in user information"
+}
+
+violation contains msg if {
+    not input.user_information.support_period.end_of_support_date_disclosed
+    msg := "CRA Annex II.8: End-of-support date not disclosed"
+}
+
+# Annex II (9) — Where to find security updates
+violation contains msg if {
+    not input.user_information.updates.access_method_disclosed
+    msg := "CRA Annex II.9: Method for the user to access security updates not disclosed"
+}
+
+violation contains msg if {
+    not input.user_information.updates.installation_instructions
+    msg := "CRA Annex II.9: Instructions for installing security updates not provided"
+}
+
+# Annex II (10) — Secure decommissioning of the product
+violation contains msg if {
+    not input.user_information.decommissioning.guidance_provided
+    msg := "CRA Annex II.10: Guidance on secure decommissioning (data wipe / device disposal) not provided"
+}
+
+# Annex II (11) — Languages
+violation contains msg if {
+    not input.user_information.languages.member_state_languages_covered
+    msg := "CRA Annex II.11: User information not provided in the official language(s) of the EU Member States where the product is made available"
+}
+
+# Annex II (12) — Easily understandable to expected users
+violation contains msg if {
+    not input.user_information.readability.appropriate_for_users
+    msg := "CRA Annex II.12: User information not written in a way easily understandable to its expected users"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "family": "Annex II",
+    "name":   "Information and instructions to the user",
+    "controls_evaluated": 20,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/compliance/cra/vulnerability_handling/cra_vulnerability_handling.rego
+++ b/frameworks/compliance/cra/vulnerability_handling/cra_vulnerability_handling.rego
@@ -1,0 +1,111 @@
+package cra.vulnerability_handling
+
+import rego.v1
+
+# EU Cyber Resilience Act (CRA) — Annex I Part II
+# Vulnerability handling requirements for products with digital elements.
+#
+# Manufacturers must put in place processes to handle vulnerabilities
+# throughout the expected support period (Article 13(8): minimum 5 years
+# or product's actual lifetime if shorter).
+
+default compliant := false
+
+# Annex I Part II (1) — Vulnerability identification + documentation
+violation contains msg if {
+    not input.vulnerability_handling.sbom.maintained
+    msg := "CRA Annex II.1(a): Software bill of materials (SBOM) not maintained for the product"
+}
+
+violation contains msg if {
+    not input.vulnerability_handling.sbom.machine_readable_format
+    msg := "CRA Annex II.1(b): SBOM not in a machine-readable format (e.g., SPDX, CycloneDX)"
+}
+
+violation contains msg if {
+    not input.vulnerability_handling.sbom.components_documented
+    msg := "CRA Annex II.1(c): Top-level dependencies of the product not documented in SBOM"
+}
+
+# Annex I Part II (2) — Address + remediate vulnerabilities
+violation contains msg if {
+    not input.vulnerability_handling.remediation.process_documented
+    msg := "CRA Annex II.2(a): Documented vulnerability remediation process not in place"
+}
+
+violation contains msg if {
+    not input.vulnerability_handling.remediation.security_updates_provided_free
+    msg := "CRA Annex II.2(b): Security updates not provided free of charge to users during support period"
+}
+
+violation contains msg if {
+    input.vulnerability_handling.support_period_years < 5
+    msg := sprintf("CRA Annex II.2 / Art.13(8): Declared support period (%d years) is below the 5-year minimum", [input.vulnerability_handling.support_period_years])
+}
+
+# Annex I Part II (3) — Regular vulnerability testing
+violation contains msg if {
+    not input.vulnerability_handling.testing.regular_testing_performed
+    msg := "CRA Annex II.3(a): Regular security testing/auditing not performed"
+}
+
+violation contains msg if {
+    not input.vulnerability_handling.testing.test_results_reviewed
+    msg := "CRA Annex II.3(b): Vulnerability test results not reviewed before product release"
+}
+
+# Annex I Part II (4) — Information sharing on resolved vulnerabilities
+violation contains msg if {
+    not input.vulnerability_handling.disclosure.public_disclosure_after_patch
+    msg := "CRA Annex II.4(a): Resolved vulnerabilities not publicly disclosed after patches are available"
+}
+
+violation contains msg if {
+    not input.vulnerability_handling.disclosure.cve_assigned
+    msg := "CRA Annex II.4(b): CVE identifiers not assigned to resolved vulnerabilities"
+}
+
+# Annex I Part II (5) — Coordinated vulnerability disclosure policy
+violation contains msg if {
+    not input.vulnerability_handling.coordinated_disclosure.policy_published
+    msg := "CRA Annex II.5(a): Coordinated vulnerability disclosure (CVD) policy not published"
+}
+
+violation contains msg if {
+    not input.vulnerability_handling.coordinated_disclosure.contact_point_provided
+    msg := "CRA Annex II.5(b): Single contact point for vulnerability reports not provided"
+}
+
+# Annex I Part II (6) — Mechanisms for users to report vulnerabilities
+violation contains msg if {
+    not input.vulnerability_handling.reporting_channel.exists
+    msg := "CRA Annex II.6: User-facing channel for reporting vulnerabilities to the manufacturer not provided"
+}
+
+# Annex I Part II (7) — Mechanism for secure distribution of updates
+violation contains msg if {
+    not input.vulnerability_handling.update_distribution.secure_channel
+    msg := "CRA Annex II.7(a): Security update distribution channel not authenticated/integrity-protected"
+}
+
+violation contains msg if {
+    not input.vulnerability_handling.update_distribution.timely_delivery
+    msg := "CRA Annex II.7(b): Security updates not delivered to end users in a timely manner after release"
+}
+
+# Annex I Part II (8) — Ensure mitigation measures are deployed
+violation contains msg if {
+    not input.vulnerability_handling.mitigation.compensating_controls_documented
+    msg := "CRA Annex II.8: Compensating controls / temporary mitigations not documented for users when patches are not yet available"
+}
+
+compliant if { count(violation) == 0 }
+
+compliance_report := {
+    "family": "Annex I Part II",
+    "name":   "Vulnerability handling requirements",
+    "controls_evaluated": 16,
+    "violations": violation,
+    "violation_count": count(violation),
+    "compliant": compliant,
+}

--- a/frameworks/sovereignty/digital_sovereignty/cyber_resilience_sovereignty.rego
+++ b/frameworks/sovereignty/digital_sovereignty/cyber_resilience_sovereignty.rego
@@ -10,9 +10,14 @@ import rego.v1
 #   NIST SP 800-160 Vol. 2 (Cyber Resiliency Engineering)
 #   NIST CSF 2.0 — Govern, Identify, Protect, Detect, Respond, Recover
 #   ISO 22301 (Business Continuity Management)
-#   EU Cyber Resilience Act (CRA) — Regulation 2024/2847
 #   ENISA Cyber Resilience Guidelines
 #   NCSC Cyber Resilience Framework (UK)
+#
+# NOTE on CRA: This module does NOT implement the EU Cyber Resilience Act
+# (Regulation (EU) 2024/2847). CRA is implemented in its own dedicated
+# framework at frameworks/compliance/cra/ — package cra.main — which
+# covers all 15 articles + annexes the CRA actually mandates. See
+# frameworks/compliance/cra/COVERAGE.md for the article-level mapping.
 #
 # Input schema:
 #   input.cyber_resilience


### PR DESCRIPTION
## Summary

New framework for **Regulation (EU) 2024/2847 — the Cyber Resilience Act**. CRA entered into force in November 2024 and mandatory compliance starts **December 2027** for manufacturers, importers, and distributors of products with digital elements placed on the EU market.

## Structure

```
frameworks/compliance/cra/
├── essential_requirements/      Annex I Part I       — 21 controls
├── vulnerability_handling/      Annex I Part II      — 16 controls
├── incident_reporting/          Article 14           — 11 controls (24h/72h/14d timelines)
├── technical_documentation/     Art.28 / Annex VII   — 15 controls
├── conformity_assessment/       Art.32-33 + CE       — 11 controls
├── manufacturer_obligations/    Article 13           — 14 controls
└── cra_main.rego                Aggregator → `cra.main`
```

**Total**: 88 distinct control checks.

**OPA endpoint**: `POST <opa_compliance>/v1/data/cra/main/compliance_report`

Returns the standard contract shape `{framework, compliant, total_controls, violations, violation_count}` plus a `module_summary` breaking down per-module pass/fail.

## What CRA covers that we didn't have

| Article / Annex | What it requires | Why it matters |
|---|---|---|
| Annex I Part I | 12 essential cybersecurity requirements (secure default config, vulnerability protection, confidentiality, integrity, data minimization, attack-surface reduction, logging…) | Every connected product placed on the EU market |
| Annex I Part II | SBOM, coordinated vulnerability disclosure, 5-year minimum support period | Product lifecycle, not just point-in-time |
| Article 13 | Manufacturer obligations (risk assessment, third-party component due diligence, end-of-support notification) | Internal process maturity |
| Article 14 | **24h / 72h / 14d** incident + vulnerability reporting timelines to ENISA | Sharpest deadline in CRA — strict per-clock-hour enforcement |
| Article 28 + Annex VII | Technical documentation, 10-year retention | Audit-ability |
| Articles 32-33 | Conformity assessment + CE marking; Important Class II → notified body required | Market access gate |

## Test plan

- [x] `opa check` clean across all CRA files
- [x] `opa test` on the cra/ tree — 10/10 passing
- [x] Full-repo `opa test` — 85/85 (10 new + 75 pre-existing)
- [x] Targeted rule tests for: 24h early-warning timeline (Art.14(2)(a)), Module A insufficiency for Important Class II (Art.32(2)), 5-year minimum support period double-fire (Art.13(8) + Annex II.2)
- [ ] Reviewer verifies CI green

## Follow-ups in the consuming repo

After merge:

1. Add `cra: compliance` to `opa_framework_map` in `ansible/vars/site_config.yml` of `ynotbhatc/compliance`
2. Bump `policies/` submodule pointer in the compliance repo
3. Reload OPA containers (lab-aap / mac-aap / RHPDS) to pick up the new package

🤖 Generated with [Claude Code](https://claude.com/claude-code)