### PR TITLE
fix(mcp-governance): approve both AAC naming conventions; stop response collapsing

### DIFF
--- a/governance/mcp/mcp_governance.rego
+++ b/governance/mcp/mcp_governance.rego
@@ -23,32 +23,32 @@ import rego.v1
 # ---------------------------------------------------------------------------
 
 read_only_tools := {
-    "list_inventories", "get_inventory", "list_hosts", "get_host",
-    "list_job_templates", "get_job_template", "list_jobs", "job_status",
-    "job_logs", "list_projects", "get_project", "list_groups",
-    "list_credentials", "get_credential", "list_users", "get_user",
-    "list_organizations", "api_ping_list", "api_me_list",
-    "api_dashboard_list", "api_jobs_read", "api_jobs_list",
-    "api_jobs_stdout_read", "api_jobs_job_events_list",
-    "api_job_templates_read", "api_job_templates_list",
-    "api_job_templates_launch_read",
-    "api_inventories_read", "api_inventories_list",
-    "api_hosts_read", "api_hosts_list",
-    "api_projects_read", "api_projects_list",
-    "api_projects_update_read",
-    "api_credentials_read", "api_credentials_list",
-    "api_organizations_read", "api_organizations_list",
-    "api_users_read", "api_users_list",
-    "api_workflow_job_templates_read", "api_workflow_job_templates_list",
-    "api_workflow_job_templates_launch_read",
-    "api_workflow_jobs_read", "api_workflow_jobs_list",
-    "api_workflow_jobs_workflow_nodes_list",
-    "api_workflow_job_nodes_read", "api_workflow_job_nodes_list",
-    "api_workflow_job_template_nodes_read", "api_workflow_job_template_nodes_list",
-    "api_execution_environments_read", "api_execution_environments_list",
-    "api_schedules_read", "api_schedules_list",
-    "api_unified_job_templates_list", "api_unified_jobs_list",
-    "api_job_templates_survey_spec_list",
+	"list_inventories", "get_inventory", "list_hosts", "get_host",
+	"list_job_templates", "get_job_template", "list_jobs", "job_status",
+	"job_logs", "list_projects", "get_project", "list_groups",
+	"list_credentials", "get_credential", "list_users", "get_user",
+	"list_organizations", "api_ping_list", "api_me_list",
+	"api_dashboard_list", "api_jobs_read", "api_jobs_list",
+	"api_jobs_stdout_read", "api_jobs_job_events_list",
+	"api_job_templates_read", "api_job_templates_list",
+	"api_job_templates_launch_read",
+	"api_inventories_read", "api_inventories_list",
+	"api_hosts_read", "api_hosts_list",
+	"api_projects_read", "api_projects_list",
+	"api_projects_update_read",
+	"api_credentials_read", "api_credentials_list",
+	"api_organizations_read", "api_organizations_list",
+	"api_users_read", "api_users_list",
+	"api_workflow_job_templates_read", "api_workflow_job_templates_list",
+	"api_workflow_job_templates_launch_read",
+	"api_workflow_jobs_read", "api_workflow_jobs_list",
+	"api_workflow_jobs_workflow_nodes_list",
+	"api_workflow_job_nodes_read", "api_workflow_job_nodes_list",
+	"api_workflow_job_template_nodes_read", "api_workflow_job_template_nodes_list",
+	"api_execution_environments_read", "api_execution_environments_list",
+	"api_schedules_read", "api_schedules_list",
+	"api_unified_job_templates_list", "api_unified_jobs_list",
+	"api_job_templates_survey_spec_list",
 }
 
 # ---------------------------------------------------------------------------
@@ -60,12 +60,12 @@ read_only_tools := {
 
 # Flatten all registered template groups into a single id → name lookup
 _registered_name(tid) := name if {
-    some _group, templates in data.aac.templates
-    some id_str, name in templates
-    tid == to_number(id_str)
+	some _group, templates in data.aac.templates
+	some id_str, name in templates
+	tid == to_number(id_str)
 }
 
-_has_registered_name(tid) if { _registered_name(tid) }
+_has_registered_name(tid) if _registered_name(tid)
 
 # ---------------------------------------------------------------------------
 # Option 2 — ID allowlist (legacy fallback for templates not yet synced to OPA)
@@ -73,55 +73,55 @@ _has_registered_name(tid) if { _registered_name(tid) }
 
 # Job templates explicitly approved for AI launch
 approved_template_ids := {
-    10, 11, 12, 13,        # CIS assessments (RHEL 9/8, Ubuntu, Windows)
-    15, 16, 17,            # Fact collection
-    23, 24,                # PostgreSQL init, trending report
-    25, 26,                # OPA policy report, NERC-CIP report
-    27, 28,                # Load OPA policies, deploy OPA containers
-    29,                    # AMI full compliance audit
-    30, 31,                # Deploy smart meter containers, Grafana dashboard
-    32, 33, 34, 35,        # Sentinel: TF validate, Ansible validate, runtime block, audit sweep
-    36, 37,                # Sentinel: AI controls, seed templates
-    38, 39,                # Sentinel preflight, demo stability setup
-    40,                    # AAC - Rotate MCP Token
-    41, 42, 43,            # AMI: NIST, device, head-end
-    45, 46, 47, 48,        # Build compliance EE, Sentinel TF bad/good, Ansible good
-    53, 57,                # DS: seed workflow, assessment
-    101,                   # NERC/AMI - Generate Audit PDF
-    106,                   # DS - Generate Audit PDF
-    107, 108, 109, 110,    # Network devices: VyOS/OPNsense deploy, CIS VyOS/pfSense
-    111, 112, 113, 114,    # Seed workflows: CIS/Nightly/NERC-AMI, PostgreSQL init
-    115,                   # IEC 62443 Assessment
-    116,                   # CIP-010 Baseline Capture/Check
-    117,                   # CIP-008 Incident Response Evidence
-    102, 103, 104, 105,    # Sentinel: runtime block, audit sweep, AI governance, preflight
-    121,                   # AAC - Seed Golden Image Workflow
-    122, 123, 124,         # Golden Image: Check, Rollback, Notify Help Desk
-    125,                   # AAC - Golden Image Enforcement (workflow)
-    126,                   # AAC - Demo: Introduce Drift
-    160, 165,              # Golden Image: Reset Demo, Manage RHPDS Demo Host
-    166, 167,              # CAF 4.0: Fact Collection, Assessment and Store
+	10, 11, 12, 13, # CIS assessments (RHEL 9/8, Ubuntu, Windows)
+	15, 16, 17, # Fact collection
+	23, 24, # PostgreSQL init, trending report
+	25, 26, # OPA policy report, NERC-CIP report
+	27, 28, # Load OPA policies, deploy OPA containers
+	29, # AMI full compliance audit
+	30, 31, # Deploy smart meter containers, Grafana dashboard
+	32, 33, 34, 35, # Sentinel: TF validate, Ansible validate, runtime block, audit sweep
+	36, 37, # Sentinel: AI controls, seed templates
+	38, 39, # Sentinel preflight, demo stability setup
+	40, # AAC - Rotate MCP Token
+	41, 42, 43, # AMI: NIST, device, head-end
+	45, 46, 47, 48, # Build compliance EE, Sentinel TF bad/good, Ansible good
+	53, 57, # DS: seed workflow, assessment
+	101, # NERC/AMI - Generate Audit PDF
+	106, # DS - Generate Audit PDF
+	107, 108, 109, 110, # Network devices: VyOS/OPNsense deploy, CIS VyOS/pfSense
+	111, 112, 113, 114, # Seed workflows: CIS/Nightly/NERC-AMI, PostgreSQL init
+	115, # IEC 62443 Assessment
+	116, # CIP-010 Baseline Capture/Check
+	117, # CIP-008 Incident Response Evidence
+	102, 103, 104, 105, # Sentinel: runtime block, audit sweep, AI governance, preflight
+	121, # AAC - Seed Golden Image Workflow
+	122, 123, 124, # Golden Image: Check, Rollback, Notify Help Desk
+	125, # AAC - Golden Image Enforcement (workflow)
+	126, # AAC - Demo: Introduce Drift
+	160, 165, # Golden Image: Reset Demo, Manage RHPDS Demo Host
+	166, 167, # CAF 4.0: Fact Collection, Assessment and Store
 }
 
 # Tools that are always blocked regardless of context
 blocked_tools := {
-    # Destructive operations
-    "api_hosts_delete", "api_inventories_delete",
-    "api_job_templates_delete", "api_projects_delete",
-    "api_credentials_delete", "api_users_delete",
-    "api_organizations_delete", "api_teams_delete",
-    "api_jobs_delete",
-    # Credential management
-    "api_credentials_create", "api_credentials_update",
-    "api_credentials_partial_update",
-    # User/org admin
-    "api_users_create", "api_users_update",
-    "api_organizations_create", "api_organizations_update",
-    # System settings
-    "api_settings_update", "api_settings_partial_update",
-    "api_settings_delete", "api_config_create", "api_config_delete",
-    # Job cancellation (read-only AI shouldn't stop running jobs)
-    "api_jobs_cancel_create",
+	# Destructive operations
+	"api_hosts_delete", "api_inventories_delete",
+	"api_job_templates_delete", "api_projects_delete",
+	"api_credentials_delete", "api_users_delete",
+	"api_organizations_delete", "api_teams_delete",
+	"api_jobs_delete",
+	# Credential management
+	"api_credentials_create", "api_credentials_update",
+	"api_credentials_partial_update",
+	# User/org admin
+	"api_users_create", "api_users_update",
+	"api_organizations_create", "api_organizations_update",
+	# System settings
+	"api_settings_update", "api_settings_partial_update",
+	"api_settings_delete", "api_config_create", "api_config_delete",
+	# Job cancellation (read-only AI shouldn't stop running jobs)
+	"api_jobs_cancel_create",
 }
 
 # ---------------------------------------------------------------------------
@@ -130,39 +130,45 @@ blocked_tools := {
 
 default risk_level := "high"
 
-risk_level := "read_only" if { input.tool in read_only_tools }
+risk_level := "read_only" if input.tool in read_only_tools
 
-risk_level := "blocked" if { input.tool in blocked_tools }
+risk_level := "blocked" if input.tool in blocked_tools
 
+# Match "AAC" rather than "AAC_": the estate uses BOTH conventions and the
+# underscore-only form missed two thirds of them. On the reference controller,
+# 98 templates are named "AAC - <thing>" and 50 "AAC_<thing>" — the space-dash
+# form includes the whole NERC-CIP demo set (Collate, Capture Baseline, Check
+# Drift), so launching them fell through to the default-deny and the agent could
+# not do ordinary work.
 risk_level := "low" if {
-    input.tool in {"run_job", "api_job_templates_launch_create"}
-    name := _registered_name(_template_id)
-    startswith(name, "AAC_")
+	input.tool in {"run_job", "api_job_templates_launch_create"}
+	name := _registered_name(_template_id)
+	startswith(name, "AAC")
 }
 
 risk_level := "low" if {
-    input.tool in {"run_job", "api_job_templates_launch_create"}
-    template_id := _template_id
-    template_id in approved_template_ids
+	input.tool in {"run_job", "api_job_templates_launch_create"}
+	template_id := _template_id
+	template_id in approved_template_ids
 }
 
 risk_level := "medium" if {
-    input.tool in {"sync_project", "api_projects_update_create"}
+	input.tool in {"sync_project", "api_projects_update_create"}
 }
 
 # Demo/setup scaffold operations — allowed but logged
 risk_level := "medium" if {
-    input.tool in {
-        "api_job_templates_create",
-        "api_job_templates_credentials_create",
-        "api_job_templates_survey_spec_create",
-        "api_workflow_job_templates_create",
-        "api_workflow_job_template_nodes_create",
-        "api_workflow_job_template_nodes_success_nodes_create",
-        "api_workflow_job_template_nodes_failure_nodes_create",
-        "api_workflow_job_template_nodes_always_nodes_create",
-        "api_workflow_job_templates_launch_create",
-    }
+	input.tool in {
+		"api_job_templates_create",
+		"api_job_templates_credentials_create",
+		"api_job_templates_survey_spec_create",
+		"api_workflow_job_templates_create",
+		"api_workflow_job_template_nodes_create",
+		"api_workflow_job_template_nodes_success_nodes_create",
+		"api_workflow_job_template_nodes_failure_nodes_create",
+		"api_workflow_job_template_nodes_always_nodes_create",
+		"api_workflow_job_templates_launch_create",
+	}
 }
 
 # ---------------------------------------------------------------------------
@@ -171,11 +177,11 @@ risk_level := "medium" if {
 
 default allow := false
 
-allow if { risk_level == "read_only" }
+allow if risk_level == "read_only"
 
-allow if { risk_level == "low" }
+allow if risk_level == "low"
 
-allow if { risk_level == "medium" }
+allow if risk_level == "medium"
 
 # Blocked and high/unknown risk → deny
 
@@ -183,61 +189,68 @@ allow if { risk_level == "medium" }
 # Decision output
 # ---------------------------------------------------------------------------
 
-decision := "ALLOW" if { allow }
-decision := "DENY" if { not allow }
+decision := "ALLOW" if allow
+decision := "DENY" if not allow
+
+# `response` is an object literal: if any field is undefined the WHOLE object is
+# undefined and OPA returns {} to the MCP server. A default guarantees `reason`
+# always resolves, so a missed rule degrades to a vague message instead of
+# silently voiding the decision. This bit us when risk_level was broadened to
+# "AAC" but this rule still required "AAC_".
+default reason := "No specific rule matched — see risk_level for the decision basis"
 
 reason := "Read-only operation — allowed" if {
-    allow
-    risk_level == "read_only"
+	allow
+	risk_level == "read_only"
 }
 
 reason := msg if {
-    allow
-    risk_level == "low"
-    tid := _template_id
-    name := _registered_name(tid)
-    startswith(name, "AAC_")
-    msg := sprintf("Job launch approved — '%v' (id: %v) is a registered AAC template", [name, tid])
+	allow
+	risk_level == "low"
+	tid := _template_id
+	name := _registered_name(tid)
+	startswith(name, "AAC")
+	msg := sprintf("Job launch approved — '%v' (id: %v) is a registered AAC template", [name, tid])
 }
 
 reason := msg if {
-    allow
-    risk_level == "low"
-    tid := _template_id
-    not _has_registered_name(tid)
-    msg := sprintf("Job launch approved — template %v is in the legacy ID allowlist", [tid])
+	allow
+	risk_level == "low"
+	tid := _template_id
+	not _has_registered_name(tid)
+	msg := sprintf("Job launch approved — template %v is in the legacy ID allowlist", [tid])
 }
 
 reason := "Project sync — allowed with logging" if {
-    allow
-    risk_level == "medium"
-    input.tool in {"sync_project", "api_projects_update_create"}
+	allow
+	risk_level == "medium"
+	input.tool in {"sync_project", "api_projects_update_create"}
 }
 
 reason := "Demo scaffold operation — allowed with logging" if {
-    allow
-    risk_level == "medium"
-    not input.tool in {"sync_project", "api_projects_update_create"}
+	allow
+	risk_level == "medium"
+	not input.tool in {"sync_project", "api_projects_update_create"}
 }
 
 reason := msg if {
-    not allow
-    risk_level == "blocked"
-    msg := sprintf("Tool '%v' is blocked — destructive or privileged operations are not permitted for AI agents", [input.tool])
+	not allow
+	risk_level == "blocked"
+	msg := sprintf("Tool '%v' is blocked — destructive or privileged operations are not permitted for AI agents", [input.tool])
 }
 
 reason := msg if {
-    not allow
-    risk_level == "low"
-    tid := _template_id
-    not tid in approved_template_ids
-    msg := sprintf("Job launch denied — template %v is not in the compliance assessment allowlist", [tid])
+	not allow
+	risk_level == "low"
+	tid := _template_id
+	not tid in approved_template_ids
+	msg := sprintf("Job launch denied — template %v is not in the compliance assessment allowlist", [tid])
 }
 
 reason := msg if {
-    not allow
-    risk_level == "high"
-    msg := sprintf("Tool '%v' has no explicit approval rule — defaulting to DENY (unknown risk)", [object.get(input, ["tool"], "unknown")])
+	not allow
+	risk_level == "high"
+	msg := sprintf("Tool '%v' has no explicit approval rule — defaulting to DENY (unknown risk)", [object.get(input, ["tool"], "unknown")])
 }
 
 # ---------------------------------------------------------------------------
@@ -246,17 +259,17 @@ reason := msg if {
 
 # Coerce to number — MCP passes path params as strings (e.g. "26"), but
 # approved_template_ids contains integers; to_number handles both cases.
-_template_id := v if { v := to_number(input.arguments.template_id) }
-_template_id := v if { v := to_number(input.arguments.id) }
+_template_id := v if v := to_number(input.arguments.template_id)
+_template_id := v if v := to_number(input.arguments.id)
 
 # ---------------------------------------------------------------------------
 # Full response object (queried by MCP server)
 # ---------------------------------------------------------------------------
 
 response := {
-    "allow":      allow,
-    "decision":   decision,
-    "risk_level": risk_level,
-    "reason":     reason,
-    "tool":       object.get(input, ["tool"], ""),
+	"allow": allow,
+	"decision": decision,
+	"risk_level": risk_level,
+	"reason": reason,
+	"tool": object.get(input, ["tool"], ""),
 }

--- a/governance/mcp/tests/test_mcp_governance_smoke.rego
+++ b/governance/mcp/tests/test_mcp_governance_smoke.rego
@@ -14,3 +14,67 @@ test_report_wellformed_on_empty_input if {
 	count(result) > 0
 	is_string(result.decision)
 }
+
+# ---------------------------------------------------------------------------
+# Registry-based approval (added 2026-08-01)
+#
+# The estate names templates BOTH "AAC_<thing>" and "AAC - <thing>". The rule
+# originally matched only "AAC_", which missed 98 of 148 AAC templates on the
+# reference controller — including the whole NERC-CIP demo set — so ordinary
+# work fell through to the default-deny.
+# ---------------------------------------------------------------------------
+
+# Scope the override to the subtree. `with data as {...}` would replace the
+# whole data document — including this test package — and every test then
+# becomes mutually recursive (rego_recursion_error).
+_registry := {"controller": {
+	"99": "AAC_GoldenImage_Check",
+	"212": "AAC - Collate OCP NERC-CIP (Compliance Operator)",
+	"777": "Some Unmanaged Template",
+}}
+
+_launch(id) := {
+	"tool": "api_job_templates_launch_create",
+	"arguments": {"id": id},
+	"agent": "claude",
+}
+
+test_underscore_named_template_allowed if {
+	r := mcp.response with input as _launch(99) with data.aac.templates as _registry
+	r.allow
+	r.risk_level == "low"
+}
+
+# The regression this guards: space-dash naming must be approved too.
+test_space_dash_named_template_allowed if {
+	r := mcp.response with input as _launch(212) with data.aac.templates as _registry
+	r.allow
+	r.risk_level == "low"
+}
+
+test_unregistered_template_denied if {
+	r := mcp.response with input as _launch(777) with data.aac.templates as _registry
+	not r.allow
+	r.risk_level == "high"
+}
+
+# `response` is an object literal — one undefined field collapses the whole
+# object and OPA hands the MCP server nothing. This is what happened when
+# risk_level was broadened to "AAC" while the reason rule still required "AAC_".
+test_response_never_collapses_to_undefined if {
+	every id in [99, 212, 777] {
+		r := mcp.response with input as _launch(id) with data.aac.templates as _registry
+		is_boolean(r.allow)
+		is_string(r.decision)
+		is_string(r.risk_level)
+		is_string(r.reason)
+	}
+}
+
+test_destructive_still_blocked if {
+	every t in ["api_users_delete", "api_credentials_create"] {
+		r := mcp.response with input as {"tool": t, "agent": "claude"} with data.aac.templates as _registry
+		not r.allow
+		r.risk_level == "blocked"
+	}
+}


### PR DESCRIPTION
**Goal: show governance without blocking work.** Today the policy blocks ordinary work, so governance can't be turned on at all.

## The gap

The registry approval rule matched only `AAC_<thing>`. The estate uses **both** conventions, and the underscore form is the *minority*:

| naming | count | matched? |
|---|---|---|
| `AAC - <thing>` | **98** | ❌ |
| `AAC_<thing>` | 50 | ✅ |
| non-AAC | 48 | ❌ |

The space-dash form covers the **entire NERC-CIP demo set** — Collate (212), Capture Baseline (213), Check Drift (214) — so launching any of them fell to the default-deny.

## Broadening the prefix alone would have shipped a worse bug

Changing only `risk_level` produced this for a space-dash template:

```
allow      -> true
decision   -> ALLOW
risk_level -> low
reason     -> (undefined)
```

`response` is an **object literal**, so one undefined field collapses the whole object — OPA returns nothing and the MCP server gets no decision at all. The `reason` rule still required `AAC_`.

Caught by evaluating the fields individually rather than trusting the aggregate `response`. Both rules are now fixed, plus a **`default reason`** so a missed rule degrades to a vague message instead of silently voiding the decision.

## Behaviour after — governance visible, work unblocked

```
AAC_GoldenImage_Check (99)                 ALLOW  low
AAC - Collate OCP NERC-CIP (212)           ALLOW  low
AAC - Check OCP NERC-CIP Drift (214)       ALLOW  low
unregistered template (777)                DENY   high
api_users_delete                           DENY   blocked
api_credentials_create                     DENY   blocked
```

Every call still produces a logged ALLOW/DENY with a risk level and a human-readable reason — so governance is demonstrable — while the operations we actually run are approved.

## Tests — `PASS: 6/6`

Five new: both naming conventions approved, unregistered denied, destructive still blocked, and an explicit test that `response` never collapses to undefined.

**Test note worth keeping:** the fixtures override `data.aac.templates`, **not** `data`. `with data as {...}` replaces the entire document including the test package, making every test mutually recursive — the same trap as `object.get(data, ...)` in `enforcement/aap`.

## Still required before governance can be enabled

`data.aac.templates` is **empty (`{}`)** on the reference controller — the name registry has never been populated there, so the approval path has no data to match against. A sync playbook follows in the compliance repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)