### PR TITLE
fix(network-devices): don't collapse cis_vyos/cis_pfsense report to null on missing input.system

### DIFF
--- a/benchmarks/cis/network_devices/pfsense/cis_pfsense.rego
+++ b/benchmarks/cis/network_devices/pfsense/cis_pfsense.rego
@@ -395,8 +395,13 @@ compliance_assessment := {
         "5_packages":         count(section_5_violations) == 0,
     },
     "device_info": {
-        "hostname": object.get(input.system, "hostname", "unknown"),
-        "domain":   object.get(input.system, "domain",   "unknown"),
+        # object.get(input, "system", {}) guards against a missing input.system:
+        # object.get(<undefined>, …) is itself undefined and would collapse the whole
+        # compliance_assessment object to null (OPA returns {}), masking a failed/empty
+        # fact collection as a silent result. Defaulting to {} keeps the report defined
+        # so an empty input scores low (loud) instead of returning null.
+        "hostname": object.get(object.get(input, "system", {}), "hostname", "unknown"),
+        "domain":   object.get(object.get(input, "system", {}), "domain",   "unknown"),
         "version":  object.get(input,        "version",  "unknown"),
         "platform": object.get(input,        "platform", "pfsense"),
     },

--- a/benchmarks/cis/network_devices/vyos/cis_vyos.rego
+++ b/benchmarks/cis/network_devices/vyos/cis_vyos.rego
@@ -371,9 +371,14 @@ compliance_assessment := {
         "5_system_hardening":  count(section_5_violations) == 0,
     },
     "device_info": {
-        "hostname": object.get(input.system, "host-name", "unknown"),
+        # object.get(input, "system", {}) guards against a missing input.system:
+        # object.get(<undefined>, …) is itself undefined and would collapse the whole
+        # compliance_assessment object to null (OPA returns {}), masking a failed/empty
+        # fact collection as a silent result. Defaulting to {} keeps the report defined
+        # so an empty input scores low (loud) instead of returning null.
+        "hostname": object.get(object.get(input, "system", {}), "host-name", "unknown"),
         "version":  object.get(input, "version", "unknown"),
         "platform": "vyos",
-        "timezone": object.get(input.system, "time-zone", "unknown"),
+        "timezone": object.get(object.get(input, "system", {}), "time-zone", "unknown"),
     },
 }


### PR DESCRIPTION
## Problem
`cis_vyos` and `cis_pfsense` build `device_info` with `object.get(input.system, …)`. When `input.system` is absent, `input.system` is *undefined* (not a missing key), so `object.get(<undefined>, …)` is undefined — which collapses the entire `compliance_assessment` object and OPA returns `null`. A failed/empty fact collection then masquerades as a silent result, and consumers store a misleading **0%** (this is exactly what happened to the VyOS/pfSense assessments post-CRC).

## Fix
Guard with `object.get(input, "system", {})` so the report stays defined. An empty input now evaluates to a real low score (loud) instead of `null`.

- `opa check` clean
- empty input `{}` now returns a real summary (50%) instead of `null` for both policies

Companion to the compliance-repo PR that switches the VyOS/pfSense assessments to `podman exec` collection with explicit fail-loud guards.