### PR TITLE
test(phase1): contract smoke tests for consumer endpoints (+ collapse-bug findings)

### DIFF
--- a/benchmarks/cis/amazon_linux_2023/tests/test_cis_amazon_linux_2023_smoke.rego
+++ b/benchmarks/cis/amazon_linux_2023/tests/test_cis_amazon_linux_2023_smoke.rego
@@ -1,0 +1,16 @@
+package cis_amazon_linux_2023_test
+
+import rego.v1
+
+import data.cis_amazon_linux_2023
+
+# Phase 1 contract smoke test.
+# Proves the live orchestrator endpoint returns a well-formed report object on
+# empty input, never the `undefined -> {}` collapse.
+# Entrypoint: data.cis_amazon_linux_2023.executive_summary
+# (defined in cis_al20239_complete.rego, the _complete orchestrator).
+test_report_wellformed_on_empty_input if {
+	report := cis_amazon_linux_2023.executive_summary with input as {}
+	is_object(report)
+	count(report) > 0
+}

--- a/benchmarks/cis/debian_11/tests/test_cis_debian_11_smoke.rego
+++ b/benchmarks/cis/debian_11/tests/test_cis_debian_11_smoke.rego
@@ -1,0 +1,18 @@
+package cis_debian_11_test
+
+import rego.v1
+
+import data.cis_debian_11
+
+# Phase 1 contract smoke test.
+# Proves a well-formed report object is returned on empty input, never the
+# `undefined -> {}` collapse.
+# Entrypoint: data.cis_debian_11.compliance_summary
+# (The primary top-level report data.cis_debian_11.compliance_assessment is
+#  undefined on empty input — it dereferences input.system_info and requires
+#  real input by design; see broken-endpoint notes.)
+test_report_wellformed_on_empty_input if {
+	report := cis_debian_11.compliance_summary with input as {}
+	is_object(report)
+	count(report) > 0
+}

--- a/benchmarks/cis/rhel_10/tests/test_cis_rhel10_smoke.rego
+++ b/benchmarks/cis/rhel_10/tests/test_cis_rhel10_smoke.rego
@@ -1,0 +1,15 @@
+package cis.rhel_10_test
+
+import rego.v1
+
+import data.cis.rhel_10
+
+# Phase 1 contract smoke test.
+# Proves the live orchestrator endpoint returns a well-formed report object on
+# empty input, never the `undefined -> {}` collapse.
+# Entrypoint: data.cis.rhel_10.compliance_summary
+test_report_wellformed_on_empty_input if {
+	report := rhel_10.compliance_summary with input as {}
+	is_object(report)
+	count(report) > 0
+}

--- a/benchmarks/cis/rhel_8/tests/test_cis_rhel8_smoke.rego
+++ b/benchmarks/cis/rhel_8/tests/test_cis_rhel8_smoke.rego
@@ -1,0 +1,15 @@
+package cis_rhel8_test
+
+import rego.v1
+
+import data.cis_rhel8
+
+# Phase 1 contract smoke test.
+# Proves the live orchestrator endpoint returns a well-formed report object on
+# empty input, never the `undefined -> {}` collapse.
+# Entrypoint: data.cis_rhel8.compliance_assessment
+test_report_wellformed_on_empty_input if {
+	report := cis_rhel8.compliance_assessment with input as {}
+	is_object(report)
+	count(report) > 0
+}

--- a/benchmarks/cis/rhel_9/tests/test_cis_rhel9_smoke.rego
+++ b/benchmarks/cis/rhel_9/tests/test_cis_rhel9_smoke.rego
@@ -1,0 +1,17 @@
+package cis_rhel9_test
+
+import rego.v1
+
+import data.cis_rhel9
+
+# Phase 1 contract smoke test.
+# Proves the live orchestrator endpoint returns a well-formed report object on
+# empty input, never the `undefined -> {}` collapse.
+# Entrypoint: data.cis_rhel9.executive_summary
+# (data.cis_rhel9.main.compliance_report is the fail-silent collapse endpoint —
+#  it returns {} on empty input, so it is intentionally NOT tested here.)
+test_report_wellformed_on_empty_input if {
+	report := cis_rhel9.executive_summary with input as {}
+	is_object(report)
+	count(report) > 0
+}

--- a/benchmarks/cis/rocky_linux_8/tests/test_cis_rocky_8_smoke.rego
+++ b/benchmarks/cis/rocky_linux_8/tests/test_cis_rocky_8_smoke.rego
@@ -1,0 +1,15 @@
+package cis_rocky_linux_8_test
+
+import rego.v1
+
+import data.cis_rocky_linux_8
+
+# Phase 1 contract smoke test.
+# Proves the live orchestrator endpoint returns a well-formed report object on
+# empty input, never the `undefined -> {}` collapse.
+# Entrypoint: data.cis_rocky_linux_8.compliance_assessment
+test_report_wellformed_on_empty_input if {
+	report := cis_rocky_linux_8.compliance_assessment with input as {}
+	is_object(report)
+	count(report) > 0
+}

--- a/benchmarks/cis/rocky_linux_9/tests/test_cis_rocky_9_smoke.rego
+++ b/benchmarks/cis/rocky_linux_9/tests/test_cis_rocky_9_smoke.rego
@@ -1,0 +1,15 @@
+package cis_rocky_linux_9_test
+
+import rego.v1
+
+import data.cis_rocky_linux_9
+
+# Phase 1 contract smoke test.
+# Proves the live orchestrator endpoint returns a well-formed report object on
+# empty input, never the `undefined -> {}` collapse.
+# Entrypoint: data.cis_rocky_linux_9.compliance_assessment
+test_report_wellformed_on_empty_input if {
+	report := cis_rocky_linux_9.compliance_assessment with input as {}
+	is_object(report)
+	count(report) > 0
+}

--- a/benchmarks/cis/ubuntu_20_04/tests/test_cis_ubuntu_2004_smoke.rego
+++ b/benchmarks/cis/ubuntu_20_04/tests/test_cis_ubuntu_2004_smoke.rego
@@ -1,0 +1,18 @@
+package cis_ubuntu_20_04_test
+
+import rego.v1
+
+import data.cis_ubuntu_20_04
+
+# Phase 1 contract smoke test.
+# Proves a well-formed report object is returned on empty input, never the
+# `undefined -> {}` collapse.
+# Entrypoint: data.cis_ubuntu_20_04.compliance_summary
+# (The primary top-level report data.cis_ubuntu_20_04.compliance_assessment is
+#  undefined on empty input — it dereferences input.system_info and requires
+#  real input by design; see broken-endpoint notes.)
+test_report_wellformed_on_empty_input if {
+	report := cis_ubuntu_20_04.compliance_summary with input as {}
+	is_object(report)
+	count(report) > 0
+}

--- a/benchmarks/cis/ubuntu_22_04/tests/test_cis_ubuntu_2204_smoke.rego
+++ b/benchmarks/cis/ubuntu_22_04/tests/test_cis_ubuntu_2204_smoke.rego
@@ -1,0 +1,18 @@
+package cis_ubuntu_22_04_test
+
+import rego.v1
+
+import data.cis_ubuntu_22_04
+
+# Phase 1 contract smoke test.
+# Proves a well-formed report object is returned on empty input, never the
+# `undefined -> {}` collapse.
+# Entrypoint: data.cis_ubuntu_22_04.compliance_summary
+# (The primary top-level report data.cis_ubuntu_22_04.compliance_assessment is
+#  undefined on empty input — it dereferences input.system_info and requires
+#  real input by design; see broken-endpoint notes.)
+test_report_wellformed_on_empty_input if {
+	report := cis_ubuntu_22_04.compliance_summary with input as {}
+	is_object(report)
+	count(report) > 0
+}

--- a/benchmarks/cis/ubuntu_24_04/tests/test_cis_ubuntu_2404_smoke.rego
+++ b/benchmarks/cis/ubuntu_24_04/tests/test_cis_ubuntu_2404_smoke.rego
@@ -1,0 +1,18 @@
+package cis_ubuntu_24_04_test
+
+import rego.v1
+
+import data.cis_ubuntu_24_04
+
+# Phase 1 contract smoke test.
+# Proves a well-formed report object is returned on empty input, never the
+# `undefined -> {}` collapse.
+# Entrypoint: data.cis_ubuntu_24_04.compliance_summary
+# (The primary top-level report data.cis_ubuntu_24_04.compliance_assessment is
+#  undefined on empty input — it dereferences input.system_info and requires
+#  real input by design; see broken-endpoint notes.)
+test_report_wellformed_on_empty_input if {
+	report := cis_ubuntu_24_04.compliance_summary with input as {}
+	is_object(report)
+	count(report) > 0
+}

--- a/benchmarks/cis/windows_server_2019_modular/tests/test_cis_windows_server_2019_smoke.rego
+++ b/benchmarks/cis/windows_server_2019_modular/tests/test_cis_windows_server_2019_smoke.rego
@@ -1,0 +1,14 @@
+package cis_windows_server_2019_test
+
+import rego.v1
+
+import data.cis_windows_server_2019
+
+# Phase 1 contract smoke test.
+# Proves the live orchestrator endpoint returns a well-formed compliance
+# report object on empty input, never the `undefined -> {}` collapse.
+test_report_wellformed_on_empty_input if {
+	report := cis_windows_server_2019.compliance_assessment with input as {}
+	is_object(report)
+	count(report) > 0
+}

--- a/benchmarks/cis/windows_server_2022_modular/tests/test_cis_windows_server_2022_smoke.rego
+++ b/benchmarks/cis/windows_server_2022_modular/tests/test_cis_windows_server_2022_smoke.rego
@@ -1,0 +1,14 @@
+package cis_windows_server_2022_test
+
+import rego.v1
+
+import data.cis_windows_server_2022
+
+# Phase 1 contract smoke test.
+# Proves the live orchestrator endpoint returns a well-formed compliance
+# report object on empty input, never the `undefined -> {}` collapse.
+test_report_wellformed_on_empty_input if {
+	report := cis_windows_server_2022.compliance_assessment with input as {}
+	is_object(report)
+	count(report) > 0
+}

--- a/benchmarks/stig/kubernetes/tests/test_stig_kubernetes_smoke.rego
+++ b/benchmarks/stig/kubernetes/tests/test_stig_kubernetes_smoke.rego
@@ -1,0 +1,14 @@
+package stig_kubernetes.main_test
+
+import rego.v1
+import data.stig_kubernetes.main
+
+# Phase 1 contract smoke test: the live orchestrator endpoint
+# (data.stig_kubernetes.main.compliance_report) must return a well-formed
+# object on empty input, never collapse to undefined.
+test_report_wellformed_on_empty_input if {
+	report := main.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/benchmarks/stig/openshift_4/tests/test_stig_openshift_4_smoke.rego
+++ b/benchmarks/stig/openshift_4/tests/test_stig_openshift_4_smoke.rego
@@ -1,0 +1,14 @@
+package stig_openshift_4.main_test
+
+import rego.v1
+import data.stig_openshift_4.main
+
+# Phase 1 contract smoke test: the live orchestrator endpoint
+# (data.stig_openshift_4.main.compliance_report) must return a well-formed
+# object on empty input, never collapse to undefined.
+test_report_wellformed_on_empty_input if {
+	report := main.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/benchmarks/stig/rhel_8/tests/test_stig_rhel_8_smoke.rego
+++ b/benchmarks/stig/rhel_8/tests/test_stig_rhel_8_smoke.rego
@@ -1,0 +1,12 @@
+package stig.rhel_8_test
+
+import rego.v1
+import data.stig.rhel_8
+
+# Phase 1 contract smoke test: the primary aggregate report (stig_assessment)
+# must return a well-formed object on empty input, never collapse to undefined.
+todo_test_report_wellformed_on_empty_input if {
+	report := rhel_8.stig_assessment with input as {}
+	is_object(report)
+	count(report) > 0
+}

--- a/benchmarks/stig/rhel_9/tests/test_stig_rhel_9_smoke.rego
+++ b/benchmarks/stig/rhel_9/tests/test_stig_rhel_9_smoke.rego
@@ -1,0 +1,12 @@
+package stig.rhel_9_test
+
+import rego.v1
+import data.stig.rhel_9
+
+# Phase 1 contract smoke test: the primary aggregate report (stig_assessment)
+# must return a well-formed object on empty input, never collapse to undefined.
+todo_test_report_wellformed_on_empty_input if {
+	report := rhel_9.stig_assessment with input as {}
+	is_object(report)
+	count(report) > 0
+}

--- a/benchmarks/stig/ubuntu_20_04/tests/test_stig_ubuntu_20_04_smoke.rego
+++ b/benchmarks/stig/ubuntu_20_04/tests/test_stig_ubuntu_20_04_smoke.rego
@@ -1,0 +1,12 @@
+package stig.ubuntu_20_04_test
+
+import rego.v1
+import data.stig.ubuntu_20_04
+
+# Phase 1 contract smoke test: the primary aggregate report (stig_assessment)
+# must return a well-formed object on empty input, never collapse to undefined.
+todo_test_report_wellformed_on_empty_input if {
+	report := ubuntu_20_04.stig_assessment with input as {}
+	is_object(report)
+	count(report) > 0
+}

--- a/benchmarks/stig/windows_10/tests/test_stig_windows_10_smoke.rego
+++ b/benchmarks/stig/windows_10/tests/test_stig_windows_10_smoke.rego
@@ -1,0 +1,12 @@
+package stig.windows_10_test
+
+import rego.v1
+import data.stig.windows_10
+
+# Phase 1 contract smoke test: the primary aggregate report (stig_assessment)
+# must return a well-formed object on empty input, never collapse to undefined.
+todo_test_report_wellformed_on_empty_input if {
+	report := windows_10.stig_assessment with input as {}
+	is_object(report)
+	count(report) > 0
+}

--- a/benchmarks/stig/windows_11/tests/test_stig_windows_11_smoke.rego
+++ b/benchmarks/stig/windows_11/tests/test_stig_windows_11_smoke.rego
@@ -1,0 +1,12 @@
+package stig.windows_11_test
+
+import rego.v1
+import data.stig.windows_11
+
+# Phase 1 contract smoke test: the primary aggregate report (stig_assessment)
+# must return a well-formed object on empty input, never collapse to undefined.
+todo_test_report_wellformed_on_empty_input if {
+	report := windows_11.stig_assessment with input as {}
+	is_object(report)
+	count(report) > 0
+}

--- a/benchmarks/stig/windows_server_2016/tests/test_stig_windows_server_2016_smoke.rego
+++ b/benchmarks/stig/windows_server_2016/tests/test_stig_windows_server_2016_smoke.rego
@@ -1,0 +1,12 @@
+package stig.windows_server_2016_test
+
+import rego.v1
+import data.stig.windows_server_2016
+
+# Phase 1 contract smoke test: the primary aggregate report (stig_assessment)
+# must return a well-formed object on empty input, never collapse to undefined.
+todo_test_report_wellformed_on_empty_input if {
+	report := windows_server_2016.stig_assessment with input as {}
+	is_object(report)
+	count(report) > 0
+}

--- a/benchmarks/stig/windows_server_2019/tests/test_stig_windows_server_2019_smoke.rego
+++ b/benchmarks/stig/windows_server_2019/tests/test_stig_windows_server_2019_smoke.rego
@@ -1,0 +1,12 @@
+package stig.windows_server_2019_test
+
+import rego.v1
+import data.stig.windows_server_2019
+
+# Phase 1 contract smoke test: the primary aggregate report (stig_assessment)
+# must return a well-formed object on empty input, never collapse to undefined.
+todo_test_report_wellformed_on_empty_input if {
+	report := windows_server_2019.stig_assessment with input as {}
+	is_object(report)
+	count(report) > 0
+}

--- a/benchmarks/stig/windows_server_2022/tests/test_stig_windows_server_2022_smoke.rego
+++ b/benchmarks/stig/windows_server_2022/tests/test_stig_windows_server_2022_smoke.rego
@@ -1,0 +1,12 @@
+package stig.windows_server_2022_test
+
+import rego.v1
+import data.stig.windows_server_2022
+
+# Phase 1 contract smoke test: the primary aggregate report (stig_assessment)
+# must return a well-formed object on empty input, never collapse to undefined.
+todo_test_report_wellformed_on_empty_input if {
+	report := windows_server_2022.stig_assessment with input as {}
+	is_object(report)
+	count(report) > 0
+}

--- a/docs/testing/phase1-findings.md
+++ b/docs/testing/phase1-findings.md
@@ -1,0 +1,79 @@
+# Phase 1 contract smoke tests — findings
+
+**Date:** 2026-07-02
+**Branch/PR:** `test/phase1-contract-smoke-tests`
+
+## What Phase 1 did
+
+Added a **contract smoke test** for every consumer-facing orchestrator endpoint: evaluate the
+aggregate report rule with empty input and assert it returns a **well-formed object** (`is_object`,
+`count > 0`), never the Rego-v1 `undefined → {}` collapse (CLAUDE.md rule #5). 50 new tests.
+
+Result: **169 pass, 0 fail, 20 skipped.** The 20 skips are `todo_`-prefixed tests parked against
+**broken endpoints** — they encode the correct contract and flip green the moment the endpoint is
+fixed. Nothing is green-washed; nothing red breaks CI.
+
+## Headline finding
+
+The smoke tests uncovered a **systemic `undefined → {}` collapse across ~30 consumer endpoints** —
+the same bug class PRs #29–#35 fixed one at a time. Two mechanisms:
+
+- **Missing `default` on a rule referenced by the report object** (e.g. `compliant`, a score, a
+  wrapper boolean). Because the rule is `undefined` whenever the system is *non-compliant*, these
+  endpoints return `{}` in normal operation — exactly when the report matters most.
+- **Unguarded `input.*` inside the report object literal** (e.g. `"hostname": input.system_info.hostname`).
+  One missing fact makes the whole report `undefined`.
+
+## Broken endpoints
+
+### HIGH — returns `{}` whenever non-compliant (missing `default`)
+| Endpoint | File | Missing default |
+|---|---|---|
+| cis windows_11 | benchmarks/cis/windows_11/cis_windows_11.rego | `compliant` |
+| cis postgresql_13/14/15 | benchmarks/cis/postgresql/* | `compliant` |
+| cis mysql_8 | benchmarks/cis/mysql/cis_mysql_8.rego | `compliant` |
+| cis oracle_19c | benchmarks/cis/oracle/cis_oracle_19c.rego | `compliant` |
+| cis apache_2_4 | benchmarks/cis/apache/cis_apache_2_4.rego | `compliant` |
+| fisma | frameworks/federal/fisma/fisma_main.rego | `fisma_compliant` |
+| cmmc | frameworks/federal/cmmc/cmmc_main.rego | sub-module reports |
+| pci_dss | frameworks/financial/pci_dss/pci_dss_main.rego | per-req scores |
+| sox | frameworks/financial/sox/sox_main.rego | `sox_compliance_score` |
+| iso27001 | frameworks/management/iso27001/iso27001_policy.rego | `allow` |
+| gdpr | frameworks/privacy/gdpr/gdpr_main.rego | module `*_compliant` wrappers |
+| hipaa | frameworks/privacy/hipaa/hipaa_main.rego | module `*_compliant` wrappers |
+| eu_ai_act | governance/eu_ai_act/eu_ai_act_main.rego | `risk_tier` |
+| oidc | governance/oidc/* | `summary` defaults to `{}` |
+
+### MEDIUM — returns `{}` on incomplete facts (unguarded `input.*` in report literal)
+STIG `stig_assessment` (8): rhel_8, rhel_9, windows_10, windows_11, windows_server_2016/2019/2022,
+ubuntu_20_04 — all embed `input.system_info.hostname` in metadata.
+OT/gov: nerc_cip cip015 (`input.insm.systems`), ami device (`total_devices`), iec_62443
+(`input.target_sl`), ai_governance (`input.action`), mcp (`input.tool`), finops (`total_resources`),
+digital_sovereignty (sub-domain `input.*`).
+
+### MISSING — no aggregate report endpoint at all
+- **soc2** (`frameworks/management/soc2/soc2_main.rego`) — no `compliance_report` rule.
+- **cis_m365** (`benchmarks/cis/saas/m365/`) — only per-section reports; no orchestrator.
+
+### STRUCTURAL — shared `package cis` collision
+`windows_10, windows_server_2016, docker, kubernetes, aws, azure, gcp` all declare `package cis`
+with their own `compliance_summary`. Querying `cis.compliance_summary` tree-wide raises
+`eval_conflict_error`. Latent today (nothing queries it), but blocks smoke tests and would break a
+combined query. Fix: give each its own package (`cis.windows_10`, `cis.docker`, …).
+
+### CONTRACT DRIFT — documented endpoint dead, working alternative exists
+- **cis_rhel9** — the compliance repo CLAUDE.md documents `POST /v1/data/cis_rhel9/compliance_assessment`,
+  but that rule and `cis_rhel9.main.compliance_report` both return `{}`. `executive_summary` works and
+  is what the live playbooks actually query. Reconcile docs ↔ policy (ties into the RHEL 9 consolidation).
+- **cis ubuntu 20.04/22.04/24.04, debian_11** — `compliance_assessment` undefined on empty input;
+  `compliance_summary` works and was tested instead.
+
+## Recommended follow-up (Phase 1.5)
+
+Fix the collapse bugs, which flips the 20 `todo_` tests green:
+1. **HIGH batch** — add `default <rule> := false/0` to each rule the report references. Mechanical, low-risk.
+2. **MEDIUM batch** — wrap in-literal input refs with `object.get(input, [...], "unknown")`.
+3. **soc2 / cis_m365** — add an aggregate `compliance_report` orchestrator.
+4. **`package cis` split** — repackage the 7 colliding CIS frameworks.
+
+Then Phase 4: wire a CI gate that fails if any P0 endpoint evaluates to `{}` on empty input.

--- a/frameworks/compliance/ncsc_caf/tests/test_ncsc_caf_smoke.rego
+++ b/frameworks/compliance/ncsc_caf/tests/test_ncsc_caf_smoke.rego
@@ -1,0 +1,14 @@
+# Phase 1 contract smoke test — proves the .main orchestrator's compliance_report
+# returns a well-formed object on empty input (never the undefined -> {} collapse).
+package ncsc_caf.main_test
+
+import rego.v1
+
+import data.ncsc_caf.main
+
+test_report_wellformed_on_empty_input if {
+	report := main.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/frameworks/critical_infrastructure/ami/device_compliance/tests/test_ami_device_smoke.rego
+++ b/frameworks/critical_infrastructure/ami/device_compliance/tests/test_ami_device_smoke.rego
@@ -1,0 +1,15 @@
+# Phase 1 contract smoke test — AMI device compliance aggregate report.
+# Contract: data.ami.device.compliance.compliance_report must return a
+# well-formed, non-empty object on empty input (never undefined -> {}).
+package ami.device.compliance_test
+
+import rego.v1
+
+import data.ami.device.compliance
+
+todo_test_report_wellformed_on_empty_input if {
+	result := compliance.compliance_report with input as {}
+	is_object(result)
+	count(result) > 0
+	is_boolean(result.compliant)
+}

--- a/frameworks/critical_infrastructure/ami/headend/tests/test_ami_headend_smoke.rego
+++ b/frameworks/critical_infrastructure/ami/headend/tests/test_ami_headend_smoke.rego
@@ -1,0 +1,15 @@
+# Phase 1 contract smoke test — AMI headend security aggregate report.
+# Contract: data.ami.headend.security.compliance_report must return a
+# well-formed, non-empty object on empty input (never undefined -> {}).
+package ami.headend.security_test
+
+import rego.v1
+
+import data.ami.headend.security
+
+test_report_wellformed_on_empty_input if {
+	result := security.compliance_report with input as {}
+	is_object(result)
+	count(result) > 0
+	is_boolean(result.compliant)
+}

--- a/frameworks/critical_infrastructure/ami/nist_ir_7628/tests/test_ami_nist_ir7628_complete_smoke.rego
+++ b/frameworks/critical_infrastructure/ami/nist_ir_7628/tests/test_ami_nist_ir7628_complete_smoke.rego
@@ -1,0 +1,14 @@
+# Phase 1 contract smoke test — AMI NIST IR 7628 complete assessment.
+# Contract: data.ami.nist_ir7628.complete.compliance_assessment must return a
+# well-formed, non-empty object on empty input (never undefined -> {}).
+package ami.nist_ir7628.complete_test
+
+import rego.v1
+
+import data.ami.nist_ir7628.complete
+
+test_report_wellformed_on_empty_input if {
+	result := complete.compliance_assessment with input as {}
+	is_object(result)
+	count(result) > 0
+}

--- a/frameworks/critical_infrastructure/iec_62443/tests/test_iec_62443_smoke.rego
+++ b/frameworks/critical_infrastructure/iec_62443/tests/test_iec_62443_smoke.rego
@@ -1,0 +1,15 @@
+# Phase 1 contract smoke test — IEC 62443 aggregate compliance report.
+# Contract: data.iec_62443_main.iec_62443_compliance_report must return a
+# well-formed, non-empty object on empty input (never undefined -> {}).
+package iec_62443_main_test
+
+import rego.v1
+
+import data.iec_62443_main
+
+todo_test_report_wellformed_on_empty_input if {
+	result := iec_62443_main.iec_62443_compliance_report with input as {}
+	is_object(result)
+	count(result) > 0
+	is_boolean(result.compliant)
+}

--- a/frameworks/critical_infrastructure/nerc_cip/tests/test_cip015_smoke.rego
+++ b/frameworks/critical_infrastructure/nerc_cip/tests/test_cip015_smoke.rego
@@ -1,0 +1,15 @@
+# Phase 1 contract smoke test — NERC CIP-015 INSM aggregate report.
+# Contract: data.nerc_cip_cip015.cip_015_compliance_report must return a
+# well-formed, non-empty object on empty input (never undefined -> {}).
+package nerc_cip_cip015_test
+
+import rego.v1
+
+import data.nerc_cip_cip015
+
+todo_test_report_wellformed_on_empty_input if {
+	result := nerc_cip_cip015.cip_015_compliance_report with input as {}
+	is_object(result)
+	count(result) > 0
+	is_boolean(result.compliant)
+}

--- a/frameworks/critical_infrastructure/nerc_cip/tests/test_nerc_cip_main_smoke.rego
+++ b/frameworks/critical_infrastructure/nerc_cip/tests/test_nerc_cip_main_smoke.rego
@@ -1,0 +1,16 @@
+# Phase 1 contract smoke test — NERC CIP aggregate compliance report.
+# Contract: data.nerc_cip_main.report must return a well-formed, non-empty
+# object on empty input (never the undefined -> {} collapse that consumers
+# would receive as a silently-empty report).
+package nerc_cip_main_test
+
+import rego.v1
+
+import data.nerc_cip_main
+
+test_report_wellformed_on_empty_input if {
+	result := nerc_cip_main.report with input as {}
+	is_object(result)
+	count(result) > 0
+	is_boolean(result.overall_compliant)
+}

--- a/frameworks/critical_infrastructure/nist_800_82/tests/test_nist_800_82_smoke.rego
+++ b/frameworks/critical_infrastructure/nist_800_82/tests/test_nist_800_82_smoke.rego
@@ -1,0 +1,13 @@
+package nist_800_82.main_test
+
+import rego.v1
+
+# Phase 1 contract smoke test.
+# Proves data.nist_800_82.main.compliance_report returns a well-formed object
+# on empty input — never the Rego v1 "undefined -> {}" collapse.
+test_report_wellformed_on_empty_input if {
+	report := data.nist_800_82.main.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/frameworks/federal/cmmc/tests/test_cmmc_smoke.rego
+++ b/frameworks/federal/cmmc/tests/test_cmmc_smoke.rego
@@ -1,0 +1,23 @@
+package cmmc_test
+
+import rego.v1
+
+# Phase 1 contract smoke test — BROKEN ENDPOINT (skipped, not green-washed).
+#
+# CMMC uses `package cmmc` (not cmmc.main). The platform-convention endpoint
+# data.cmmc.compliance_report does NOT exist; the actual aggregate rule is
+# data.cmmc.cmmc_compliance_report, and it collapses to undefined ("{}") on
+# empty input. Root cause: it embeds sub-module reports such as
+# `ac_report := data.cmmc.access_control.compliance_report`, which are undefined
+# on empty input, cascading the whole object literal to undefined (Rego v1
+# collapse). `data.cmmc.compliant` itself IS defined (false), so the fix is to
+# make the sub-module compliance_report rules default-safe.
+#
+# `todo_` prefix => OPA reports SKIPPED (documents the desired contract without
+# green-washing or breaking CI). Remove the prefix once the endpoint is fixed.
+todo_test_report_wellformed_on_empty_input if {
+	report := data.cmmc.cmmc_compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/frameworks/federal/fisma/tests/test_fisma_smoke.rego
+++ b/frameworks/federal/fisma/tests/test_fisma_smoke.rego
@@ -1,0 +1,23 @@
+package fisma.main_test
+
+import rego.v1
+
+# Phase 1 contract smoke test — BROKEN ENDPOINT (skipped, not green-washed).
+#
+# The platform-convention endpoint data.fisma.main.compliance_report does NOT
+# exist. The nearest aggregate report rule, data.fisma.main.fisma_assessment,
+# collapses to undefined ("{}") on empty input: it embeds `fisma_compliant == true`
+# but fisma_compliant has no `default`, so on empty input that field is undefined,
+# which turns the whole object literal undefined (Rego v1 collapse).
+#
+# This test is deliberately named with the `todo_` prefix so OPA reports it as
+# SKIPPED rather than PASS/FAIL — it documents the contract we WANT without
+# green-washing the bug or breaking CI. Remove the `todo_` prefix once the
+# endpoint is fixed (add `default fisma_compliant := false` and expose a
+# `compliance_report` rule).
+todo_test_report_wellformed_on_empty_input if {
+	report := data.fisma.main.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/frameworks/federal/nist/sp_800_171/tests/test_nist_800_171_smoke.rego
+++ b/frameworks/federal/nist/sp_800_171/tests/test_nist_800_171_smoke.rego
@@ -1,0 +1,13 @@
+package nist_800_171.main_test
+
+import rego.v1
+
+# Phase 1 contract smoke test.
+# Proves data.nist_800_171.main.compliance_report returns a well-formed object
+# on empty input — never the Rego v1 "undefined -> {}" collapse.
+test_report_wellformed_on_empty_input if {
+	report := data.nist_800_171.main.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/frameworks/financial/dora/tests/test_dora_smoke.rego
+++ b/frameworks/financial/dora/tests/test_dora_smoke.rego
@@ -1,0 +1,13 @@
+package dora.main_test
+
+import rego.v1
+
+# Phase 1 contract smoke test.
+# Proves data.dora.main.compliance_report returns a well-formed object
+# on empty input — never the Rego v1 "undefined -> {}" collapse.
+test_report_wellformed_on_empty_input if {
+	report := data.dora.main.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/frameworks/financial/ny_dfs/tests/test_ny_dfs_smoke.rego
+++ b/frameworks/financial/ny_dfs/tests/test_ny_dfs_smoke.rego
@@ -1,0 +1,13 @@
+package ny_dfs.main_test
+
+import rego.v1
+
+# Phase 1 contract smoke test.
+# Proves data.ny_dfs.main.compliance_report returns a well-formed object
+# on empty input — never the Rego v1 "undefined -> {}" collapse.
+test_report_wellformed_on_empty_input if {
+	report := data.ny_dfs.main.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/frameworks/financial/pci_dss/tests/test_pci_dss_smoke.rego
+++ b/frameworks/financial/pci_dss/tests/test_pci_dss_smoke.rego
@@ -1,0 +1,22 @@
+package pci_dss.main_test
+
+import rego.v1
+
+# Phase 1 contract smoke test — BROKEN ENDPOINT (skipped, not green-washed).
+#
+# The platform-convention endpoint data.pci_dss.main.compliance_report does NOT
+# exist. The nearest aggregate report rule, data.pci_dss.main.pci_dss_detailed_findings,
+# collapses to undefined ("{}") on empty input. Root cause: it embeds
+# pci_dss_compliance_score, which sums per-requirement scores such as
+# data.pci_dss.access_control.requirement_7.pci_requirement_7_score — these have
+# no `default`, so they are undefined on empty input and cascade the whole object
+# literal to undefined (Rego v1 collapse).
+#
+# `todo_` prefix => OPA reports SKIPPED (documents the desired contract without
+# green-washing or breaking CI). Remove the prefix once the endpoint is fixed
+# (default-safe requirement scores + a `compliance_report` rule).
+todo_test_report_wellformed_on_empty_input if {
+	report := data.pci_dss.main.pci_dss_detailed_findings with input as {}
+	is_object(report)
+	count(report) > 0
+}

--- a/frameworks/financial/sec_cyber/tests/test_sec_cyber_smoke.rego
+++ b/frameworks/financial/sec_cyber/tests/test_sec_cyber_smoke.rego
@@ -1,0 +1,13 @@
+package sec_cyber.main_test
+
+import rego.v1
+
+# Phase 1 contract smoke test.
+# Proves data.sec_cyber.main.compliance_report returns a well-formed object
+# on empty input — never the Rego v1 "undefined -> {}" collapse.
+test_report_wellformed_on_empty_input if {
+	report := data.sec_cyber.main.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/frameworks/financial/sox/tests/test_sox_smoke.rego
+++ b/frameworks/financial/sox/tests/test_sox_smoke.rego
@@ -1,0 +1,22 @@
+package sox.main_test
+
+import rego.v1
+
+# Phase 1 contract smoke test — BROKEN ENDPOINT (skipped, not green-washed).
+#
+# The platform-convention endpoint data.sox.main.compliance_report does NOT
+# exist. The nearest aggregate report rule, data.sox.main.overall_sox_assessment,
+# collapses to undefined ("{}") on empty input. Root cause: it embeds
+# sox_compliance_score, which has no `default` and is undefined on empty input,
+# cascading the whole object literal to undefined (Rego v1 collapse).
+# `data.sox.main.sox_compliant` itself IS defined (false).
+#
+# `todo_` prefix => OPA reports SKIPPED (documents the desired contract without
+# green-washing or breaking CI). Remove the prefix once the endpoint is fixed
+# (default-safe scores + a `compliance_report` rule).
+todo_test_report_wellformed_on_empty_input if {
+	report := data.sox.main.overall_sox_assessment with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliance_status)
+}

--- a/frameworks/financial/swift_csp/tests/test_swift_csp_smoke.rego
+++ b/frameworks/financial/swift_csp/tests/test_swift_csp_smoke.rego
@@ -1,0 +1,13 @@
+package swift_csp.main_test
+
+import rego.v1
+
+# Phase 1 contract smoke test.
+# Proves data.swift_csp.main.compliance_report returns a well-formed object
+# on empty input — never the Rego v1 "undefined -> {}" collapse.
+test_report_wellformed_on_empty_input if {
+	report := data.swift_csp.main.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/frameworks/management/csa_ccm/tests/test_csa_ccm_smoke.rego
+++ b/frameworks/management/csa_ccm/tests/test_csa_ccm_smoke.rego
@@ -1,0 +1,14 @@
+# Phase 1 contract smoke test — proves the .main orchestrator's compliance_report
+# returns a well-formed object on empty input (never the undefined -> {} collapse).
+package csa_ccm.main_test
+
+import rego.v1
+
+import data.csa_ccm.main
+
+test_report_wellformed_on_empty_input if {
+	report := main.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/frameworks/management/hitrust/tests/test_hitrust_smoke.rego
+++ b/frameworks/management/hitrust/tests/test_hitrust_smoke.rego
@@ -1,0 +1,14 @@
+# Phase 1 contract smoke test — proves the .main orchestrator's compliance_report
+# returns a well-formed object on empty input (never the undefined -> {} collapse).
+package hitrust.main_test
+
+import rego.v1
+
+import data.hitrust.main
+
+test_report_wellformed_on_empty_input if {
+	report := main.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/frameworks/management/tisax/tests/test_tisax_smoke.rego
+++ b/frameworks/management/tisax/tests/test_tisax_smoke.rego
@@ -1,0 +1,14 @@
+# Phase 1 contract smoke test — proves the .main orchestrator's compliance_report
+# returns a well-formed object on empty input (never the undefined -> {} collapse).
+package tisax.main_test
+
+import rego.v1
+
+import data.tisax.main
+
+test_report_wellformed_on_empty_input if {
+	report := main.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/frameworks/privacy/ccpa/tests/test_ccpa_smoke.rego
+++ b/frameworks/privacy/ccpa/tests/test_ccpa_smoke.rego
@@ -1,0 +1,14 @@
+# Phase 1 contract smoke test — proves the .main orchestrator's compliance_report
+# returns a well-formed object on empty input (never the undefined -> {} collapse).
+package ccpa.main_test
+
+import rego.v1
+
+import data.ccpa.main
+
+test_report_wellformed_on_empty_input if {
+	report := main.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/frameworks/privacy/iso27701/tests/test_iso27701_smoke.rego
+++ b/frameworks/privacy/iso27701/tests/test_iso27701_smoke.rego
@@ -1,0 +1,14 @@
+# Phase 1 contract smoke test — proves the .main orchestrator's compliance_report
+# returns a well-formed object on empty input (never the undefined -> {} collapse).
+package iso27701.main_test
+
+import rego.v1
+
+import data.iso27701.main
+
+test_report_wellformed_on_empty_input if {
+	report := main.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/frameworks/sovereignty/digital_sovereignty/tests/test_digital_sovereignty_smoke.rego
+++ b/frameworks/sovereignty/digital_sovereignty/tests/test_digital_sovereignty_smoke.rego
@@ -1,0 +1,15 @@
+# Phase 1 contract smoke test — Digital Sovereignty aggregate report.
+# Contract: data.digital_sovereignty.main.report must return a well-formed,
+# non-empty object on empty input (never undefined -> {}).
+package digital_sovereignty.main_test
+
+import rego.v1
+
+import data.digital_sovereignty.main
+
+todo_test_report_wellformed_on_empty_input if {
+	result := main.report with input as {}
+	is_object(result)
+	count(result) > 0
+	is_boolean(result.overall_compliant)
+}

--- a/governance/ai/tests/test_ai_governance_smoke.rego
+++ b/governance/ai/tests/test_ai_governance_smoke.rego
@@ -1,0 +1,15 @@
+# Phase 1 contract smoke test — AI governance aggregate decision response.
+# Contract: data.ai_governance.governance_response must return a well-formed,
+# non-empty decision object on empty input (never undefined -> {}).
+package ai_governance_test
+
+import rego.v1
+
+import data.ai_governance
+
+todo_test_report_wellformed_on_empty_input if {
+	result := ai_governance.governance_response with input as {}
+	is_object(result)
+	count(result) > 0
+	is_string(result.decision)
+}

--- a/governance/finops/tests/test_finops_smoke.rego
+++ b/governance/finops/tests/test_finops_smoke.rego
@@ -1,0 +1,15 @@
+# Phase 1 contract smoke test — FinOps tagging aggregate compliance report.
+# Contract: data.finops.tagging.compliance_report must return a well-formed,
+# non-empty object on empty input (never undefined -> {}).
+package finops.tagging_test
+
+import rego.v1
+
+import data.finops.tagging
+
+todo_test_report_wellformed_on_empty_input if {
+	result := tagging.compliance_report with input as {}
+	is_object(result)
+	count(result) > 0
+	is_boolean(result.compliant)
+}

--- a/governance/mcp/tests/test_mcp_governance_smoke.rego
+++ b/governance/mcp/tests/test_mcp_governance_smoke.rego
@@ -1,0 +1,16 @@
+# Phase 1 contract smoke test — MCP governance decision response.
+# This endpoint returns a decision object (not a compliance_report).
+# Contract: data.ai_governance.mcp.response must return a well-formed,
+# non-empty object with a decision field on empty input (never undefined -> {}).
+package ai_governance.mcp_test
+
+import rego.v1
+
+import data.ai_governance.mcp
+
+todo_test_report_wellformed_on_empty_input if {
+	result := mcp.response with input as {}
+	is_object(result)
+	count(result) > 0
+	is_string(result.decision)
+}

--- a/governance/oidc/tests/test_oidc_smoke.rego
+++ b/governance/oidc/tests/test_oidc_smoke.rego
@@ -1,0 +1,16 @@
+# Phase 1 contract smoke test — OIDC token validation summary.
+# This endpoint returns a decision/summary object (not a compliance_report).
+# Contract: data.governance.oidc.summary must return a well-formed, non-empty
+# object with its key field(s) on empty input (never the default -> {} collapse).
+package governance.oidc_test
+
+import rego.v1
+
+import data.governance.oidc
+
+todo_test_report_wellformed_on_empty_input if {
+	result := oidc.summary with input as {}
+	is_object(result)
+	count(result) > 0
+	is_boolean(result.authorized)
+}

--- a/threat_detection/crypto_mining/tests/test_crypto_miner_smoke.rego
+++ b/threat_detection/crypto_mining/tests/test_crypto_miner_smoke.rego
@@ -1,0 +1,15 @@
+# Phase 1 contract smoke test — Crypto Miner Detection aggregate assessment.
+# Contract: data.security.crypto_miner_detection.compliance_assessment must
+# return a well-formed, non-empty object on empty input (never undefined -> {}).
+package security.crypto_miner_detection_test
+
+import rego.v1
+
+import data.security.crypto_miner_detection
+
+test_report_wellformed_on_empty_input if {
+	result := crypto_miner_detection.compliance_assessment with input as {}
+	is_object(result)
+	count(result) > 0
+	is_boolean(result.compliant)
+}


### PR DESCRIPTION
## What

Phase 1 of the testing plan: a **contract smoke test** for every consumer-facing orchestrator endpoint. Each evaluates the aggregate report rule on empty input and asserts it returns a **well-formed object** — never the Rego-v1 `undefined → {}` collapse (CLAUDE.md rule #5).

**50 new test files. `opa test . --ignore .github` → 169 pass / 0 fail / 20 skipped.** Tests only — no policy files modified.

## The 20 skips are intentional

They are `todo_`-prefixed tests parked against endpoints that currently collapse to `{}`. They encode the correct contract, show as SKIPPED (CI stays green), and flip to active by removing the `todo_` prefix once each endpoint is fixed. Nothing is green-washed.

## Headline finding

These smoke tests uncovered a **systemic `undefined → {}` collapse across ~30 consumer endpoints** — the same bug class PRs #29–#35 fixed one at a time. Two mechanisms: (1) a report field references a rule with no `default` (so it returns `{}` whenever the system is *non-compliant* — normal operation), and (2) unguarded `input.*` inside the report object literal (one missing fact nukes the whole report).

Full catalog by severity in **`docs/testing/phase1-findings.md`** — includes HIGH (missing `default`: postgresql/mysql/oracle/apache, fisma, cmmc, pci_dss, sox, iso27001, gdpr, hipaa, eu_ai_act, …), MEDIUM (STIG `stig_assessment` ×8, ami device, iec_62443, mcp, finops, cip015, …), MISSING (soc2, cis_m365 have no aggregate report), STRUCTURAL (7 CIS frameworks share `package cis` → `eval_conflict_error`), and CONTRACT DRIFT (documented `cis_rhel9/compliance_assessment` endpoint is dead).

## Follow-up

Phase 1.5 fixes the collapse bugs (mostly mechanical `default` additions), flipping the 20 `todo_` tests green; then a CI gate that fails on any P0 endpoint returning `{}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)