### PR TITLE
fix(git): extract_approver conflicts when a message mentions the trailer twice

### DIFF
--- a/enforcement/git/approval_policy.rego
+++ b/enforcement/git/approval_policy.rego
@@ -7,20 +7,20 @@ import rego.v1
 
 # Protected paths that require approval
 protected_paths := {
-    "policies/",
-    "opa/",
-    ".github/workflows/",
-    "aap-integration/",
-    "ansible/",
+	"policies/",
+	"opa/",
+	".github/workflows/",
+	"aap-integration/",
+	"ansible/",
 }
 
 # Users authorized to approve changes
 authorized_approvers := {
-    "ynotbha@aisle-five.com",
-    "tcoulter@example.com",
-    "john.doe@example.com",
-    "security-team@example.com",
-    "compliance-admin@example.com",
+	"ynotbha@aisle-five.com",
+	"tcoulter@example.com",
+	"john.doe@example.com",
+	"security-team@example.com",
+	"compliance-admin@example.com",
 }
 
 # Default: changes are not approved
@@ -31,89 +31,97 @@ default approved := false
 # 2. Changes don't affect protected paths, OR
 # 3. Pull request has required approvals
 approved if {
-    input.commit_message
-    contains(input.commit_message, "Approved-By:")
-    approver := extract_approver(input.commit_message)
-    approver in authorized_approvers
+	input.commit_message
+	some approver in extract_approvers(input.commit_message)
+	approver in authorized_approvers
 }
 
 # Allow changes to non-protected paths without approval
 approved if {
-    not affects_protected_paths
+	not affects_protected_paths
 }
 
 # Check if changes affect protected paths
 affects_protected_paths if {
-    some file in input.changed_files
-    some path in protected_paths
-    startswith(file, path)
+	some file in input.changed_files
+	some path in protected_paths
+	startswith(file, path)
 }
 
-# Extract approver email from commit message
-extract_approver(msg) := approver if {
-    lines := split(msg, "\n")
-    some line in lines
-    contains(line, "Approved-By:")
-    parts := split(line, ":")
-    approver := trim_space(parts[1])
+# Extract every approver email from the commit message.
+#
+# Returns a SET, not a single value. A function that yields more than one
+# output for the same input is an eval_conflict_error, and a commit message can
+# legitimately contain more than one line mentioning the trailer — a real
+# trailer plus prose discussing it, or two co-approvers. The previous
+# single-valued form aborted evaluation in that case; it only appeared to work
+# because the calling workflow truncated the message to 20 lines first.
+#
+# Only a line that *starts with* the trailer counts, so prose that merely
+# mentions "Approved-By:" mid-sentence is correctly ignored.
+extract_approvers(msg) := {approver |
+	some line in split(msg, "\n")
+	trimmed := trim_space(line)
+	startswith(trimmed, "Approved-By:")
+	approver := trim_space(substring(trimmed, count("Approved-By:"), -1))
 }
 
 # Validation: Check if approval is required but missing
 default requires_approval := false
 
 requires_approval if {
-    affects_protected_paths
-    not approved
+	affects_protected_paths
+	not approved
 }
 
 # Generate approval requirement message
 approval_message := msg if {
-    requires_approval
-    affected := [file |
-        some file in input.changed_files
-        some path in protected_paths
-        startswith(file, path)
-    ]
-    msg := sprintf("Changes to protected paths require approval: %v", [affected])
+	requires_approval
+	affected := [file |
+		some file in input.changed_files
+		some path in protected_paths
+		startswith(file, path)
+	]
+	msg := sprintf("Changes to protected paths require approval: %v", [affected])
 }
 
 # Policy decision
 decision := {
-    "approved": approved,
-    "requires_approval": requires_approval,
-    "affected_protected_paths": affected_protected_paths,
-    "message": "Check complete",
+	"approved": approved,
+	"requires_approval": requires_approval,
+	"affected_protected_paths": affected_protected_paths,
+	"message": "Check complete",
 }
 
 # Helper: Get affected protected paths
 default affected_protected_paths := []
 
 affected_protected_paths := paths if {
-    paths := [file |
-        some file in input.changed_files
-        some path in protected_paths
-        startswith(file, path)
-    ]
+	paths := [file |
+		some file in input.changed_files
+		some path in protected_paths
+		startswith(file, path)
+	]
 }
 
 # Test data helpers
 test_approved_change if {
-    approved with input as {
-        "commit_message": "Update policies\n\nApproved-By: john.doe@example.com",
-        "changed_files": ["policies/cis_rhel9/test.rego"],
-    }
+	approved with input as {
+		"commit_message": "Update policies\n\nApproved-By: john.doe@example.com",
+		"changed_files": ["policies/cis_rhel9/test.rego"],
+	}
 }
 
 test_unapproved_change if {
-    requires_approval with input as {
-        "commit_message": "Update policies",
-        "changed_files": ["policies/cis_rhel9/test.rego"],
-    }
+	requires_approval with input as {
+		"commit_message": "Update policies",
+		"changed_files": ["policies/cis_rhel9/test.rego"],
+	}
 }
 
 test_non_protected_change if {
-    approved with input as {
-        "commit_message": "Update documentation",
-        "changed_files": ["docs/README.md"],
-    }
+	approved with input as {
+		"commit_message": "Update documentation",
+		"changed_files": ["docs/README.md"],
+	}
 }

--- a/enforcement/git/tests/test_approval_policy.rego
+++ b/enforcement/git/tests/test_approval_policy.rego
@@ -1,0 +1,102 @@
+package corporate.git_approval_test
+
+import data.corporate.git_approval
+import rego.v1
+
+_protected := [".github/workflows/approval-check.yml"]
+
+_unprotected := ["README.md"]
+
+# The exact shape that broke evaluation: a real trailer PLUS prose that
+# mentions the trailer. Previously produced eval_conflict_error.
+_msg_trailer_and_prose := concat("\n", [
+	"fix(ci): something",
+	"",
+	"Approved-By: ynotbha@aisle-five.com",
+	"",
+	"Body text explaining that a commit may lose `Approved-By:` when truncated.",
+])
+
+test_trailer_with_prose_mention_does_not_conflict if {
+	d := git_approval.decision with input as {
+		"commit_message": _msg_trailer_and_prose,
+		"changed_files": _protected,
+		"author": "ynotbhatc",
+		"pr_number": 1,
+	}
+	d.approved
+	d.requires_approval == false
+}
+
+# Two trailers, the authorized one SECOND. Under the old single-valued
+# function this was an eval_conflict_error; a set-valued extractor must find
+# both and approve on the authorized one regardless of order.
+test_two_approver_trailers_both_extracted if {
+	msg := concat("\n", [
+		"chore: dual approval",
+		"",
+		"Approved-By: someone-else@example.com",
+		"Approved-By: ynotbha@aisle-five.com",
+	])
+	d := git_approval.decision with input as {
+		"commit_message": msg,
+		"changed_files": _protected,
+		"author": "ynotbhatc",
+		"pr_number": 6,
+	}
+	d.approved
+	d.requires_approval == false
+}
+
+test_prose_only_mention_is_not_an_approval if {
+	msg := concat("\n", [
+		"docs: describe the convention",
+		"",
+		"Protected paths need `Approved-By:` in the message.",
+	])
+	d := git_approval.decision with input as {
+		"commit_message": msg,
+		"changed_files": _protected,
+		"author": "ynotbhatc",
+		"pr_number": 2,
+	}
+	not d.approved
+	d.requires_approval
+}
+
+test_unauthorized_approver_rejected if {
+	msg := "chore: x\n\nApproved-By: stranger@example.com"
+	d := git_approval.decision with input as {
+		"commit_message": msg,
+		"changed_files": _protected,
+		"author": "ynotbhatc",
+		"pr_number": 3,
+	}
+	not d.approved
+}
+
+test_unprotected_path_needs_no_approval if {
+	d := git_approval.decision with input as {
+		"commit_message": "docs: tweak",
+		"changed_files": _unprotected,
+		"author": "ynotbhatc",
+		"pr_number": 4,
+	}
+	d.approved
+	d.requires_approval == false
+}
+
+test_long_message_trailer_at_end_still_found if {
+	body := [sprintf("line %d of a long explanation", [i]) | some i in numbers.range(1, 40)]
+	msg := concat("\n", array.concat(
+		array.concat(["feat: big change", ""], body),
+		["", "Approved-By: ynotbha@aisle-five.com"],
+	))
+	d := git_approval.decision with input as {
+		"commit_message": msg,
+		"changed_files": _protected,
+		"author": "ynotbhatc",
+		"pr_number": 5,
+	}
+	d.approved
+}


### PR DESCRIPTION
## The bug

`extract_approver` was single-valued and matched **any** line containing `Approved-By:` — including prose. A message with two such lines yields multiple outputs for one input:

```
approval_policy.rego:53: eval_conflict_error: functions must not produce multiple outputs for same inputs
```

Evaluation aborts, so the check **fails on a properly approved change**.

## Why it surfaced now — two bugs masking each other

The calling workflow truncated the message with `head -20` before handing it to OPA, which usually removed the second mention. Removing that truncation (compliance#361 — itself a fix for the trailer being *dropped* on long messages) exposed this immediately, because #361's own message mentions the trailer twice: once as the real trailer, once in prose explaining the bug.

## The fix

- `extract_approvers` returns a **set** — multiple matches are valid, not a conflict
- Only a line that **starts with** the trailer counts, so prose mentioning `Approved-By:` mid-sentence is ignored rather than parsed as an approval
- `approved` holds if **any** extracted approver is authorized

## Tests — `PASS: 9/9`

New `enforcement/git/tests/`, 7 cases: trailer + prose mention (no conflict), dual trailers with the authorized one **second**, prose-only mention (must **not** approve), unauthorized approver, unprotected path, and a 40-line message with the trailer at the end.

Assertions go through `decision` rather than calling `extract_approvers` directly — the pre-commit hook runs `opa check` **per file**, and cross-file references don't resolve that way.

**Verified by replay:** compliance#361's exact input (28 lines, 2 trailer mentions) — previously `eval_conflict_error`, now:

```json
{ "approved": true, "requires_approval": false,
  "affected_protected_paths": [".github/workflows/approval-check.yml"] }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)