### PR TITLE
fix(cis): stop db/web compliance_report collapsing to {} when non-compliant

### DIFF
--- a/benchmarks/cis/apache/cis_apache_2_4.rego
+++ b/benchmarks/cis/apache/cis_apache_2_4.rego
@@ -7,6 +7,8 @@ import rego.v1
 # Reference: https://www.cisecurity.org/benchmark/apache_http_server
 
 # Main compliance evaluation
+default compliant := false
+
 compliant if {
 	count(violations) == 0
 }

--- a/benchmarks/cis/apache/tests/test_cis_apache_2_4_smoke.rego
+++ b/benchmarks/cis/apache/tests/test_cis_apache_2_4_smoke.rego
@@ -1,0 +1,14 @@
+package cis.apache_2_4_test
+
+import rego.v1
+
+import data.cis.apache_2_4 as pkg
+
+# Phase 1 contract smoke test: the report must be a well-formed object with a
+# boolean 'compliant' field even on empty input — never the undefined -> {} collapse.
+test_report_wellformed_on_empty_input if {
+	report := pkg.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/benchmarks/cis/mysql/cis_mysql_8.rego
+++ b/benchmarks/cis/mysql/cis_mysql_8.rego
@@ -7,6 +7,8 @@ import rego.v1
 # Reference: https://www.cisecurity.org/benchmark/mysql
 
 # Main compliance evaluation
+default compliant := false
+
 compliant if {
 	count(violations) == 0
 }

--- a/benchmarks/cis/mysql/tests/test_cis_mysql_8_smoke.rego
+++ b/benchmarks/cis/mysql/tests/test_cis_mysql_8_smoke.rego
@@ -1,0 +1,14 @@
+package cis.mysql_8_test
+
+import rego.v1
+
+import data.cis.mysql_8 as pkg
+
+# Phase 1 contract smoke test: the report must be a well-formed object with a
+# boolean 'compliant' field even on empty input — never the undefined -> {} collapse.
+test_report_wellformed_on_empty_input if {
+	report := pkg.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/benchmarks/cis/oracle/cis_oracle_19c.rego
+++ b/benchmarks/cis/oracle/cis_oracle_19c.rego
@@ -7,6 +7,8 @@ import rego.v1
 # Reference: https://www.cisecurity.org/benchmark/oracle_database
 
 # Main compliance evaluation
+default compliant := false
+
 compliant if {
 	count(violations) == 0
 }

--- a/benchmarks/cis/oracle/tests/test_cis_oracle_19c_smoke.rego
+++ b/benchmarks/cis/oracle/tests/test_cis_oracle_19c_smoke.rego
@@ -1,0 +1,14 @@
+package cis.oracle_19c_test
+
+import rego.v1
+
+import data.cis.oracle_19c as pkg
+
+# Phase 1 contract smoke test: the report must be a well-formed object with a
+# boolean 'compliant' field even on empty input — never the undefined -> {} collapse.
+test_report_wellformed_on_empty_input if {
+	report := pkg.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/benchmarks/cis/postgresql/cis_postgresql_13.rego
+++ b/benchmarks/cis/postgresql/cis_postgresql_13.rego
@@ -7,6 +7,8 @@ import rego.v1
 # Reference: https://www.cisecurity.org/benchmark/postgresql
 
 # Main compliance evaluation
+default compliant := false
+
 compliant if {
 	count(violations) == 0
 }

--- a/benchmarks/cis/postgresql/cis_postgresql_14.rego
+++ b/benchmarks/cis/postgresql/cis_postgresql_14.rego
@@ -7,6 +7,8 @@ import rego.v1
 # Reference: https://www.cisecurity.org/benchmark/postgresql
 
 # Main compliance evaluation
+default compliant := false
+
 compliant if {
 	count(violations) == 0
 }

--- a/benchmarks/cis/postgresql/cis_postgresql_15.rego
+++ b/benchmarks/cis/postgresql/cis_postgresql_15.rego
@@ -7,6 +7,8 @@ import rego.v1
 # Reference: https://www.cisecurity.org/benchmark/postgresql
 
 # Main compliance evaluation
+default compliant := false
+
 compliant if {
 	count(violations) == 0
 }

--- a/benchmarks/cis/postgresql/tests/test_cis_postgresql_13_smoke.rego
+++ b/benchmarks/cis/postgresql/tests/test_cis_postgresql_13_smoke.rego
@@ -1,0 +1,14 @@
+package cis.postgresql_13_test
+
+import rego.v1
+
+import data.cis.postgresql_13 as pkg
+
+# Phase 1 contract smoke test: the report must be a well-formed object with a
+# boolean 'compliant' field even on empty input — never the undefined -> {} collapse.
+test_report_wellformed_on_empty_input if {
+	report := pkg.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/benchmarks/cis/postgresql/tests/test_cis_postgresql_14_smoke.rego
+++ b/benchmarks/cis/postgresql/tests/test_cis_postgresql_14_smoke.rego
@@ -1,0 +1,14 @@
+package cis.postgresql_14_test
+
+import rego.v1
+
+import data.cis.postgresql_14 as pkg
+
+# Phase 1 contract smoke test: the report must be a well-formed object with a
+# boolean 'compliant' field even on empty input — never the undefined -> {} collapse.
+test_report_wellformed_on_empty_input if {
+	report := pkg.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/benchmarks/cis/postgresql/tests/test_cis_postgresql_15_smoke.rego
+++ b/benchmarks/cis/postgresql/tests/test_cis_postgresql_15_smoke.rego
@@ -1,0 +1,14 @@
+package cis.postgresql_15_test
+
+import rego.v1
+
+import data.cis.postgresql_15 as pkg
+
+# Phase 1 contract smoke test: the report must be a well-formed object with a
+# boolean 'compliant' field even on empty input — never the undefined -> {} collapse.
+test_report_wellformed_on_empty_input if {
+	report := pkg.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}

--- a/benchmarks/cis/windows_11/cis_windows_11.rego
+++ b/benchmarks/cis/windows_11/cis_windows_11.rego
@@ -7,6 +7,8 @@ import rego.v1
 # Reference: https://www.cisecurity.org/benchmark/microsoft_windows_11
 
 # Main compliance evaluation
+default compliant := false
+
 compliant if {
 	count(violations) == 0
 }

--- a/benchmarks/cis/windows_11/tests/test_cis_windows_11_smoke.rego
+++ b/benchmarks/cis/windows_11/tests/test_cis_windows_11_smoke.rego
@@ -1,0 +1,14 @@
+package cis.windows_11_test
+
+import rego.v1
+
+import data.cis.windows_11 as pkg
+
+# Phase 1 contract smoke test: the report must be a well-formed object with a
+# boolean 'compliant' field even on empty input — never the undefined -> {} collapse.
+test_report_wellformed_on_empty_input if {
+	report := pkg.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+}


### PR DESCRIPTION
## What

Adds `default compliant := false` to 7 CIS database/web-server benchmarks and a contract smoke test for each. First of the Phase 1.5 collapse-bug fixes surfaced by PR #38.

## The bug

Each report embeds `"compliant": compliant`, but `compliant` was defined only as `compliant if { count(violations) == 0 }` with **no default**. Per CLAUDE.md rule #5, an undefined field collapses the whole object literal — so the endpoint returned `{}` whenever violations existed, i.e. exactly when the system is **non-compliant** and the report matters most.

Verified before/after: `cis.postgresql_13.compliance_report` on a non-compliant input returned `undefined`/`{}` before, returns `compliant: false` after.

## Fixed endpoints

`cis.postgresql_13`, `cis.postgresql_14`, `cis.postgresql_15`, `cis.mysql_8`, `cis.oracle_19c`, `cis.apache_2_4`, `cis.windows_11` — each +2 lines (`default compliant := false`) plus a new `tests/test_*_smoke.rego`.

`opa test . --ignore .github` → **146/146**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)