### PR TITLE
feat(enforcement): AAP job policy set — full Policy as Code parity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,9 @@ enforcement/                   Policy-as-Code gatekeepers (Sentinel-style)
 ├── terraform/                 Block bad Terraform plans
 ├── dockerfile/                Block bad Dockerfiles
 ├── kubernetes/                Block bad K8s manifests
+├── aap/                       AAP job gating — Policy as Code decision set
+│                              (maintenance windows, owner scope, labels,
+│                              extra_vars, naming, source control)
 └── git/                       Git change approval policy (used for repo
                                protection — see Approved-By convention)
 
@@ -60,7 +63,8 @@ threat_detection/              Behavioral threat patterns
 └── crypto_mining/             Crypto-miner indicators
 ```
 
-Headline count: **476 .rego files** across the above directories.
+Headline count: **510 policy files** (587 including tests) across the above directories.
+Count it, never quote it — `git ls-tree -r HEAD --name-only | grep '\.rego$' | grep -vcE '(^|/)(test_|.*_test\.rego$)'` — the number drifts with every merge.
 
 ## Skill: Rego v1 syntax (MANDATORY)
 

--- a/enforcement/aap/README.md
+++ b/enforcement/aap/README.md
@@ -1,0 +1,106 @@
+# AAP job policy — Policy as Code decision set
+
+Rego policies that gate **Ansible Automation Platform job execution**, written against AAP's
+published Policy as Code contract so they drop straight into the platform's own enforcement feature.
+
+Every rule returns exactly what AAP expects:
+
+```json
+{ "allowed": false, "violations": ["reason 1", "reason 2"] }
+```
+
+Package: `aac.aap.policy` — one rule per decision, so each can be associated independently with an
+organization, an inventory, or a job template.
+
+## Why this exists
+
+Red Hat ships the *enforcement mechanism* and a handful of example policies. It ships **no policy
+library**. This is the library — the same relationship AAC has to compliance frameworks, applied to
+automation governance.
+
+## The decision set
+
+| Query path | Blocks on |
+|---|---|
+| `/v1/data/aac/aap/policy/maintenance_window` | Time of day, day of week, dated change freezes |
+| `/v1/data/aac/aap/policy/maintenance_mode` | A named freeze on specific inventories or platform-wide |
+| `/v1/data/aac/aap/policy/owner_scope` | Which users/teams may target which inventories; inventory-to-org coherence |
+| `/v1/data/aac/aap/policy/superuser_restriction` | Superuser launches (use an attributable service account) |
+| `/v1/data/aac/aap/policy/credential_scope` | Global credentials; credential/inventory environment mismatch |
+| `/v1/data/aac/aap/policy/required_labels` | Required, forbidden, one-of, and `key:value`-format labels |
+| `/v1/data/aac/aap/policy/extra_vars_control` | Disallowed keys, secret-shaped keys, malformed values |
+| `/v1/data/aac/aap/policy/team_extra_vars` | Which teams may set which variables |
+| `/v1/data/aac/aap/policy/naming_standard` | Job-template naming convention, length, forbidden terms |
+| `/v1/data/aac/aap/policy/source_control` | Approved repo and branch; SSH URLs; detached-HEAD execution |
+| `/v1/data/aac/aap/policy/deny_all` | Everything — the incident switch |
+
+## Coverage against Red Hat's published examples
+
+All twelve are covered:
+
+| Red Hat example | Covered by |
+|---|---|
+| `maintenance_window` | `maintenance_window` |
+| `restrict_inv_use_to_org` | `owner_scope` |
+| `superuser_allowed_false` | `superuser_restriction` |
+| `global_credential_allowed_false` | `credential_scope` |
+| `mismatch_prefix_allowed_false` | `credential_scope` |
+| `extra_vars_allowlist` | `extra_vars_control` |
+| `extra_vars_validation` | `extra_vars_control` |
+| `team_based_extra_vars_restriction` | `team_extra_vars` |
+| `jt_naming_validation` | `naming_standard` |
+| `github_repo_validation` | `source_control` |
+| `project_scm_branch` | `source_control` |
+| `allowed_false` | `deny_all` |
+
+`maintenance_mode` and `required_labels` have no Red Hat equivalent.
+
+## Configuration
+
+Policies ship with safe defaults and are tuned entirely through data — no policy edits. Load
+`data/aap_policy_config.example.json` (or your own) alongside the policies:
+
+```bash
+opa run --server \
+  enforcement/aap/ \
+  enforcement/aap/data/aap_policy_config.example.json
+```
+
+Every block under `data.aac.aap.config.*` is optional; anything absent falls back to the defaults
+declared in the policy.
+
+### Defaults are permissive by design
+
+An unconfigured deployment allows automation. Bindings, allowlists, and freezes only take effect
+once you supply them — so loading these policies cannot accidentally halt a platform. The two
+exceptions are deliberate and safe: superuser launches are denied by default, and secret-shaped
+`extra_vars` keys (`password`, `token`, `api_key`, …) are rejected by default.
+
+## Evaluation time
+
+Time-based rules prefer `input.created` — the job's own timestamp — so a decision is reproducible
+when replayed during an audit. They fall back to wall-clock time only when `created` is absent.
+
+## Break glass
+
+`maintenance_window`, `maintenance_mode`, and `deny_all` each honour a bypass label
+(`break-glass`, `incident-response`). Bypassing is not silent: the label is part of the job record,
+so the override is itself evidence.
+
+## Testing
+
+```bash
+opa test enforcement/aap/ -v
+```
+
+47 tests cover allow and deny paths for every decision, plus a contract test asserting all eleven
+return `{allowed: bool, violations: []}`.
+
+## Input contract
+
+Consumes AAP's job-context input: `id`, `name`, `created`, `created_by` (`username`,
+`is_superuser`, `teams`), `credentials[]`, `execution_environment`, `extra_vars`, `inventory`,
+`job_template`, `labels[]`, `project`, and the rest of the documented payload. Fields absent from a
+given deployment degrade gracefully — a rule that cannot see its subject does not fire.
+
+`extra_vars` is accepted as either an object or a JSON string.

--- a/enforcement/aap/data/aap_policy_config.example.json
+++ b/enforcement/aap/data/aap_policy_config.example.json
@@ -1,0 +1,98 @@
+{
+  "aac": {
+    "aap": {
+      "config": {
+        "maintenance_window": {
+          "timezone": "America/Los_Angeles",
+          "allowed_days": ["Monday", "Tuesday", "Wednesday", "Thursday"],
+          "start_hour": 22,
+          "end_hour": 4,
+          "freeze_dates": ["2026-12-24", "2026-12-25", "2026-12-31"],
+          "break_glass_label": "break-glass"
+        },
+
+        "maintenance_mode": {
+          "active": false,
+          "inventories": ["prod-web", "prod-db"],
+          "reason": "quarterly database migration",
+          "break_glass_label": "break-glass"
+        },
+
+        "owner_scope": {
+          "bindings": {
+            "alice": ["prod-*", "stage-*"],
+            "bob": ["dev-*"]
+          },
+          "team_bindings": {
+            "platform-sre": ["*"],
+            "app-team": ["dev-*", "stage-*"]
+          },
+          "unbound_users_allowed": false,
+          "enforce_org_match": true
+        },
+
+        "superuser": {
+          "deny": true,
+          "exempt_users": []
+        },
+
+        "credential_scope": {
+          "deny_global_credentials": true,
+          "require_prefix_match": true,
+          "prefix_separator": "-",
+          "exempt_credentials": ["shared-galaxy-token"]
+        },
+
+        "labels": {
+          "required": [],
+          "forbidden": ["quarantined", "do-not-run"],
+          "required_for_inventories": {
+            "prod-*": ["change-approved", "peer-reviewed"]
+          },
+          "one_of": [["env-dev", "env-stage", "env-prod"]],
+          "pattern_requirements": {
+            "change-ticket": "^CHG[0-9]{7}$"
+          }
+        },
+
+        "extra_vars": {
+          "allowlist": ["app_version", "target_env", "deploy_batch"],
+          "denylist": ["ansible_become_password"],
+          "allow_unlisted": false,
+          "value_patterns": {
+            "target_env": "^(dev|stage|prod)$",
+            "app_version": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+          },
+          "forbid_secret_like_keys": true
+        },
+
+        "team_extra_vars": {
+          "teams": {
+            "app-team": ["app_version", "deploy_batch"],
+            "dba": ["db_schema_version"]
+          },
+          "unbound_teams_allowed": false
+        },
+
+        "naming": {
+          "pattern": "^(PROD|STAGE|DEV)-[A-Za-z0-9]+ - .+$",
+          "max_length": 80,
+          "forbid_terms": ["test", "tmp", "copy of", "delete me"]
+        },
+
+        "source_control": {
+          "allowed_repos": ["github.com/acme/*"],
+          "allowed_branches": ["main", "release/*"],
+          "forbid_detached_head": true,
+          "require_https": true
+        },
+
+        "deny_all": {
+          "active": false,
+          "reason": "automation is administratively halted",
+          "exempt_labels": ["incident-response"]
+        }
+      }
+    }
+  }
+}

--- a/enforcement/aap/extra_vars_control.rego
+++ b/enforcement/aap/extra_vars_control.rego
@@ -1,0 +1,158 @@
+# AAP job policy — what variables may enter automation.
+#
+# extra_vars are the widest injection surface on a job. This constrains which
+# keys may be set, what values they may take, and who may set them.
+#
+# Query paths:
+#   /v1/data/aac/aap/policy/extra_vars_control
+#   /v1/data/aac/aap/policy/team_extra_vars
+#
+# Covers PAC examples: extra_vars_allowlist, extra_vars_validation,
+# team_based_extra_vars_restriction
+package aac.aap.policy
+
+import rego.v1
+
+# ---------------------------------------------------------------------------
+# Configuration — override via data.aac.aap.config.extra_vars
+#
+#   {"allowlist": ["app_version", "target_env"],
+#    "denylist": ["ansible_become_password"],
+#    "allow_unlisted": false,
+#    "value_patterns": {"target_env": "^(dev|stage|prod)$"},
+#    "forbid_secret_like_keys": true}
+# ---------------------------------------------------------------------------
+_ev_defaults := {
+	"allowlist": [],
+	"denylist": [],
+	# When false, any key outside the allowlist is rejected.
+	"allow_unlisted": true,
+	"value_patterns": {},
+	"forbid_secret_like_keys": true,
+	"secret_key_pattern": "(?i)(pass|passwd|password|secret|token|api_?key|private_?key)",
+}
+
+_ev_cfg := object.union(_ev_defaults, _override) if {
+	_override := data.aac.aap.config.extra_vars
+	is_object(_override)
+} else := _ev_defaults
+
+# extra_vars may arrive as an object or as a JSON string.
+_extra_vars := ev if {
+	is_object(input.extra_vars)
+	ev := input.extra_vars
+} else := ev if {
+	is_string(input.extra_vars)
+	ev := json.unmarshal(input.extra_vars)
+} else := {}
+
+_ev_keys := {lower(k) | some k, _ in _extra_vars}
+
+_ev_allowlist := {lower(k) | some k in _ev_cfg.allowlist}
+
+_ev_denylist := {lower(k) | some k in _ev_cfg.denylist}
+
+# --- explicit denylist -----------------------------------------------------
+_ev_violations contains msg if {
+	some k in _ev_keys
+	k in _ev_denylist
+	msg := sprintf("extra_var '%s' is explicitly denied.", [k])
+}
+
+# --- allowlist enforcement -------------------------------------------------
+_ev_violations contains msg if {
+	not _ev_cfg.allow_unlisted
+	count(_ev_allowlist) > 0
+	some k in _ev_keys
+	not k in _ev_allowlist
+	msg := sprintf(
+		"extra_var '%s' is not in the approved allowlist %v.",
+		[k, _ev_cfg.allowlist],
+	)
+}
+
+# --- secret-shaped keys ----------------------------------------------------
+_ev_violations contains msg if {
+	_ev_cfg.forbid_secret_like_keys
+	some k in _ev_keys
+	regex.match(_ev_cfg.secret_key_pattern, k)
+	msg := sprintf(
+		"extra_var '%s' looks like a secret — pass it through a credential or Ansible Vault, not extra_vars.",
+		[k],
+	)
+}
+
+# --- value validation ------------------------------------------------------
+_ev_violations contains msg if {
+	some key, pattern in _ev_cfg.value_patterns
+	some k, v in _extra_vars
+	lower(k) == lower(key)
+	sv := _as_string(v)
+	not regex.match(pattern, sv)
+	msg := sprintf(
+		"extra_var '%s' value '%s' does not match the required format %s.",
+		[k, sv, pattern],
+	)
+}
+
+_as_string(v) := v if is_string(v)
+
+_as_string(v) := sprintf("%v", [v]) if not is_string(v)
+
+extra_vars_control := {
+	"allowed": count(_ev_violations) == 0,
+	"violations": [v | some v in _ev_violations],
+}
+
+# ---------------------------------------------------------------------------
+# Team-scoped extra_vars — override via data.aac.aap.config.team_extra_vars
+#
+#   {"teams": {"app-team": ["app_version"], "dba": ["db_schema_version"]},
+#    "unbound_teams_allowed": false}
+#
+# A user may only set keys permitted to at least one of their teams.
+# ---------------------------------------------------------------------------
+_tev_defaults := {"teams": {}, "unbound_teams_allowed": true}
+
+_tev_cfg := object.union(_tev_defaults, _override) if {
+	_override := data.aac.aap.config.team_extra_vars
+	is_object(_override)
+} else := _tev_defaults
+
+_user_teams := {lower(t) | some t in object.get(input, ["created_by", "teams"], [])}
+
+_team_permitted := {lower(k) |
+	some team in _user_teams
+	some k in object.get(_tev_cfg.teams, team, [])
+}
+
+_has_team_binding if {
+	some team in _user_teams
+	object.get(_tev_cfg.teams, team, null) != null
+}
+
+_tev_violations contains msg if {
+	count(_extra_vars) > 0
+	_has_team_binding
+	some k in _ev_keys
+	not k in _team_permitted
+	msg := sprintf(
+		"extra_var '%s' is not permitted for teams %v (permitted: %v).",
+		[k, _user_teams, _team_permitted],
+	)
+}
+
+_tev_violations contains msg if {
+	count(_extra_vars) > 0
+	not _has_team_binding
+	not _tev_cfg.unbound_teams_allowed
+	msg := sprintf(
+		"User's teams %v have no extra_vars binding and unbound use is disabled.",
+		[_user_teams],
+	)
+}
+
+team_extra_vars := {
+	"allowed": count(_tev_violations) == 0,
+	"violations": [v | some v in _tev_violations],
+}

--- a/enforcement/aap/maintenance_window.rego
+++ b/enforcement/aap/maintenance_window.rego
@@ -1,0 +1,184 @@
+# AAP job policy — time-of-day windows, change freezes, and maintenance mode.
+#
+# Consumes the Ansible Automation Platform Policy as Code job-context input and
+# returns the documented decision contract:
+#
+#   {"allowed": bool, "violations": [string]}
+#
+# Query paths (associate with an organization, inventory, or job template):
+#   /v1/data/aac/aap/policy/maintenance_window
+#   /v1/data/aac/aap/policy/maintenance_mode
+#
+# Covers PAC example: maintenance_window
+package aac.aap.policy
+
+import rego.v1
+
+# ---------------------------------------------------------------------------
+# Configuration — override via data.aac.aap.config.maintenance_window
+# ---------------------------------------------------------------------------
+_mw_defaults := {
+	"timezone": "UTC",
+	# Days on which automation may run at all.
+	"allowed_days": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+	# Permitted window, 24h clock. Wraps midnight when start > end.
+	"start_hour": 0,
+	"end_hour": 24,
+	# Full-day freezes, "YYYY-MM-DD".
+	"freeze_dates": [],
+	# A job carrying this label bypasses the window (audited by its presence).
+	"break_glass_label": "break-glass",
+}
+
+_mw_cfg := object.union(_mw_defaults, _override) if {
+	_override := data.aac.aap.config.maintenance_window
+	is_object(_override)
+} else := _mw_defaults
+
+# ---------------------------------------------------------------------------
+# Evaluation time — prefer the job's own timestamp so decisions are
+# reproducible when replayed; fall back to wall clock.
+# ---------------------------------------------------------------------------
+_eval_ns := ns if {
+	is_string(input.created)
+	ns := time.parse_rfc3339_ns(input.created)
+} else := time.now_ns()
+
+_tz := _mw_cfg.timezone
+
+_weekday := time.weekday([_eval_ns, _tz])
+
+_hour := h if {
+	clock := time.clock([_eval_ns, _tz])
+	h := clock[0]
+}
+
+_date := sprintf("%04d-%02d-%02d", [y, m, d]) if {
+	parts := time.date([_eval_ns, _tz])
+	y := parts[0]
+	m := parts[1]
+	d := parts[2]
+}
+
+_labels := {lower(l.name) | some l in object.get(input, "labels", [])}
+
+_break_glass if {
+	lower(_mw_cfg.break_glass_label) in _labels
+}
+
+# ---------------------------------------------------------------------------
+# Window logic
+# ---------------------------------------------------------------------------
+_in_hours if {
+	_mw_cfg.start_hour <= _mw_cfg.end_hour
+	_hour >= _mw_cfg.start_hour
+	_hour < _mw_cfg.end_hour
+}
+
+# Window wraps midnight, e.g. 22:00 -> 04:00
+_in_hours if {
+	_mw_cfg.start_hour > _mw_cfg.end_hour
+	_hour >= _mw_cfg.start_hour
+}
+
+_in_hours if {
+	_mw_cfg.start_hour > _mw_cfg.end_hour
+	_hour < _mw_cfg.end_hour
+}
+
+_day_allowed if {
+	_weekday in _mw_cfg.allowed_days
+}
+
+_frozen if {
+	_date in _mw_cfg.freeze_dates
+}
+
+# ---------------------------------------------------------------------------
+# Violations
+# ---------------------------------------------------------------------------
+_mw_violations contains msg if {
+	not _break_glass
+	_frozen
+	msg := sprintf(
+		"Change freeze in effect for %s — automation is blocked. Apply the '%s' label with an approved change record to override.",
+		[_date, _mw_cfg.break_glass_label],
+	)
+}
+
+_mw_violations contains msg if {
+	not _break_glass
+	not _day_allowed
+	msg := sprintf(
+		"%s is not an approved day for automation (allowed: %v).",
+		[_weekday, _mw_cfg.allowed_days],
+	)
+}
+
+_mw_violations contains msg if {
+	not _break_glass
+	not _in_hours
+	msg := sprintf(
+		"%02d:00 %s is outside the approved change window %02d:00-%02d:00.",
+		[_hour, _tz, _mw_cfg.start_hour, _mw_cfg.end_hour],
+	)
+}
+
+# ---------------------------------------------------------------------------
+# Decision
+# ---------------------------------------------------------------------------
+maintenance_window := {
+	"allowed": count(_mw_violations) == 0,
+	"violations": [v | some v in _mw_violations],
+}
+
+# ---------------------------------------------------------------------------
+# Maintenance mode — a named freeze on specific inventories or the whole
+# platform. Override via data.aac.aap.config.maintenance_mode.
+#
+#   {"active": true, "inventories": ["prod-web"], "reason": "DB migration",
+#    "break_glass_label": "break-glass"}
+#
+# An empty "inventories" list means platform-wide.
+# ---------------------------------------------------------------------------
+_mm_defaults := {
+	"active": false,
+	"inventories": [],
+	"reason": "unspecified",
+	"break_glass_label": "break-glass",
+}
+
+_mm_cfg := object.union(_mm_defaults, _override) if {
+	_override := data.aac.aap.config.maintenance_mode
+	is_object(_override)
+} else := _mm_defaults
+
+_mm_break_glass if {
+	lower(_mm_cfg.break_glass_label) in _labels
+}
+
+_inventory_name := lower(object.get(input, ["inventory", "name"], ""))
+
+_mm_scoped if {
+	count(_mm_cfg.inventories) == 0
+}
+
+_mm_scoped if {
+	some inv in _mm_cfg.inventories
+	lower(inv) == _inventory_name
+}
+
+_mm_violations contains msg if {
+	_mm_cfg.active
+	_mm_scoped
+	not _mm_break_glass
+	msg := sprintf(
+		"Maintenance mode is active for inventory '%s' (reason: %s). Automation is blocked until it is cleared.",
+		[_inventory_name, _mm_cfg.reason],
+	)
+}
+
+maintenance_mode := {
+	"allowed": count(_mm_violations) == 0,
+	"violations": [v | some v in _mm_violations],
+}

--- a/enforcement/aap/naming_and_source.rego
+++ b/enforcement/aap/naming_and_source.rego
@@ -1,0 +1,188 @@
+# AAP job policy — naming standards and trusted automation sources.
+#
+# Query paths:
+#   /v1/data/aac/aap/policy/naming_standard   — job template naming
+#   /v1/data/aac/aap/policy/source_control    — approved repo and branch
+#   /v1/data/aac/aap/policy/deny_all          — break-glass blanket deny
+#
+# Covers PAC examples: jt_naming_validation, github_repo_validation,
+# project_scm_branch, allowed_false
+package aac.aap.policy
+
+import rego.v1
+
+# ---------------------------------------------------------------------------
+# Job-template naming — override via data.aac.aap.config.naming
+#
+#   {"pattern": "^(PROD|STAGE|DEV)-[A-Za-z0-9]+ - .+$",
+#    "max_length": 80, "forbid_terms": ["test", "tmp", "copy of"]}
+# ---------------------------------------------------------------------------
+_nm_defaults := {
+	"pattern": "",
+	"max_length": 0,
+	"forbid_terms": [],
+}
+
+_nm_cfg := object.union(_nm_defaults, _override) if {
+	_override := data.aac.aap.config.naming
+	is_object(_override)
+} else := _nm_defaults
+
+_jt_name := object.get(input, ["job_template", "name"], object.get(input, "name", ""))
+
+_nm_violations contains msg if {
+	_nm_cfg.pattern != ""
+	_jt_name != ""
+	not regex.match(_nm_cfg.pattern, _jt_name)
+	msg := sprintf(
+		"Job template name '%s' does not match the required convention %s.",
+		[_jt_name, _nm_cfg.pattern],
+	)
+}
+
+_nm_violations contains msg if {
+	_nm_cfg.max_length > 0
+	count(_jt_name) > _nm_cfg.max_length
+	msg := sprintf(
+		"Job template name is %d characters; the maximum is %d.",
+		[count(_jt_name), _nm_cfg.max_length],
+	)
+}
+
+_nm_violations contains msg if {
+	some term in _nm_cfg.forbid_terms
+	contains(lower(_jt_name), lower(term))
+	msg := sprintf(
+		"Job template name '%s' contains the forbidden term '%s'.",
+		[_jt_name, term],
+	)
+}
+
+naming_standard := {
+	"allowed": count(_nm_violations) == 0,
+	"violations": [v | some v in _nm_violations],
+}
+
+# ---------------------------------------------------------------------------
+# Source control — override via data.aac.aap.config.source_control
+#
+#   {"allowed_repos": ["github.com/acme/*"],
+#    "allowed_branches": ["main", "release/*"],
+#    "forbid_detached_head": true,
+#    "require_https": true}
+# ---------------------------------------------------------------------------
+_sc_defaults := {
+	"allowed_repos": [],
+	"allowed_branches": [],
+	"forbid_detached_head": true,
+	"require_https": true,
+}
+
+_sc_cfg := object.union(_sc_defaults, _override) if {
+	_override := data.aac.aap.config.source_control
+	is_object(_override)
+} else := _sc_defaults
+
+_scm_url := lower(object.get(input, ["project", "scm_url"], ""))
+
+_scm_branch := object.get(input, ["project", "scm_branch"], "")
+
+# Normalise git@host:org/repo and https://host/org/repo to host/org/repo
+_repo_id := id if {
+	startswith(_scm_url, "git@")
+	trimmed := trim_prefix(_scm_url, "git@")
+	id := replace(trim_suffix(trimmed, ".git"), ":", "/")
+} else := id if {
+	regex.match("^https?://", _scm_url)
+	stripped := regex.replace(_scm_url, "^https?://", "")
+	id := trim_suffix(stripped, ".git")
+} else := ""
+
+_sc_violations contains msg if {
+	_sc_cfg.require_https
+	_scm_url != ""
+	startswith(_scm_url, "git@")
+	msg := sprintf(
+		"Project source '%s' uses SSH — HTTPS is required so access is brokered by a managed credential.",
+		[_scm_url],
+	)
+}
+
+_sc_violations contains msg if {
+	count(_sc_cfg.allowed_repos) > 0
+	_repo_id != ""
+	not _repo_allowed
+	msg := sprintf(
+		"Project repository '%s' is not an approved automation source (allowed: %v).",
+		[_repo_id, _sc_cfg.allowed_repos],
+	)
+}
+
+_repo_allowed if {
+	some pattern in _sc_cfg.allowed_repos
+	glob.match(lower(pattern), ["/"], _repo_id)
+}
+
+_sc_violations contains msg if {
+	count(_sc_cfg.allowed_branches) > 0
+	_scm_branch != ""
+	not _branch_allowed
+	msg := sprintf(
+		"Project branch '%s' is not approved for execution (allowed: %v).",
+		[_scm_branch, _sc_cfg.allowed_branches],
+	)
+}
+
+_branch_allowed if {
+	some pattern in _sc_cfg.allowed_branches
+	glob.match(pattern, ["/"], _scm_branch)
+}
+
+_sc_violations contains msg if {
+	_sc_cfg.forbid_detached_head
+	regex.match("^[0-9a-f]{40}$", lower(_scm_branch))
+	msg := sprintf(
+		"Project is pinned to commit %s rather than a named branch — automation must run from a reviewable ref.",
+		[_scm_branch],
+	)
+}
+
+source_control := {
+	"allowed": count(_sc_violations) == 0,
+	"violations": [v | some v in _sc_violations],
+}
+
+# ---------------------------------------------------------------------------
+# Blanket deny — the incident switch. Associate with an organization to halt
+# all automation. Override via data.aac.aap.config.deny_all.
+#
+#   {"active": true, "reason": "SEV1 in progress", "exempt_labels": ["incident-response"]}
+# ---------------------------------------------------------------------------
+_da_defaults := {
+	"active": false,
+	"reason": "automation is administratively halted",
+	"exempt_labels": ["incident-response"],
+}
+
+_da_cfg := object.union(_da_defaults, _override) if {
+	_override := data.aac.aap.config.deny_all
+	is_object(_override)
+} else := _da_defaults
+
+_da_labels := {lower(l.name) | some l in object.get(input, "labels", [])}
+
+_da_exempt if {
+	some e in _da_cfg.exempt_labels
+	lower(e) in _da_labels
+}
+
+_da_violations contains msg if {
+	_da_cfg.active
+	not _da_exempt
+	msg := sprintf("All automation is blocked: %s.", [_da_cfg.reason])
+}
+
+deny_all := {
+	"allowed": count(_da_violations) == 0,
+	"violations": [v | some v in _da_violations],
+}

--- a/enforcement/aap/owner_scope.rego
+++ b/enforcement/aap/owner_scope.rego
@@ -1,0 +1,202 @@
+# AAP job policy — who may automate what.
+#
+# Binds launching users (and their teams) to the inventories and environments
+# they are permitted to target, and constrains privileged launches.
+#
+# Query paths:
+#   /v1/data/aac/aap/policy/owner_scope           — owner -> inventory/environment
+#   /v1/data/aac/aap/policy/superuser_restriction  — deny superuser launches
+#   /v1/data/aac/aap/policy/credential_scope       — credential/inventory coherence
+#
+# Covers PAC examples: restrict_inv_use_to_org, superuser_allowed_false,
+# mismatch_prefix_allowed_false, global_credential_allowed_false
+package aac.aap.policy
+
+import rego.v1
+
+# ---------------------------------------------------------------------------
+# Configuration — override via data.aac.aap.config.owner_scope
+#
+#   {"bindings": {"alice": ["prod-*", "stage-*"], "bob": ["dev-*"]},
+#    "team_bindings": {"platform-sre": ["*"]},
+#    "unbound_users_allowed": false,
+#    "enforce_org_match": true}
+# ---------------------------------------------------------------------------
+_os_defaults := {
+	"bindings": {},
+	"team_bindings": {},
+	# When false, a user with no binding cannot launch anything.
+	"unbound_users_allowed": true,
+	# Require the inventory's organization to match the job template's.
+	"enforce_org_match": true,
+}
+
+_os_cfg := object.union(_os_defaults, _override) if {
+	_override := data.aac.aap.config.owner_scope
+	is_object(_override)
+} else := _os_defaults
+
+_username := lower(object.get(input, ["created_by", "username"], ""))
+
+_inv_name := lower(object.get(input, ["inventory", "name"], ""))
+
+_teams := {lower(t) | some t in object.get(input, ["created_by", "teams"], [])}
+
+# Patterns this launcher is permitted to target, from user and team bindings.
+_allowed_patterns := patterns if {
+	user_pats := object.get(_os_cfg.bindings, _username, [])
+	team_pats := [p |
+		some team in _teams
+		some p in object.get(_os_cfg.team_bindings, team, [])
+	]
+	patterns := array.concat(user_pats, team_pats)
+}
+
+_has_binding if {
+	count(_allowed_patterns) > 0
+}
+
+_matches_any if {
+	some pattern in _allowed_patterns
+	glob.match(lower(pattern), [], _inv_name)
+}
+
+_os_violations contains msg if {
+	_inv_name != ""
+	_has_binding
+	not _matches_any
+	msg := sprintf(
+		"User '%s' is not permitted to target inventory '%s' (permitted: %v).",
+		[_username, _inv_name, _allowed_patterns],
+	)
+}
+
+_os_violations contains msg if {
+	_inv_name != ""
+	not _has_binding
+	not _os_cfg.unbound_users_allowed
+	msg := sprintf(
+		"User '%s' has no inventory binding and unbound launches are disabled.",
+		[_username],
+	)
+}
+
+# Inventory must belong to the same organization as the job template.
+_jt_org := object.get(input, ["job_template", "organization"], null)
+
+_inv_org := object.get(input, ["inventory", "organization"], null)
+
+_os_violations contains msg if {
+	_os_cfg.enforce_org_match
+	is_number(_jt_org)
+	is_number(_inv_org)
+	_jt_org != _inv_org
+	msg := sprintf(
+		"Inventory organization (%d) does not match the job template's organization (%d).",
+		[_inv_org, _jt_org],
+	)
+}
+
+owner_scope := {
+	"allowed": count(_os_violations) == 0,
+	"violations": [v | some v in _os_violations],
+}
+
+# ---------------------------------------------------------------------------
+# Superuser restriction — override via data.aac.aap.config.superuser
+#
+#   {"deny": true, "exempt_users": ["break-glass-svc"]}
+# ---------------------------------------------------------------------------
+_su_defaults := {"deny": true, "exempt_users": []}
+
+_su_cfg := object.union(_su_defaults, _override) if {
+	_override := data.aac.aap.config.superuser
+	is_object(_override)
+} else := _su_defaults
+
+_su_exempt if {
+	some u in _su_cfg.exempt_users
+	lower(u) == _username
+}
+
+_su_violations contains msg if {
+	_su_cfg.deny
+	object.get(input, ["created_by", "is_superuser"], false) == true
+	not _su_exempt
+	msg := sprintf(
+		"Superuser '%s' may not launch automation directly — use a scoped service account so the action is attributable.",
+		[_username],
+	)
+}
+
+superuser_restriction := {
+	"allowed": count(_su_violations) == 0,
+	"violations": [v | some v in _su_violations],
+}
+
+# ---------------------------------------------------------------------------
+# Credential scope — override via data.aac.aap.config.credential_scope
+#
+#   {"deny_global_credentials": true,
+#    "require_prefix_match": true,
+#    "prefix_separator": "-"}
+#
+# require_prefix_match guards the classic mistake of pointing a production
+# credential at a development inventory (or vice versa) by comparing the
+# leading token of each name.
+# ---------------------------------------------------------------------------
+_cs_defaults := {
+	"deny_global_credentials": true,
+	"require_prefix_match": true,
+	"prefix_separator": "-",
+	"exempt_credentials": [],
+}
+
+_cs_cfg := object.union(_cs_defaults, _override) if {
+	_override := data.aac.aap.config.credential_scope
+	is_object(_override)
+} else := _cs_defaults
+
+_credentials := object.get(input, "credentials", [])
+
+_cred_exempt(name) if {
+	some e in _cs_cfg.exempt_credentials
+	lower(e) == lower(name)
+}
+
+# A credential with no owning organization is global.
+_cs_violations contains msg if {
+	_cs_cfg.deny_global_credentials
+	some cred in _credentials
+	cred.organization == null
+	not cred.managed
+	not _cred_exempt(cred.name)
+	msg := sprintf(
+		"Credential '%s' is global (no owning organization) — scope it to an organization before use.",
+		[cred.name],
+	)
+}
+
+_prefix(name) := p if {
+	parts := split(lower(name), _cs_cfg.prefix_separator)
+	p := parts[0]
+}
+
+_cs_violations contains msg if {
+	_cs_cfg.require_prefix_match
+	_inv_name != ""
+	some cred in _credentials
+	not _cred_exempt(cred.name)
+	cp := _prefix(cred.name)
+	ip := _prefix(_inv_name)
+	cp != ip
+	msg := sprintf(
+		"Credential '%s' (prefix '%s') does not match inventory '%s' (prefix '%s') — likely an environment mismatch.",
+		[cred.name, cp, _inv_name, ip],
+	)
+}
+
+credential_scope := {
+	"allowed": count(_cs_violations) == 0,
+	"violations": [v | some v in _cs_violations],
+}

--- a/enforcement/aap/required_labels.rego
+++ b/enforcement/aap/required_labels.rego
@@ -1,0 +1,129 @@
+# AAP job policy — label-driven gating.
+#
+# Labels are the cheapest way to carry governance intent on a job: a change
+# ticket, an approval, an environment marker, a quarantine flag. This policy
+# makes them enforceable.
+#
+# Query path:
+#   /v1/data/aac/aap/policy/required_labels
+#
+# No PAC example covers this — it is an AAC addition.
+package aac.aap.policy
+
+import rego.v1
+
+# ---------------------------------------------------------------------------
+# Configuration — override via data.aac.aap.config.labels
+#
+#   {"required": ["change-ticket"],
+#    "forbidden": ["quarantined", "do-not-run"],
+#    "required_for_inventories": {"prod-*": ["change-approved", "peer-reviewed"]},
+#    "one_of": [["env-dev", "env-stage", "env-prod"]],
+#    "pattern_requirements": {"change-ticket": "^CHG[0-9]{7}$"}}
+# ---------------------------------------------------------------------------
+_lbl_defaults := {
+	"required": [],
+	"forbidden": [],
+	"required_for_inventories": {},
+	"one_of": [],
+	"pattern_requirements": {},
+}
+
+_lbl_cfg := object.union(_lbl_defaults, _override) if {
+	_override := data.aac.aap.config.labels
+	is_object(_override)
+} else := _lbl_defaults
+
+_label_list := object.get(input, "labels", [])
+
+_label_names := {lower(l.name) | some l in _label_list}
+
+_inventory := lower(object.get(input, ["inventory", "name"], ""))
+
+# --- forbidden -------------------------------------------------------------
+_lbl_violations contains msg if {
+	some f in _lbl_cfg.forbidden
+	lower(f) in _label_names
+	msg := sprintf(
+		"Job carries the forbidden label '%s' — execution is blocked.",
+		[f],
+	)
+}
+
+# --- globally required -----------------------------------------------------
+_lbl_violations contains msg if {
+	some r in _lbl_cfg.required
+	not lower(r) in _label_names
+	msg := sprintf("Required label '%s' is missing.", [r])
+}
+
+# --- required for matching inventories -------------------------------------
+_lbl_violations contains msg if {
+	some pattern, required in _lbl_cfg.required_for_inventories
+	glob.match(lower(pattern), [], _inventory)
+	some r in required
+	not lower(r) in _label_names
+	msg := sprintf(
+		"Inventory '%s' matches '%s', which requires the label '%s'.",
+		[_inventory, pattern, r],
+	)
+}
+
+# --- exactly-one-of groups (e.g. an environment marker) --------------------
+_lbl_violations contains msg if {
+	some group in _lbl_cfg.one_of
+	present := [g | some g in group; lower(g) in _label_names]
+	count(present) == 0
+	msg := sprintf("Exactly one of %v must be present; none were.", [group])
+}
+
+_lbl_violations contains msg if {
+	some group in _lbl_cfg.one_of
+	present := [g | some g in group; lower(g) in _label_names]
+	count(present) > 1
+	msg := sprintf(
+		"Exactly one of %v must be present; found %v.",
+		[group, present],
+	)
+}
+
+# --- value format ----------------------------------------------------------
+# Enforces "key:value" labels, e.g. change-ticket:CHG0012345
+_lbl_violations contains msg if {
+	some key, pattern in _lbl_cfg.pattern_requirements
+	values := [v |
+		some l in _label_list
+		parts := split(l.name, ":")
+		count(parts) == 2
+		lower(parts[0]) == lower(key)
+		v := parts[1]
+	]
+	count(values) > 0
+	some v in values
+	not regex.match(pattern, v)
+	msg := sprintf(
+		"Label '%s' value '%s' does not match the required format %s.",
+		[key, v, pattern],
+	)
+}
+
+_lbl_violations contains msg if {
+	some key, pattern in _lbl_cfg.pattern_requirements
+	values := [v |
+		some l in _label_list
+		parts := split(l.name, ":")
+		count(parts) == 2
+		lower(parts[0]) == lower(key)
+		v := parts[1]
+	]
+	count(values) == 0
+	msg := sprintf(
+		"Label '%s' is required in 'key:value' form matching %s, but no value was supplied.",
+		[key, pattern],
+	)
+}
+
+required_labels := {
+	"allowed": count(_lbl_violations) == 0,
+	"violations": [v | some v in _lbl_violations],
+}

--- a/enforcement/aap/tests/test_aap_policy.rego
+++ b/enforcement/aap/tests/test_aap_policy.rego
@@ -1,0 +1,358 @@
+# Tests for the AAP job policy set.
+#
+# Every decision returns {"allowed": bool, "violations": [string]} — the
+# contract Ansible Automation Platform's policy enforcement expects.
+package aac.aap.policy_test
+
+import data.aac.aap.policy
+import rego.v1
+
+# A Tuesday, 23:00 UTC.
+_base_input := {
+	"id": 4242,
+	"name": "PROD-web - Deploy",
+	"created": "2026-07-28T23:00:00Z",
+	"created_by": {"id": 7, "username": "alice", "is_superuser": false, "teams": ["app-team"]},
+	"credentials": [{"id": 5, "name": "prod-ssh", "organization": 1, "managed": false, "kind": "ssh"}],
+	"inventory": {"id": 2, "name": "prod-web", "organization": 1},
+	"job_template": {"id": 9, "name": "PROD-web - Deploy", "organization": 1},
+	"project": {"scm_url": "https://github.com/acme/automation.git", "scm_branch": "main"},
+	"labels": [{"id": 1, "name": "change-ticket:CHG0012345"}],
+	"extra_vars": {"app_version": "2.1.4"},
+}
+
+_with(overrides) := object.union(_base_input, overrides)
+
+# ---------------------------------------------------------------------------
+# 1. Time of day / change window
+# ---------------------------------------------------------------------------
+test_window_allows_inside_hours if {
+	r := policy.maintenance_window with input as _base_input
+		with data.aac.aap.config as {"maintenance_window": {"start_hour": 22, "end_hour": 4}}
+	r.allowed
+	count(r.violations) == 0
+}
+
+test_window_blocks_outside_hours if {
+	r := policy.maintenance_window with input as _with({"created": "2026-07-28T14:00:00Z"})
+		with data.aac.aap.config as {"maintenance_window": {"start_hour": 22, "end_hour": 4}}
+	not r.allowed
+	count(r.violations) == 1
+}
+
+test_window_wraps_midnight if {
+	r := policy.maintenance_window with input as _with({"created": "2026-07-29T02:00:00Z"})
+		with data.aac.aap.config as {"maintenance_window": {"start_hour": 22, "end_hour": 4}}
+	r.allowed
+}
+
+test_window_blocks_disallowed_day if {
+	# 2026-08-01 is a Saturday.
+	r := policy.maintenance_window with input as _with({"created": "2026-08-01T23:00:00Z"})
+		with data.aac.aap.config as {"maintenance_window": {"allowed_days": ["Monday"]}}
+	not r.allowed
+}
+
+test_window_blocks_on_freeze_date if {
+	r := policy.maintenance_window with input as _base_input
+		with data.aac.aap.config as {"maintenance_window": {"freeze_dates": ["2026-07-28"]}}
+	not r.allowed
+}
+
+test_window_break_glass_label_overrides if {
+	r := policy.maintenance_window with input as _with({
+		"created": "2026-07-28T14:00:00Z",
+		"labels": [{"name": "break-glass"}],
+	})
+		with data.aac.aap.config as {"maintenance_window": {"start_hour": 22, "end_hour": 4}}
+	r.allowed
+}
+
+# ---------------------------------------------------------------------------
+# 2. Maintenance mode
+# ---------------------------------------------------------------------------
+test_maintenance_mode_inactive_allows if {
+	r := policy.maintenance_mode with input as _base_input
+	r.allowed
+}
+
+test_maintenance_mode_blocks_scoped_inventory if {
+	r := policy.maintenance_mode with input as _base_input
+		with data.aac.aap.config as {"maintenance_mode": {
+			"active": true,
+			"inventories": ["prod-web"],
+			"reason": "DB migration",
+		}}
+	not r.allowed
+	contains(r.violations[0], "DB migration")
+}
+
+test_maintenance_mode_ignores_other_inventory if {
+	r := policy.maintenance_mode with input as _with({"inventory": {"name": "dev-web", "organization": 1}})
+		with data.aac.aap.config as {"maintenance_mode": {"active": true, "inventories": ["prod-web"]}}
+	r.allowed
+}
+
+test_maintenance_mode_platform_wide_when_list_empty if {
+	r := policy.maintenance_mode with input as _base_input
+		with data.aac.aap.config as {"maintenance_mode": {"active": true}}
+	not r.allowed
+}
+
+# ---------------------------------------------------------------------------
+# 3. Owner -> environment / inventory
+# ---------------------------------------------------------------------------
+test_owner_scope_allows_bound_pattern if {
+	r := policy.owner_scope with input as _base_input
+		with data.aac.aap.config as {"owner_scope": {"bindings": {"alice": ["prod-*"]}}}
+	r.allowed
+}
+
+test_owner_scope_blocks_unbound_pattern if {
+	r := policy.owner_scope with input as _base_input
+		with data.aac.aap.config as {"owner_scope": {"bindings": {"alice": ["dev-*"]}}}
+	not r.allowed
+}
+
+test_owner_scope_team_binding_grants_access if {
+	r := policy.owner_scope with input as _base_input
+		with data.aac.aap.config as {"owner_scope": {"team_bindings": {"app-team": ["prod-*"]}}}
+	r.allowed
+}
+
+test_owner_scope_blocks_unbound_user_when_disabled if {
+	r := policy.owner_scope with input as _base_input
+		with data.aac.aap.config as {"owner_scope": {"unbound_users_allowed": false}}
+	not r.allowed
+}
+
+test_owner_scope_blocks_org_mismatch if {
+	r := policy.owner_scope with input as _with({"inventory": {"name": "prod-web", "organization": 99}})
+		with data.aac.aap.config as {"owner_scope": {"bindings": {"alice": ["prod-*"]}}}
+	not r.allowed
+}
+
+# ---------------------------------------------------------------------------
+# 4. Labels
+# ---------------------------------------------------------------------------
+test_labels_allows_when_required_present if {
+	r := policy.required_labels with input as _base_input
+		with data.aac.aap.config as {"labels": {"required": ["change-ticket:CHG0012345"]}}
+	r.allowed
+}
+
+test_labels_blocks_missing_required if {
+	r := policy.required_labels with input as _base_input
+		with data.aac.aap.config as {"labels": {"required": ["peer-reviewed"]}}
+	not r.allowed
+}
+
+test_labels_blocks_forbidden if {
+	r := policy.required_labels with input as _with({"labels": [{"name": "quarantined"}]})
+		with data.aac.aap.config as {"labels": {"forbidden": ["quarantined"]}}
+	not r.allowed
+}
+
+test_labels_required_for_matching_inventory if {
+	r := policy.required_labels with input as _base_input
+		with data.aac.aap.config as {"labels": {"required_for_inventories": {"prod-*": ["peer-reviewed"]}}}
+	not r.allowed
+}
+
+test_labels_one_of_requires_exactly_one if {
+	r := policy.required_labels with input as _with({"labels": [{"name": "env-dev"}, {"name": "env-prod"}]})
+		with data.aac.aap.config as {"labels": {"one_of": [["env-dev", "env-prod"]]}}
+	not r.allowed
+}
+
+test_labels_value_pattern_enforced if {
+	r := policy.required_labels with input as _with({"labels": [{"name": "change-ticket:oops"}]})
+		with data.aac.aap.config as {"labels": {"pattern_requirements": {"change-ticket": "^CHG[0-9]{7}$"}}}
+	not r.allowed
+}
+
+test_labels_value_pattern_passes if {
+	r := policy.required_labels with input as _base_input
+		with data.aac.aap.config as {"labels": {"pattern_requirements": {"change-ticket": "^CHG[0-9]{7}$"}}}
+	r.allowed
+}
+
+# ---------------------------------------------------------------------------
+# 5. Superuser
+# ---------------------------------------------------------------------------
+test_superuser_blocked_by_default if {
+	r := policy.superuser_restriction with input as _with({"created_by": {"username": "root", "is_superuser": true}})
+	not r.allowed
+}
+
+test_superuser_exempt_user_allowed if {
+	r := policy.superuser_restriction with input as _with({"created_by": {"username": "root", "is_superuser": true}})
+		with data.aac.aap.config as {"superuser": {"exempt_users": ["root"]}}
+	r.allowed
+}
+
+test_non_superuser_allowed if {
+	r := policy.superuser_restriction with input as _base_input
+	r.allowed
+}
+
+# ---------------------------------------------------------------------------
+# 6. Credential scope
+# ---------------------------------------------------------------------------
+test_credential_scope_allows_matching_prefix if {
+	r := policy.credential_scope with input as _base_input
+	r.allowed
+}
+
+test_credential_scope_blocks_prefix_mismatch if {
+	r := policy.credential_scope with input as _with({"credentials": [{"name": "dev-ssh", "organization": 1, "managed": false}]})
+	not r.allowed
+}
+
+test_credential_scope_blocks_global_credential if {
+	r := policy.credential_scope with input as _with({"credentials": [{"name": "prod-ssh", "organization": null, "managed": false}]})
+	not r.allowed
+}
+
+# ---------------------------------------------------------------------------
+# 7. extra_vars
+# ---------------------------------------------------------------------------
+test_extra_vars_allows_listed_key if {
+	r := policy.extra_vars_control with input as _base_input
+		with data.aac.aap.config as {"extra_vars": {"allowlist": ["app_version"], "allow_unlisted": false}}
+	r.allowed
+}
+
+test_extra_vars_blocks_unlisted_key if {
+	r := policy.extra_vars_control with input as _with({"extra_vars": {"rm_rf": true}})
+		with data.aac.aap.config as {"extra_vars": {"allowlist": ["app_version"], "allow_unlisted": false}}
+	not r.allowed
+}
+
+test_extra_vars_blocks_secret_like_key if {
+	r := policy.extra_vars_control with input as _with({"extra_vars": {"db_password": "hunter2"}})
+	not r.allowed
+}
+
+test_extra_vars_value_pattern_enforced if {
+	r := policy.extra_vars_control with input as _with({"extra_vars": {"target_env": "banana"}})
+		with data.aac.aap.config as {"extra_vars": {"value_patterns": {"target_env": "^(dev|stage|prod)$"}}}
+	not r.allowed
+}
+
+test_extra_vars_accepts_json_string_form if {
+	r := policy.extra_vars_control with input as _with({"extra_vars": "{\"db_password\": \"x\"}"})
+	not r.allowed
+}
+
+test_team_extra_vars_blocks_unpermitted_key if {
+	r := policy.team_extra_vars with input as _base_input
+		with data.aac.aap.config as {"team_extra_vars": {"teams": {"app-team": ["other_key"]}}}
+	not r.allowed
+}
+
+test_team_extra_vars_allows_permitted_key if {
+	r := policy.team_extra_vars with input as _base_input
+		with data.aac.aap.config as {"team_extra_vars": {"teams": {"app-team": ["app_version"]}}}
+	r.allowed
+}
+
+# ---------------------------------------------------------------------------
+# 8. Naming
+# ---------------------------------------------------------------------------
+test_naming_allows_conforming_name if {
+	r := policy.naming_standard with input as _base_input
+		with data.aac.aap.config as {"naming": {"pattern": "^(PROD|STAGE|DEV)-.+ - .+$"}}
+	r.allowed
+}
+
+test_naming_blocks_nonconforming_name if {
+	r := policy.naming_standard with input as _with({"job_template": {"name": "my test job"}})
+		with data.aac.aap.config as {"naming": {"pattern": "^(PROD|STAGE|DEV)-.+ - .+$"}}
+	not r.allowed
+}
+
+test_naming_blocks_forbidden_term if {
+	r := policy.naming_standard with input as _with({"job_template": {"name": "PROD-web - copy of Deploy"}})
+		with data.aac.aap.config as {"naming": {"forbid_terms": ["copy of"]}}
+	not r.allowed
+}
+
+# ---------------------------------------------------------------------------
+# 9. Source control
+# ---------------------------------------------------------------------------
+test_source_allows_approved_repo_and_branch if {
+	r := policy.source_control with input as _base_input
+		with data.aac.aap.config as {"source_control": {
+			"allowed_repos": ["github.com/acme/*"],
+			"allowed_branches": ["main", "release/*"],
+		}}
+	r.allowed
+}
+
+test_source_blocks_unapproved_repo if {
+	r := policy.source_control with input as _with({"project": {"scm_url": "https://github.com/rando/x.git", "scm_branch": "main"}})
+		with data.aac.aap.config as {"source_control": {"allowed_repos": ["github.com/acme/*"]}}
+	not r.allowed
+}
+
+test_source_blocks_unapproved_branch if {
+	r := policy.source_control with input as _with({"project": {"scm_url": "https://github.com/acme/automation.git", "scm_branch": "wip"}})
+		with data.aac.aap.config as {"source_control": {"allowed_branches": ["main"]}}
+	not r.allowed
+}
+
+test_source_blocks_ssh_when_https_required if {
+	r := policy.source_control with input as _with({"project": {"scm_url": "git@github.com:acme/automation.git", "scm_branch": "main"}})
+	not r.allowed
+}
+
+test_source_blocks_detached_head if {
+	r := policy.source_control with input as _with({"project": {
+		"scm_url": "https://github.com/acme/automation.git",
+		"scm_branch": "a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0",
+	}})
+	not r.allowed
+}
+
+# ---------------------------------------------------------------------------
+# 10. Blanket deny
+# ---------------------------------------------------------------------------
+test_deny_all_inactive_allows if {
+	r := policy.deny_all with input as _base_input
+	r.allowed
+}
+
+test_deny_all_active_blocks if {
+	r := policy.deny_all with input as _base_input
+		with data.aac.aap.config as {"deny_all": {"active": true, "reason": "SEV1 in progress"}}
+	not r.allowed
+}
+
+test_deny_all_exempt_label_allows if {
+	r := policy.deny_all with input as _with({"labels": [{"name": "incident-response"}]})
+		with data.aac.aap.config as {"deny_all": {"active": true}}
+	r.allowed
+}
+
+# ---------------------------------------------------------------------------
+# Contract — every decision must return the PAC shape
+# ---------------------------------------------------------------------------
+test_all_decisions_return_pac_contract if {
+	every d in [
+		policy.maintenance_window,
+		policy.maintenance_mode,
+		policy.owner_scope,
+		policy.superuser_restriction,
+		policy.credential_scope,
+		policy.required_labels,
+		policy.extra_vars_control,
+		policy.team_extra_vars,
+		policy.naming_standard,
+		policy.source_control,
+		policy.deny_all,
+	] {
+		is_boolean(d.allowed)
+		is_array(d.violations)
+	} with input as _base_input
+}


### PR DESCRIPTION
Adds `enforcement/aap/` — a Rego decision set that gates **AAP job execution**, written against AAP's published Policy as Code contract so it drops straight into the platform's own enforcement feature.

Every rule returns exactly what AAP expects:

```json
{ "allowed": false, "violations": ["reason 1", "reason 2"] }
```

Package `aac.aap.policy`, one rule per decision, so each can be associated independently with an organization, inventory, or job template.

## Why

Red Hat ships the enforcement *mechanism* and a dozen example policies. It ships **no policy library**. This is the library — the same relationship AAC already has to compliance frameworks, applied to automation governance.

## The eleven decisions

| Query path | Blocks on |
|---|---|
| `maintenance_window` | Time of day, day of week, dated change freezes |
| `maintenance_mode` | Named freeze, per-inventory or platform-wide |
| `owner_scope` | User/team → inventory bindings; inventory-to-org coherence |
| `superuser_restriction` | Superuser launches |
| `credential_scope` | Global credentials; credential/inventory environment mismatch |
| `required_labels` | Required, forbidden, one-of, `key:value` format |
| `extra_vars_control` | Disallowed keys, secret-shaped keys, malformed values |
| `team_extra_vars` | Which teams may set which variables |
| `naming_standard` | Template naming, length, forbidden terms |
| `source_control` | Approved repo/branch, SSH URLs, detached-HEAD execution |
| `deny_all` | Everything — the incident switch |

## Parity with Red Hat's examples — all 12 covered

`maintenance_window` · `restrict_inv_use_to_org` · `superuser_allowed_false` · `global_credential_allowed_false` · `mismatch_prefix_allowed_false` · `extra_vars_allowlist` · `extra_vars_validation` · `team_based_extra_vars_restriction` · `jt_naming_validation` · `github_repo_validation` · `project_scm_branch` · `allowed_false`

`maintenance_mode` and `required_labels` have no upstream equivalent.

## Design notes

**Data-driven, no policy edits.** Everything tunes under `data.aac.aap.config.*`; see `data/aap_policy_config.example.json`.

**Permissive defaults.** An unconfigured deployment allows automation — loading this set cannot accidentally halt a platform. Two deliberate exceptions: superuser launches are denied, and secret-shaped `extra_vars` keys (`password`, `token`, `api_key`, …) are rejected.

**Reproducible time.** Time rules prefer `input.created` — the job's own timestamp — over wall clock, so a decision can be replayed during an audit and reach the same answer.

**Break-glass is evidence.** `maintenance_window`, `maintenance_mode`, and `deny_all` honour bypass labels, but the label lives on the job record, so the override is itself auditable.

## Testing

```
PASS: 47/47
```

Allow and deny paths for every decision, plus a contract test asserting all eleven return `{allowed: bool, violations: []}`.

## Implementation note worth knowing

Config lookups reference `data.aac.aap.config.<key>` **directly** rather than `object.get(data, [...], {})`. The latter takes a dependency on the `data` root — which includes this package — so every config rule becomes mutually recursive and the whole set fails to compile. Cost me a compile cycle; noting it so the next person doesn't repeat it.

## Also

Corrects the stale headline count in `CLAUDE.md` (476 → **510 policy files**, 587 including tests) with the command to recount, and adds `enforcement/aap/` to the structure listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)