### PR TITLE
fix(hipaa): reconcile Security Rule technical safeguards to the data-activity modules

### DIFF
--- a/frameworks/privacy/hipaa/hipaa_access_control.rego
+++ b/frameworks/privacy/hipaa/hipaa_access_control.rego
@@ -49,6 +49,11 @@ violation_unique_user_id contains msg if {
     )
 }
 
+default control_a2i_compliant := false
+default control_a2ii_compliant := false
+default control_a2iii_compliant := false
+default control_a2iv_compliant := false
+
 control_a2i_compliant if {
     count(violation_unique_user_id) == 0
 }
@@ -220,9 +225,17 @@ violations contains msg if {
     some msg in violation_minimum_necessary
 }
 
+# Fail-closed: no ePHI systems in scope → cannot certify this safeguard
+violations contains msg if {
+    count(object.get(input, "phi_systems", [])) == 0
+    msg := "HIPAA 164.312(a): no ePHI systems in scope (input.phi_systems is empty) — cannot certify Access Control. Declare the ePHI systems to be evaluated."
+}
+
 # ---------------------------------------------------------------------------
 # Overall compliance
 # ---------------------------------------------------------------------------
+
+default compliant := false
 
 compliant if {
     count(violations) == 0

--- a/frameworks/privacy/hipaa/hipaa_audit_controls.rego
+++ b/frameworks/privacy/hipaa/hipaa_audit_controls.rego
@@ -152,9 +152,17 @@ violations contains msg if { some msg in violation_audit_integrity }
 violations contains msg if { some msg in violation_audit_review }
 violations contains msg if { some msg in violation_after_hours }
 
+# Fail-closed: no ePHI systems in scope → cannot certify this safeguard
+violations contains msg if {
+    count(object.get(input, "phi_systems", [])) == 0
+    msg := "HIPAA 164.312(b): no ePHI systems in scope (input.phi_systems is empty) — cannot certify Audit Controls. Declare the ePHI systems to be evaluated."
+}
+
 # ---------------------------------------------------------------------------
 # Compliance
 # ---------------------------------------------------------------------------
+
+default compliant := false
 
 compliant if {
     count(violations) == 0

--- a/frameworks/privacy/hipaa/hipaa_authentication.rego
+++ b/frameworks/privacy/hipaa/hipaa_authentication.rego
@@ -166,6 +166,8 @@ violations contains msg if { some msg in violation_service_accounts }
 # Compliance
 # ---------------------------------------------------------------------------
 
+default compliant := false
+
 compliant if {
     count(violations) == 0
 }

--- a/frameworks/privacy/hipaa/hipaa_integrity.rego
+++ b/frameworks/privacy/hipaa/hipaa_integrity.rego
@@ -137,9 +137,17 @@ violations contains msg if { some msg in violation_phi_authentication }
 violations contains msg if { some msg in violation_backup }
 violations contains msg if { some msg in violation_destruction }
 
+# Fail-closed: no ePHI systems in scope → cannot certify this safeguard
+violations contains msg if {
+    count(object.get(input, "phi_systems", [])) == 0
+    msg := "HIPAA 164.312(c): no ePHI systems in scope (input.phi_systems is empty) — cannot certify Integrity. Declare the ePHI systems to be evaluated."
+}
+
 # ---------------------------------------------------------------------------
 # Compliance
 # ---------------------------------------------------------------------------
+
+default compliant := false
 
 compliant if {
     count(violations) == 0

--- a/frameworks/privacy/hipaa/hipaa_security_rule.rego
+++ b/frameworks/privacy/hipaa/hipaa_security_rule.rego
@@ -2,6 +2,15 @@ package hipaa.security_rule
 
 import rego.v1
 
+# Technical safeguards (§164.312) are evaluated by the data-activity modules —
+# measured from input.phi_systems[] / audit_logs[] / users[], and Guardium-feedable —
+# not by attestation booleans. This module aggregates them for the Security Rule verdict.
+import data.hipaa.access_control as tech_access_control
+import data.hipaa.audit_controls as tech_audit_controls
+import data.hipaa.authentication as tech_authentication
+import data.hipaa.integrity as tech_integrity
+import data.hipaa.transmission_security as tech_transmission
+
 # Defaults so report/details never collapse to {} on empty input
 default security_management_process := false
 default assigned_security_responsibility := false
@@ -16,11 +25,6 @@ default facility_access_controls := false
 default workstation_use_controls := false
 default workstation_security := false
 default device_media_controls := false
-default technical_access_control := false
-default audit_controls := false
-default ephi_integrity := false
-default entity_authentication := false
-default transmission_security := false
 default breach_notification_procedures := false
 default minimum_necessary_controls := false
 default patient_rights_technical := false
@@ -153,51 +157,12 @@ device_media_controls if {
 
 # =============================================================================
 # TECHNICAL SAFEGUARDS (§164.312)
+# Delegated to the data-activity modules (measured, not attested):
+#   hipaa.access_control, hipaa.audit_controls, hipaa.integrity,
+#   hipaa.authentication, hipaa.transmission_security
+# Each evaluates input.phi_systems[]/audit_logs[]/users[] and is Guardium-feedable.
+# Aggregated in technical_safeguards_compliant below.
 # =============================================================================
-
-# §164.312(a)(1) - Access Control
-technical_access_control if {
-	input.hipaa.technical.access_control.unique_user_id.assigned == true
-	input.hipaa.technical.access_control.emergency_access.procedure_defined == true
-	input.hipaa.technical.access_control.automatic_logoff.implemented == true
-	input.hipaa.technical.access_control.automatic_logoff.timeout_minutes <= 15
-	input.hipaa.technical.access_control.encryption.ephi_at_rest == true
-}
-
-# §164.312(b) - Audit Controls
-audit_controls if {
-	input.hipaa.technical.audit_controls.hardware.logging_enabled == true
-	input.hipaa.technical.audit_controls.software.logging_enabled == true
-	input.hipaa.technical.audit_controls.ephi_access.logged == true
-	input.hipaa.technical.audit_controls.logs.reviewed_regularly == true
-	input.hipaa.technical.audit_controls.logs.retention_years >= 6
-	input.hipaa.technical.audit_controls.tamper_protection.implemented == true
-}
-
-# §164.312(c)(1) - Integrity
-ephi_integrity if {
-	input.hipaa.technical.integrity.ephi_not_improperly_altered == true
-	input.hipaa.technical.integrity.transmission_integrity.controls_implemented == true
-	input.hipaa.technical.integrity.hash_verification.implemented == true
-}
-
-# §164.312(d) - Person or Entity Authentication
-entity_authentication if {
-	input.hipaa.technical.authentication.mfa.implemented == true
-	input.hipaa.technical.authentication.identity_verification.implemented == true
-	input.hipaa.technical.authentication.password_policy.enforced == true
-	input.hipaa.technical.authentication.password_policy.min_length >= 8
-	input.hipaa.technical.authentication.password_policy.complexity_required == true
-	input.hipaa.technical.authentication.failed_login_lockout.implemented == true
-}
-
-# §164.312(e)(1) - Transmission Security
-transmission_security if {
-	input.hipaa.technical.transmission.encryption.ephi_in_transit == true
-	input.hipaa.technical.transmission.tls.minimum_version >= "1.2"
-	input.hipaa.technical.transmission.network_controls.implemented == true
-	input.hipaa.technical.transmission.integrity_controls.implemented == true
-}
 
 # =============================================================================
 # BREACH NOTIFICATION RULE (§164.400-§164.414)
@@ -252,11 +217,12 @@ physical_safeguards_compliant if {
 }
 
 technical_safeguards_compliant if {
-	technical_access_control
-	audit_controls
-	ephi_integrity
-	entity_authentication
-	transmission_security
+	count(object.get(input, "phi_systems", [])) > 0 # fail-closed: ePHI scope must be declared
+	tech_access_control.compliant
+	tech_audit_controls.compliant
+	tech_integrity.compliant
+	tech_authentication.compliant
+	tech_transmission.compliant
 }
 
 default compliant := false
@@ -294,11 +260,12 @@ report := {
 		},
 		"technical": {
 			"compliant": technical_safeguards_compliant,
-			"access_control": technical_access_control,
-			"audit_controls": audit_controls,
-			"integrity": ephi_integrity,
-			"authentication": entity_authentication,
-			"transmission_security": transmission_security,
+			"ephi_scope_declared": count(object.get(input, "phi_systems", [])) > 0,
+			"access_control": tech_access_control.compliance_report,
+			"audit_controls": tech_audit_controls.compliance_report,
+			"integrity": tech_integrity.compliance_report,
+			"authentication": tech_authentication.compliance_report,
+			"transmission_security": tech_transmission.compliance_report,
 		},
 	},
 	"breach_notification": breach_notification_procedures,

--- a/frameworks/privacy/hipaa/hipaa_transmission_security.rego
+++ b/frameworks/privacy/hipaa/hipaa_transmission_security.rego
@@ -171,9 +171,17 @@ violations contains msg if { some msg in violation_vpn }
 violations contains msg if { some msg in violation_transmission_integrity }
 violations contains msg if { some msg in violation_email }
 
+# Fail-closed: no ePHI systems in scope → cannot certify this safeguard
+violations contains msg if {
+    count(object.get(input, "phi_systems", [])) == 0
+    msg := "HIPAA 164.312(e): no ePHI systems in scope (input.phi_systems is empty) — cannot certify Transmission Security. Declare the ePHI systems to be evaluated."
+}
+
 # ---------------------------------------------------------------------------
 # Compliance
 # ---------------------------------------------------------------------------
+
+default compliant := false
 
 compliant if {
     count(violations) == 0

--- a/frameworks/privacy/hipaa/tests/test_hipaa_security_rule.rego
+++ b/frameworks/privacy/hipaa/tests/test_hipaa_security_rule.rego
@@ -1,0 +1,154 @@
+# Reconciliation tests — Security Rule technical safeguards (§164.312) now
+# delegate to the data-activity modules (measured, not attested), with a
+# fail-closed ePHI-scope gate. These tests pin the verdict semantics the
+# smoke test cannot (it only checks report well-formedness).
+package hipaa.security_rule_test
+
+import rego.v1
+
+import data.hipaa.security_rule as sr
+
+# ---------------------------------------------------------------------------
+# Fail-closed: no ePHI scope → technical safeguards NOT compliant.
+# This is the regression the delegation could have introduced (modules are
+# vacuously compliant on empty input); the gate + module guards prevent it.
+# ---------------------------------------------------------------------------
+
+test_technical_fails_closed_on_empty_input if {
+	not sr.technical_safeguards_compliant with input as {}
+}
+
+test_technical_fails_closed_when_phi_systems_empty if {
+	# Even if every module were compliant, no declared ePHI scope must fail.
+	not sr.technical_safeguards_compliant
+		with input as {"phi_systems": []}
+		with data.hipaa.access_control.compliant as true
+		with data.hipaa.audit_controls.compliant as true
+		with data.hipaa.integrity.compliant as true
+		with data.hipaa.authentication.compliant as true
+		with data.hipaa.transmission_security.compliant as true
+}
+
+# ---------------------------------------------------------------------------
+# Positive control: scope declared AND all modules compliant → compliant.
+# Proves the delegation can actually return true (guards against an
+# always-false regression that a fail-closed-only test would miss).
+# ---------------------------------------------------------------------------
+
+test_technical_compliant_when_scope_and_modules_pass if {
+	sr.technical_safeguards_compliant
+		with input as {"phi_systems": [{"name": "ehr-db"}]}
+		with data.hipaa.access_control.compliant as true
+		with data.hipaa.audit_controls.compliant as true
+		with data.hipaa.integrity.compliant as true
+		with data.hipaa.authentication.compliant as true
+		with data.hipaa.transmission_security.compliant as true
+}
+
+# ---------------------------------------------------------------------------
+# Any single technical module failing fails the aggregate.
+# ---------------------------------------------------------------------------
+
+test_technical_fails_when_one_module_fails if {
+	not sr.technical_safeguards_compliant
+		with input as {"phi_systems": [{"name": "ehr-db"}]}
+		with data.hipaa.access_control.compliant as true
+		with data.hipaa.audit_controls.compliant as false
+		with data.hipaa.integrity.compliant as true
+		with data.hipaa.authentication.compliant as true
+		with data.hipaa.transmission_security.compliant as true
+}
+
+# ---------------------------------------------------------------------------
+# Report stays well-formed and surfaces the richer module reports.
+# ---------------------------------------------------------------------------
+
+test_report_technical_uses_module_reports if {
+	report := sr.report with input as {"phi_systems": [{"name": "ehr-db"}]}
+	is_object(report.safeguards.technical.audit_controls) # module compliance_report, not a bare bool
+	report.safeguards.technical.ephi_scope_declared == true
+}
+
+test_report_wellformed_on_empty_input if {
+	report := sr.report with input as {}
+	is_object(report)
+	count(report) > 0
+	report.safeguards.technical.ephi_scope_declared == false
+}
+
+# ---------------------------------------------------------------------------
+# End-to-end: a realistic, UNMOCKED Guardium-shaped input actually satisfies
+# all five §164.312 data-activity modules. Proves the delegated path can return
+# true against real facts — not just that the aggregation ANDs booleans.
+# ---------------------------------------------------------------------------
+
+_compliant_technical_input := {
+	"phi_systems": [{
+		"name": "ehr-db",
+		"audit_logging_enabled": true,
+		"audited_events": [
+			"login_success", "login_failure", "logout", "phi_access", "phi_create",
+			"phi_modify", "phi_delete", "phi_export", "permission_change",
+			"account_creation", "account_deletion", "password_change",
+		],
+		"data_at_rest_encrypted": true,
+		"encryption_algorithm": "AES-256",
+		"integrity_checking_enabled": true,
+		"integrity_check_frequency_hours": 12,
+		"transmission_encrypted": true,
+		"protocols_in_use": ["TLSv1.3"],
+		"api_endpoint": "https://ehr.internal/api",
+		"request_signing_enabled": true,
+	}],
+	"audit_logs": [{"event": "phi_access", "user_id": "u1", "timestamp": "2026-07-31T00:00:00Z"}],
+	"audit_logging": {
+		"centralized": true, "includes_user_id": true, "includes_timestamp": true,
+		"includes_action_type": true, "includes_source_ip": true, "offsite_backup_enabled": true,
+		"retention_days": 2555, "tamper_evident": true,
+	},
+	"monitoring": {
+		"after_hours_access_alerts": true, "audit_review_frequency_days": 7,
+		"automated_alerting_enabled": true, "unauthorized_access_alerts": true,
+	},
+	"users": [{"username": "alice", "shared_account": false, "phi_access_disabled": false}],
+	"access_controls": {
+		"emergency_access_procedure_documented": true, "emergency_access_tested": true,
+		"emergency_accounts_reviewed_days": 30, "role_based_access_implemented": true,
+	},
+	"session": {"automatic_logoff_enabled": true, "inactivity_timeout_minutes": 10, "screen_lock_enabled": true},
+	"encryption": {"key_management_policy_documented": true, "key_rotation_days": 90},
+	"integrity": {
+		"change_management_process": true, "checksum_or_hash_enabled": true,
+		"digital_signatures_for_phi_export": true, "hash_algorithm": "SHA-256",
+		"media_reuse_without_sanitization": false, "secure_deletion_policy": true,
+		"write_protection_on_archived_phi": true,
+	},
+	"backup": {
+		"regular_backups_enabled": true, "backup_frequency_hours": 24,
+		"offsite_or_cloud_backup": true, "restore_tested": true, "restore_test_days": 90,
+	},
+	"mfa": {
+		"enabled_for_phi_access": true, "required_for_remote_access": true,
+		"required_for_privileged_accounts": true, "methods_allowed": ["totp", "fido2"],
+		"stronger_method_also_available": true,
+	},
+	"password_policy": {
+		"complexity_required": true, "history_count": 12, "lockout_enabled": true,
+		"lockout_threshold": 5, "max_age_days": 90, "minimum_length": 14,
+	},
+	"authentication": {"concurrent_sessions_unlimited": false, "re_authentication_for_sensitive_ops": true},
+	"privileged_accounts": [],
+	"network": {"message_authentication_enabled": true, "phi_network_segmented": true, "remote_phi_access_enabled": false},
+	"tls": {
+		"minimum_version": "1.3", "enabled_ciphers": ["TLS_AES_256_GCM_SHA384"],
+		"certificate_expiry_days": 200, "certificate_expiry_monitoring": true, "mutual_tls_for_phi_apis": true,
+	},
+	"vpn": {"required_for_remote_phi_access": true, "protocol": "IKEv2", "split_tunneling_enabled": false},
+	"email": {"phi_sent_via_email": false, "dlp_enabled": true, "encrypted_email_required": true},
+	"transmission": {},
+	"api": {},
+}
+
+test_technical_compliant_with_real_input if {
+	sr.technical_safeguards_compliant with input as _compliant_technical_input
+}


### PR DESCRIPTION
## Problem

The five HIPAA §164.312 technical safeguards were implemented **twice on incompatible input schemas**:

- **Attestation** version — inline booleans in `hipaa.security_rule` (`input.hipaa.technical.*`), wired into `hipaa.main` (`/v1/data/hipaa/main`).
- **Data-activity** version — standalone modules `hipaa.{access_control,audit_controls,integrity,authentication,transmission_security}` (`input.phi_systems[]`/`audit_logs[]`/`users[]`) that were **orphaned** — not aggregated anywhere.

So `/v1/data/hipaa/main` evaluated only the attested version, and the measurable, telemetry-driven modules were unreachable. (Surfaced while mapping IBM Guardium → AAC HIPAA coverage: the data-activity modules are the Guardium-feedable ones.)

## Fix

Delegate `technical_safeguards_compliant` to the five data-activity modules and delete the duplicated inline attestation logic. The Security Rule now evaluates §164.312 from **measured** facts while administrative/physical/breach/privacy stay attestation — aligning schema with control type.

### Correctness hardening surfaced during reconciliation
- **Fail-closed ePHI-scope gate.** `technical_safeguards_compliant` requires `count(input.phi_systems) > 0`, and each data-activity module now emits a violation when no ePHI systems are declared. Without this, the modules are *vacuously* compliant on empty input — wiring them in would have flipped the Security Rule from fail-closed to **fail-open**.
- **Missing defaults (library rule #5).** Added `default compliant := false` to all five modules and defaulted the `access_control` `control_a2*` helpers — they collapsed `compliance_report` to `{}` on empty input, a latent bug exposed once `security_rule` consumed those reports.

## Contract change (safe — verified zero consumers)
`report.safeguards.technical.*` changes type from **bool** → **object** (each is now the module's `compliance_report`), plus a new `ephi_scope_declared` bool. Verified no consumer in the `compliance` repo or `AAC_Customer_Portal` reads these — nothing POSTs to `data/hipaa` today.

## Tests
New `test_hipaa_security_rule.rego`:
- fail-closed on empty / no-scope input (the regression guard),
- positive control + single-module-fail (aggregation logic via `with` mocking),
- **end-to-end: a realistic unmocked input drives `technical_safeguards_compliant` → true** (proves the delegated path works against real facts).

`opa test .` → **221/221**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)