### PR TITLE
feat(cis_rhel9): add cis_rhel9.main bridge for generic-framework path

### DIFF
--- a/benchmarks/cis/rhel_9/cis_rhel9_main.rego
+++ b/benchmarks/cis/rhel_9/cis_rhel9_main.rego
@@ -1,0 +1,29 @@
+package cis_rhel9.main
+
+# Bridge: re-export the cis_rhel9 orchestrator results under the
+# /v1/data/<framework>/main/compliance_report convention used by the
+# Generic Framework Assessment playbook. All other frameworks expose
+# `compliance_report` at <framework>.main; this brings cis_rhel9 in line.
+#
+# The actual rules live in cis_rhel9_complete.rego (package cis_rhel9).
+
+import rego.v1
+import data.cis_rhel9 as cis
+
+default compliance_report := {}
+
+compliance_report := {
+	"framework": "cis_rhel9",
+	"version": "v2.0.0",
+	"total_controls": 338,
+	"compliant": cis.compliant,
+	"passed_controls": cis.passed_controls,
+	"failed_controls": cis.failed_controls,
+	"compliance_percentage": cis.compliance_percentage,
+	"violations": cis.violations,
+	"section_results": cis.section_results,
+	"extended_hardening": cis.extended_hardening_summary,
+	"recommendations": cis.generate_recommendations,
+} if {
+	cis.compliance_percentage >= 0
+}


### PR DESCRIPTION
## Summary

- Add `policies/benchmarks/cis/rhel_9/cis_rhel9_main.rego` exposing `compliance_report` at `cis_rhel9.main`
- Re-exports the existing `cis_rhel9_complete.rego` results — no behavioral change
- Matches the convention already used by `nerc_cip_main`, `iso27001_main`, etc.

## Why

AAP 2.7's Generic Framework Assessment hits `/v1/data/<framework>/main/compliance_report` for all frameworks. The `cis_rhel9` package didn't expose anything at `.main`, so the call returned `{}`. This unblocks `framework=cis_rhel9` in that demo.

## Test plan

- [x] `opa check` passes via pre-commit hook
- [x] In-cluster OPA on lab-aap 2.7 returns populated `compliance_report` for `cis_rhel9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)