### PR TITLE
fix(coverage): honest total_controls_covered + remove misleading comments/code

### DIFF
--- a/benchmarks/cis/amazon_linux_2023/cis_al20239_complete.rego
+++ b/benchmarks/cis/amazon_linux_2023/cis_al20239_complete.rego
@@ -177,7 +177,19 @@ compliant_sections := count([1 |
 
 compliance_percentage := (compliant_sections * 100) / total_sections
 
-total_controls_covered := 338
+# Rule heads implemented across all modules in this policy set: 229
+#
+# This count is the number of Rego rule heads (`contains msg if`,
+# `contains violation if`) across every module imported by this master.
+# It is NOT a formal 1-to-1 mapping to CIS Amazon Linux 2023 Benchmark
+# control IDs. The prior value of 338 in this field was inaccurate —
+# it was carried over from the RHEL 9 master and did not reflect
+# actual coverage in the AL 2023 policy set. See per-module
+# `compliance_report` for actual violation detail.
+#
+# For audit-of-record use this library MUST be formally mapped against
+# the CIS Amazon Linux 2023 Benchmark before results are relied upon.
+total_controls_covered := 229
 
 # =============================================================================
 # RISK ASSESSMENT

--- a/benchmarks/cis/debian_11/cis_debian_11_complete.rego
+++ b/benchmarks/cis/debian_11/cis_debian_11_complete.rego
@@ -165,6 +165,15 @@ compliance_assessment := {
 # TOTAL CONTROLS COVERED
 # =============================================================================
 
-# Estimated ~400+ CIS Debian 11 controls
-# Currently using stub modules (pass by default) - ready for full implementation
-total_controls_covered := 400
+# Rule heads implemented across all modules in this policy set: 240
+#
+# This count is the number of Rego rule heads (`contains msg if`,
+# `contains violation if`) across every module imported by this master.
+# It is NOT a formal 1-to-1 mapping to CIS Debian Linux 11 Benchmark
+# control IDs. Some CIS controls are covered by multiple rules; some
+# rules cover multiple controls; some CIS controls are not implemented
+# here. See per-module `compliance_report` for actual violation detail.
+#
+# For audit-of-record use this library MUST be formally mapped against
+# the CIS Debian Linux 11 Benchmark before results are relied upon.
+total_controls_covered := 240

--- a/benchmarks/cis/network_devices/pfsense/cis_pfsense.rego
+++ b/benchmarks/cis/network_devices/pfsense/cis_pfsense.rego
@@ -316,12 +316,15 @@ section_4_violations contains msg if {
 
 # ── Section 5: Package & Update Management ────────────────────────────────────
 
-# 5.1.1  No packages with known vulnerabilities (placeholder — flag if vuln_list present)
+# 5.1.1  No packages with known vulnerabilities
+#
+# This rule requires the fact-collection layer to explicitly set
+# input.vulnerability_scan.performed == true. When performed=true and
+# vulnerable_packages is empty, the rule passes. When performed is false
+# or absent, the rule fires a distinct "unable to verify" violation
+# rather than silently passing.
 no_vulnerable_packages if {
-    not input.vulnerable_packages
-}
-
-no_vulnerable_packages if {
+    input.vulnerability_scan.performed == true
     count(input.vulnerable_packages) == 0
 }
 
@@ -337,8 +340,14 @@ captive_portal_disabled if {
 }
 
 section_5_violations contains msg if {
+    input.vulnerability_scan.performed == true
     not no_vulnerable_packages
     msg := "5.1.1 Packages with known vulnerabilities detected — update immediately"
+}
+
+section_5_violations contains msg if {
+    not input.vulnerability_scan.performed
+    msg := "5.1.1 UNABLE TO VERIFY — vulnerability scan facts not provided (input.vulnerability_scan.performed is not true)"
 }
 
 # ── Aggregate violations ──────────────────────────────────────────────────────

--- a/benchmarks/cis/ubuntu_20_04/cis_ubuntu_20_04_complete.rego
+++ b/benchmarks/cis/ubuntu_20_04/cis_ubuntu_20_04_complete.rego
@@ -162,9 +162,18 @@ compliance_assessment := {
 }
 
 # =============================================================================
-# TOTAL CONTROLS COVERED
+# COVERAGE — honest representation
 # =============================================================================
-
-# Estimated ~400+ CIS Ubuntu 20.04 controls
-# Currently using stub modules (pass by default) - ready for full implementation
-total_controls_covered := 400
+#
+# Rule heads implemented across all modules in this policy set: 240
+#
+# This count is the number of Rego rule heads (`contains msg if`,
+# `contains violation if`) across every module imported by this master.
+# It is NOT a formal 1-to-1 mapping to CIS Ubuntu 20.04 LTS Benchmark
+# control IDs. Some CIS controls are covered by multiple rules; some
+# rules cover multiple controls; some CIS controls are not implemented
+# here. See per-module `compliance_report` for actual violation detail.
+#
+# For audit-of-record use this library MUST be formally mapped against
+# the CIS Ubuntu 20.04 LTS Benchmark before results are relied upon.
+total_controls_covered := 240

--- a/benchmarks/cis/ubuntu_22_04/cis_ubuntu_22_04_complete.rego
+++ b/benchmarks/cis/ubuntu_22_04/cis_ubuntu_22_04_complete.rego
@@ -166,12 +166,21 @@ compliance_assessment := {
 }
 
 # =============================================================================
-# TOTAL CONTROLS COVERED
+# COVERAGE — honest representation
 # =============================================================================
-
-# Estimated ~400+ CIS Ubuntu 22.04 controls
-# Currently using stub modules (pass by default) - ready for full implementation
-total_controls_covered := 400
+#
+# Rule heads implemented across all modules in this policy set: 240
+#
+# This count is the number of Rego rule heads (`contains msg if`,
+# `contains violation if`) across every module imported by this master.
+# It is NOT a formal 1-to-1 mapping to CIS Ubuntu 22.04 LTS Benchmark
+# control IDs. Some CIS controls are covered by multiple rules; some
+# rules cover multiple controls; some CIS controls are not implemented
+# here. See per-module `compliance_report` for actual violation detail.
+#
+# For audit-of-record use this library MUST be formally mapped against
+# the CIS Ubuntu 22.04 LTS Benchmark before results are relied upon.
+total_controls_covered := 240
 
 # =============================================================================
 # PROFILE SELECTOR (Level 1 / Level 2)

--- a/benchmarks/cis/ubuntu_24_04/cis_ubuntu_24_04_complete.rego
+++ b/benchmarks/cis/ubuntu_24_04/cis_ubuntu_24_04_complete.rego
@@ -166,12 +166,21 @@ compliance_assessment := {
 }
 
 # =============================================================================
-# TOTAL CONTROLS COVERED
+# COVERAGE — honest representation
 # =============================================================================
-
-# Estimated ~400+ CIS Ubuntu 24.04 controls
-# Currently using stub modules (pass by default) - ready for full implementation
-total_controls_covered := 400
+#
+# Rule heads implemented across all modules in this policy set: 240
+#
+# This count is the number of Rego rule heads (`contains msg if`,
+# `contains violation if`) across every module imported by this master.
+# It is NOT a formal 1-to-1 mapping to CIS Ubuntu 24.04 LTS Benchmark
+# control IDs. Some CIS controls are covered by multiple rules; some
+# rules cover multiple controls; some CIS controls are not implemented
+# here. See per-module `compliance_report` for actual violation detail.
+#
+# For audit-of-record use this library MUST be formally mapped against
+# the CIS Ubuntu 24.04 LTS Benchmark before results are relied upon.
+total_controls_covered := 240
 
 # =============================================================================
 # PROFILE SELECTOR (Level 1 / Level 2)

--- a/frameworks/management/corporate/password_policy.rego
+++ b/frameworks/management/corporate/password_policy.rego
@@ -67,9 +67,13 @@ history_requirements_met if {
     not password_in_history
 }
 
+# password_in_history — expects the caller to have pre-hashed input.password.value
+# with the same algorithm used to populate input.user.password_history[].hash.
+# Rego is NOT the place to compute password hashes; the fact-collection layer
+# (Ansible playbook / PAM history reader) must provide comparable hash values.
 password_in_history if {
     some i
-    input.user.password_history[i].hash == hash_password(input.password.value)
+    input.user.password_history[i].hash == input.password.value_hash
 }
 
 # Password Age Requirements
@@ -329,7 +333,10 @@ policy_metadata := {
     "exception_approval_required": true
 }
 
-# Helper function for password hashing (placeholder - implement with actual hash function)
-hash_password(password) := sprintf("hash_%s", [password]) if {
-    true  # In real implementation, use proper cryptographic hash
-}
+# NOTE: A fake `hash_password()` helper previously lived here that returned
+# `"hash_" + password` (literally a prefix + plaintext). It was called from the
+# password-reuse check above and would have silently produced FALSE COMPLIANCE
+# in any real deployment (real password history stores bcrypt/argon2/sha512-crypt
+# hashes; the fake would never match). Removed. The reuse check now expects the
+# caller to pre-hash `input.password.value` using the same algorithm as the
+# password history and pass it in as `input.password.value_hash`.


### PR DESCRIPTION
## Summary

Five master files claimed inflated or fabricated CIS control counts, and two non-master files silently produced false-positive compliant results. All are policy files whose output ends up in customer-facing compliance reports — misleading coverage numbers create real audit-of-record risk.

## Concrete lies fixed

| File | Was | Now |
|---|---|---|
| `cis/debian_11/cis_debian_11_complete.rego` | `total_controls_covered := 400` + "stub modules (pass by default)" | `:= 240` + honest note |
| `cis/ubuntu_20_04/cis_ubuntu_20_04_complete.rego` | same | same fix |
| `cis/ubuntu_22_04/cis_ubuntu_22_04_complete.rego` | same | same fix |
| `cis/ubuntu_24_04/cis_ubuntu_24_04_complete.rego` | same | same fix |
| `cis/amazon_linux_2023/cis_al20239_complete.rego` | `:= 338` (copy of RHEL 9's value) | `:= 229` + honest note |
| `cis/network_devices/pfsense/cis_pfsense.rego` 5.1.1 | "no data == compliant" | now requires `vulnerability_scan.performed == true`, fires distinct "UNABLE TO VERIFY" if not |
| `frameworks/management/corporate/password_policy.rego` | `hash_password(pw) := "hash_" + pw` fake helper — would silently produce **false compliance** on real password-reuse checks | Removed helper. Reuse check now expects `input.password.value_hash` from the fact-collection layer using the real algorithm. |

## Why this matters

These policies drive `compliance_results` rows that customers and auditors will see. A `total_controls_covered := 400` claim on a policy set that has 240 rules is exactly the kind of miscount a Big-4 audit will catch and use to question the entire dataset. Getting these right is table stakes for audit-of-record positioning.

Rego rule head counts (`contains msg if`, `contains violation if`) verified via grep across each policy set. None of the modified fields are read by external consumers, so no downstream code regresses.

## Test plan
- [x] `opa check` passes on all modified files
- [x] `opa check .` passes on the whole tree
- [x] `opa eval` on ubuntu_24_04 master confirms `total_controls_covered: 240`
- [ ] CI green
- [ ] Reviewer verifies the counts by running `grep -cE 'contains msg if|contains violation if' benchmarks/cis/<distro>/*.rego`

🤖 Generated with [Claude Code](https://claude.com/claude-code)