### PR TITLE
fix(cis): make every registered CIS framework key resolve instead of returning {}

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,8 @@ Consumers pull this repo as a git submodule at a pinned commit. Today there are 
 ```
 benchmarks/                    Per-platform configuration baselines
 ├── cis/                       CIS Benchmarks (200+ files)
-│   ├── os/linux/redhat/       RHEL 8/9/10 by section
+│   ├── rhel_9/ rhel_8/        RHEL by version, modules per section
+│   │   rhel_10/               (os/linux/ holds only legacy/simple variants)
 │   ├── os/linux/ubuntu/       Ubuntu 20/22/24
 │   ├── os/windows/            Windows Server 2019/2022
 │   ├── cloud/                 AWS / Azure / GCP foundations
@@ -63,7 +64,7 @@ threat_detection/              Behavioral threat patterns
 └── crypto_mining/             Crypto-miner indicators
 ```
 
-Headline count: **510 policy files** (587 including tests) across the above directories.
+Headline count: **515 policy files** (595 including tests) across the above directories.
 Count it, never quote it — `git ls-tree -r HEAD --name-only | grep '\.rego$' | grep -vcE '(^|/)(test_|.*_test\.rego$)'` — the number drifts with every merge.
 
 ## Skill: Rego v1 syntax (MANDATORY)
@@ -118,11 +119,11 @@ compliance_report := {
 
 ```bash
 # Test a single policy + its tests
-opa test benchmarks/cis/os/linux/redhat/pam_validation.rego \
-         benchmarks/cis/os/linux/redhat/tests/test_pam.rego -v
+opa test benchmarks/cis/rhel_9/pam_validation.rego \
+         benchmarks/cis/rhel_9/tests/test_pam.rego -v
 
 # Test an entire framework
-opa test benchmarks/cis/os/linux/redhat/ -v --coverage
+opa test benchmarks/cis/rhel_9/ -v --coverage
 
 # Full repo (ignore the .github/ directory that lives inside the
 # benchmarks tree — opa tries to parse the YAML otherwise)

--- a/benchmarks/cis/_framework_key_tests/test_framework_key_bridges.rego
+++ b/benchmarks/cis/_framework_key_tests/test_framework_key_bridges.rego
@@ -1,0 +1,101 @@
+package cis_framework_key_bridges_test
+
+# Regression guard for the Generic Framework Assessment contract.
+#
+# Every key registered in opa_framework_map (compliance repo,
+# ansible/vars/site_config.yml) is queried by the playbook as
+#   /v1/data/<key>/main/compliance_report
+#
+# If that path is undefined, or if any field inside the report object is
+# undefined, OPA returns {} — the playbook stores a silently empty result
+# instead of failing. These tests assert each bridge produces a populated,
+# internally consistent report on EMPTY input, which is the case that
+# previously collapsed to {}.
+
+import rego.v1
+
+# --- report is populated (not {} and not undefined) -------------------------
+
+test_rhel9_report_populated if { count(data.cis_rhel9.main.compliance_report) > 0 }
+
+test_rhel8_report_populated if { count(data.cis_rhel8.main.compliance_report) > 0 }
+
+test_rocky8_report_populated if { count(data.cis_rocky_linux_8.main.compliance_report) > 0 }
+
+test_rocky9_report_populated if { count(data.cis_rocky_linux_9.main.compliance_report) > 0 }
+
+test_amazon2023_report_populated if { count(data.cis_amazon_linux_2023.main.compliance_report) > 0 }
+
+test_windows2022_report_populated if { count(data.cis_windows_2022.main.compliance_report) > 0 }
+
+test_windows2019_report_populated if { count(data.cis_windows_2019.main.compliance_report) > 0 }
+
+test_ubuntu2204_report_populated if { count(data.cis_ubuntu_2204.main.compliance_report) > 0 }
+
+test_ubuntu2004_report_populated if { count(data.cis_ubuntu_2004.main.compliance_report) > 0 }
+
+test_ubuntu2404_report_populated if { count(data.cis_ubuntu_2404.main.compliance_report) > 0 }
+
+test_debian11_report_populated if { count(data.cis_debian_11.main.compliance_report) > 0 }
+
+test_vyos_report_populated if { count(data.cis_vyos.main.compliance_report) > 0 }
+
+test_pfsense_report_populated if { count(data.cis_pfsense.main.compliance_report) > 0 }
+
+test_gcp_report_populated if { count(data.cis_gcp.main.compliance_report) > 0 }
+
+# --- counts are internally consistent and non-negative ----------------------
+
+reports := [
+	data.cis_rhel9.main.compliance_report,
+	data.cis_rhel8.main.compliance_report,
+	data.cis_rocky_linux_8.main.compliance_report,
+	data.cis_rocky_linux_9.main.compliance_report,
+	data.cis_amazon_linux_2023.main.compliance_report,
+	data.cis_windows_2022.main.compliance_report,
+	data.cis_windows_2019.main.compliance_report,
+	data.cis_ubuntu_2204.main.compliance_report,
+	data.cis_ubuntu_2004.main.compliance_report,
+	data.cis_ubuntu_2404.main.compliance_report,
+	data.cis_debian_11.main.compliance_report,
+	data.cis_vyos.main.compliance_report,
+	data.cis_pfsense.main.compliance_report,
+	data.cis_gcp.main.compliance_report,
+]
+
+test_no_negative_counts if {
+	every r in reports {
+		r.passed_controls >= 0
+		r.failed_controls >= 0
+		r.total_controls > 0
+	}
+}
+
+test_percentage_in_range if {
+	every r in reports {
+		r.compliance_percentage >= 0
+		r.compliance_percentage <= 100
+	}
+}
+
+test_required_fields_present if {
+	every r in reports {
+		is_string(r.framework)
+		is_boolean(r.compliant)
+		is_array(r.violations)
+	}
+}
+
+# --- fail-closed: empty input must never report full compliance -------------
+#
+# Guards the cis_al2023 -> cis_amazon_linux_2023 import-prefix bug, where the
+# orchestrator's imports pointed at a package that does not exist, so
+# all_violations was always empty and the benchmark reported 100% on any input.
+
+test_empty_input_is_not_compliant if {
+	every r in reports { r.compliant == false }
+}
+
+test_amazon2023_detects_violations_on_empty_input if {
+	data.cis_amazon_linux_2023.main.compliance_report.failed_controls > 0
+}

--- a/benchmarks/cis/amazon_linux_2023/cis_al20239_complete.rego
+++ b/benchmarks/cis/amazon_linux_2023/cis_al20239_complete.rego
@@ -6,24 +6,29 @@ package cis_amazon_linux_2023
 
 import rego.v1
 
-import data.cis_al2023.filesystem
-import data.cis_al2023.logging
-import data.cis_al2023.file_permissions
-import data.cis_al2023.services
-import data.cis_al2023.network
-import data.cis_al2023.ssh
-import data.cis_al2023.auditd
-import data.cis_al2023.pam
-import data.cis_al2023.sudo
-import data.cis_al2023.selinux
-import data.cis_al2023.user_group
-import data.cis_al2023.cron
-import data.cis_al2023.boot_security
-import data.cis_al2023.initial_setup
+import data.cis_amazon_linux_2023.filesystem
+import data.cis_amazon_linux_2023.logging
+import data.cis_amazon_linux_2023.file_permissions
+import data.cis_amazon_linux_2023.services
+import data.cis_amazon_linux_2023.network
+import data.cis_amazon_linux_2023.ssh
+import data.cis_amazon_linux_2023.auditd
+import data.cis_amazon_linux_2023.pam
+import data.cis_amazon_linux_2023.sudo
+import data.cis_amazon_linux_2023.selinux
+import data.cis_amazon_linux_2023.user_group
+import data.cis_amazon_linux_2023.cron
+import data.cis_amazon_linux_2023.boot_security
+import data.cis_amazon_linux_2023.initial_setup
 
 # =============================================================================
 # MAIN COMPLIANCE RULE
 # =============================================================================
+
+# Required by library rule #5: without a default, a never-firing rule is
+# undefined (not false), and an undefined field collapses the enclosing
+# object to {} at the OPA endpoint.
+default compliant := false
 
 compliant if {
 	filesystem.compliant

--- a/benchmarks/cis/amazon_linux_2023/cis_amazon_linux_2023_main.rego
+++ b/benchmarks/cis/amazon_linux_2023/cis_amazon_linux_2023_main.rego
@@ -1,6 +1,6 @@
-package cis_rhel9.main
+package cis_amazon_linux_2023.main
 
-# Bridge: expose cis_rhel9 under the /v1/data/<framework>/main/compliance_report
+# Bridge: expose cis_amazon_linux_2023 under the /v1/data/<framework>/main/compliance_report
 # convention consumed by the Generic Framework Assessment playbook
 # (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
 #
@@ -17,7 +17,7 @@ package cis_rhel9.main
 #    would overstate coverage. See "controls_basis" in the report.
 
 import rego.v1
-import data.cis_rhel9 as bench
+import data.cis_amazon_linux_2023 as bench
 
 default _compliant := false
 
@@ -35,7 +35,7 @@ default _sections := {}
 
 _sections := bench.section_compliance
 
-_total_controls := 224
+_total_controls := 195
 
 _failed := count(_violations)
 
@@ -47,8 +47,8 @@ default _percentage := 0
 _percentage := round((_passed * 100000) / _total_controls) / 1000 if _total_controls > 0
 
 compliance_report := {
-	"framework": "cis_rhel9",
-	"benchmark": "CIS Red Hat Enterprise Linux 9 Benchmark v2.0.0",
+	"framework": "cis_amazon_linux_2023",
+	"benchmark": "CIS Amazon Linux 2023 Benchmark v2.0.0",
 	"version": "v2.0.0",
 	"total_controls": _total_controls,
 	"controls_basis": "distinct CIS control IDs evaluated by this policy set",

--- a/benchmarks/cis/cloud/gcp/cis_gcp_main.rego
+++ b/benchmarks/cis/cloud/gcp/cis_gcp_main.rego
@@ -383,25 +383,58 @@ violations contains msg if {
 
 # ── Compliance Report ────────────────────────────────────────────────────────
 
+# Optional identity fields are read through defaulted helpers. Referencing
+# input.* directly inside the object literal made the entire report undefined
+# whenever the caller omitted them (library rule #5) — the endpoint returned
+# nothing at all rather than a report with blank metadata.
+
+default _entity_name := ""
+
+_entity_name := input.entity_name
+
+default _project_id := ""
+
+_project_id := input.gcp_project_id
+
+default _assessed_at := ""
+
+_assessed_at := input.assessment_date
+
+_total_controls := 57
+
+# Sets are not arrays; the report contract publishes arrays so downstream
+# JSON consumers get a stable type.
+_violations := [v | some v in violations]
+
+_failed := count(_violations)
+
+# Clamp: a mis-declared total must never yield a negative passed count.
+_passed := max([0, _total_controls - _failed])
+
+_percentage := round((_passed * 100000) / _total_controls) / 1000
+
 compliance_report := {
-    "framework":      "CIS Google Cloud Platform Foundation Benchmark",
-    "version":        "v2.0.0",
-    "published":      "March 2023",
-    "entity_name":    input.entity_name,
-    "project_id":     input.gcp_project_id,
-    "assessed_at":    input.assessment_date,
-    "compliant":      compliant,
-    "total_controls": 55,
-    "violations":     violations,
-    "violation_count": count(violations),
-    "section_summary": {
-        "iam":              [v | some v in violations; contains(v, "CIS GCP 1.")],
-        "logging":          [v | some v in violations; contains(v, "CIS GCP 2.")],
-        "networking":       [v | some v in violations; contains(v, "CIS GCP 3.")],
-        "virtual_machines": [v | some v in violations; contains(v, "CIS GCP 4.")],
-        "storage":          [v | some v in violations; contains(v, "CIS GCP 5.")],
-        "cloud_sql":        [v | some v in violations; contains(v, "CIS GCP 6.")],
-        "bigquery":         [v | some v in violations; contains(v, "CIS GCP 7.")],
-        "gke":              [v | some v in violations; contains(v, "CIS GCP 8.")],
-    },
+	"framework": "cis_gcp",
+	"benchmark": "CIS Google Cloud Platform Foundation Benchmark",
+	"version": "v4.0.0",
+	"entity_name": _entity_name,
+	"project_id": _project_id,
+	"assessed_at": _assessed_at,
+	"compliant": compliant,
+	"total_controls": _total_controls,
+	"passed_controls": _passed,
+	"failed_controls": _failed,
+	"compliance_percentage": _percentage,
+	"violations": _violations,
+	"violation_count": _failed,
+	"section_results": {
+		"iam": [v | some v in _violations; contains(v, "CIS GCP 1.")],
+		"logging": [v | some v in _violations; contains(v, "CIS GCP 2.")],
+		"networking": [v | some v in _violations; contains(v, "CIS GCP 3.")],
+		"virtual_machines": [v | some v in _violations; contains(v, "CIS GCP 4.")],
+		"storage": [v | some v in _violations; contains(v, "CIS GCP 5.")],
+		"cloud_sql": [v | some v in _violations; contains(v, "CIS GCP 6.")],
+		"bigquery": [v | some v in _violations; contains(v, "CIS GCP 7.")],
+		"gke": [v | some v in _violations; contains(v, "CIS GCP 8.")],
+	},
 }

--- a/benchmarks/cis/debian_11/cis_debian_11_main.rego
+++ b/benchmarks/cis/debian_11/cis_debian_11_main.rego
@@ -1,6 +1,6 @@
-package cis_rhel9.main
+package cis_debian_11.main
 
-# Bridge: expose cis_rhel9 under the /v1/data/<framework>/main/compliance_report
+# Bridge: expose cis_debian_11 under the /v1/data/<framework>/main/compliance_report
 # convention consumed by the Generic Framework Assessment playbook
 # (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
 #
@@ -17,7 +17,7 @@ package cis_rhel9.main
 #    would overstate coverage. See "controls_basis" in the report.
 
 import rego.v1
-import data.cis_rhel9 as bench
+import data.cis_debian_11 as bench
 
 default _compliant := false
 
@@ -29,13 +29,13 @@ _section_percentage := bench.compliance_percentage
 
 default _violations := []
 
-_violations := [v | some v in bench.all_violations]
+_violations := [v | some v in bench.violations]
 
 default _sections := {}
 
-_sections := bench.section_compliance
+_sections := bench.module_status
 
-_total_controls := 224
+_total_controls := 163
 
 _failed := count(_violations)
 
@@ -47,8 +47,8 @@ default _percentage := 0
 _percentage := round((_passed * 100000) / _total_controls) / 1000 if _total_controls > 0
 
 compliance_report := {
-	"framework": "cis_rhel9",
-	"benchmark": "CIS Red Hat Enterprise Linux 9 Benchmark v2.0.0",
+	"framework": "cis_debian_11",
+	"benchmark": "CIS Debian Linux 11 Benchmark v2.0.0",
 	"version": "v2.0.0",
 	"total_controls": _total_controls,
 	"controls_basis": "distinct CIS control IDs evaluated by this policy set",

--- a/benchmarks/cis/network_devices/pfsense/cis_pfsense_main.rego
+++ b/benchmarks/cis/network_devices/pfsense/cis_pfsense_main.rego
@@ -1,6 +1,6 @@
-package cis_rhel9.main
+package cis_pfsense.main
 
-# Bridge: expose cis_rhel9 under the /v1/data/<framework>/main/compliance_report
+# Bridge: expose cis_pfsense under the /v1/data/<framework>/main/compliance_report
 # convention consumed by the Generic Framework Assessment playbook
 # (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
 #
@@ -17,7 +17,7 @@ package cis_rhel9.main
 #    would overstate coverage. See "controls_basis" in the report.
 
 import rego.v1
-import data.cis_rhel9 as bench
+import data.cis_pfsense as bench
 
 default _compliant := false
 
@@ -29,13 +29,13 @@ _section_percentage := bench.compliance_percentage
 
 default _violations := []
 
-_violations := [v | some v in bench.all_violations]
+_violations := [v | some v in bench.violations]
 
 default _sections := {}
 
-_sections := bench.section_compliance
+_sections := bench.compliance_assessment
 
-_total_controls := 224
+_total_controls := 22
 
 _failed := count(_violations)
 
@@ -47,11 +47,11 @@ default _percentage := 0
 _percentage := round((_passed * 100000) / _total_controls) / 1000 if _total_controls > 0
 
 compliance_report := {
-	"framework": "cis_rhel9",
-	"benchmark": "CIS Red Hat Enterprise Linux 9 Benchmark v2.0.0",
-	"version": "v2.0.0",
+	"framework": "cis_pfsense",
+	"benchmark": "CIS pfSense Benchmark v1.0.0",
+	"version": "v1.0.0",
 	"total_controls": _total_controls,
-	"controls_basis": "distinct CIS control IDs evaluated by this policy set",
+	"controls_basis": "controls implemented in this device policy set",
 	"passed_controls": _passed,
 	"failed_controls": _failed,
 	"compliance_percentage": _percentage,

--- a/benchmarks/cis/network_devices/vyos/cis_vyos_main.rego
+++ b/benchmarks/cis/network_devices/vyos/cis_vyos_main.rego
@@ -1,6 +1,6 @@
-package cis_rhel9.main
+package cis_vyos.main
 
-# Bridge: expose cis_rhel9 under the /v1/data/<framework>/main/compliance_report
+# Bridge: expose cis_vyos under the /v1/data/<framework>/main/compliance_report
 # convention consumed by the Generic Framework Assessment playbook
 # (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
 #
@@ -17,7 +17,7 @@ package cis_rhel9.main
 #    would overstate coverage. See "controls_basis" in the report.
 
 import rego.v1
-import data.cis_rhel9 as bench
+import data.cis_vyos as bench
 
 default _compliant := false
 
@@ -29,13 +29,13 @@ _section_percentage := bench.compliance_percentage
 
 default _violations := []
 
-_violations := [v | some v in bench.all_violations]
+_violations := [v | some v in bench.violations]
 
 default _sections := {}
 
-_sections := bench.section_compliance
+_sections := bench.compliance_assessment
 
-_total_controls := 224
+_total_controls := 20
 
 _failed := count(_violations)
 
@@ -47,11 +47,11 @@ default _percentage := 0
 _percentage := round((_passed * 100000) / _total_controls) / 1000 if _total_controls > 0
 
 compliance_report := {
-	"framework": "cis_rhel9",
-	"benchmark": "CIS Red Hat Enterprise Linux 9 Benchmark v2.0.0",
-	"version": "v2.0.0",
+	"framework": "cis_vyos",
+	"benchmark": "CIS VyOS Benchmark v1.0.1",
+	"version": "v1.0.1",
 	"total_controls": _total_controls,
-	"controls_basis": "distinct CIS control IDs evaluated by this policy set",
+	"controls_basis": "controls implemented in this device policy set",
 	"passed_controls": _passed,
 	"failed_controls": _failed,
 	"compliance_percentage": _percentage,

--- a/benchmarks/cis/rhel_8/cis_rhel8_complete.rego
+++ b/benchmarks/cis/rhel_8/cis_rhel8_complete.rego
@@ -29,6 +29,11 @@ import data.cis_rhel8.l2
 # MAIN COMPLIANCE RULE
 # =============================================================================
 
+# Required by library rule #5: without a default, a never-firing rule is
+# undefined (not false), and an undefined field collapses the enclosing
+# object to {} at the OPA endpoint.
+default compliant := false
+
 compliant if {
 	filesystem.compliant
 	initial_setup.compliant

--- a/benchmarks/cis/rhel_8/cis_rhel8_main.rego
+++ b/benchmarks/cis/rhel_8/cis_rhel8_main.rego
@@ -1,6 +1,6 @@
-package cis_rhel9.main
+package cis_rhel8.main
 
-# Bridge: expose cis_rhel9 under the /v1/data/<framework>/main/compliance_report
+# Bridge: expose cis_rhel8 under the /v1/data/<framework>/main/compliance_report
 # convention consumed by the Generic Framework Assessment playbook
 # (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
 #
@@ -17,7 +17,7 @@ package cis_rhel9.main
 #    would overstate coverage. See "controls_basis" in the report.
 
 import rego.v1
-import data.cis_rhel9 as bench
+import data.cis_rhel8 as bench
 
 default _compliant := false
 
@@ -35,7 +35,7 @@ default _sections := {}
 
 _sections := bench.section_compliance
 
-_total_controls := 224
+_total_controls := 195
 
 _failed := count(_violations)
 
@@ -47,9 +47,9 @@ default _percentage := 0
 _percentage := round((_passed * 100000) / _total_controls) / 1000 if _total_controls > 0
 
 compliance_report := {
-	"framework": "cis_rhel9",
-	"benchmark": "CIS Red Hat Enterprise Linux 9 Benchmark v2.0.0",
-	"version": "v2.0.0",
+	"framework": "cis_rhel8",
+	"benchmark": "CIS Red Hat Enterprise Linux 8 Benchmark v4.0.0",
+	"version": "v4.0.0",
 	"total_controls": _total_controls,
 	"controls_basis": "distinct CIS control IDs evaluated by this policy set",
 	"passed_controls": _passed,

--- a/benchmarks/cis/rhel_9/cis_rhel9_complete.rego
+++ b/benchmarks/cis/rhel_9/cis_rhel9_complete.rego
@@ -36,6 +36,11 @@ import data.cis_rhel9.l2
 # MAIN COMPLIANCE RULE
 # =============================================================================
 
+# Required by library rule #5: without a default, a never-firing rule is
+# undefined (not false), and an undefined field collapses the enclosing
+# object to {} at the OPA endpoint.
+default compliant := false
+
 compliant if {
 	filesystem.compliant
 	logging.compliant

--- a/benchmarks/cis/rocky_linux_8/cis_rocky_linux_8_complete.rego
+++ b/benchmarks/cis/rocky_linux_8/cis_rocky_linux_8_complete.rego
@@ -25,6 +25,11 @@ import data.cis_rocky_linux_8.file_permissions
 # MAIN COMPLIANCE RULE
 # =============================================================================
 
+# Required by library rule #5: without a default, a never-firing rule is
+# undefined (not false), and an undefined field collapses the enclosing
+# object to {} at the OPA endpoint.
+default compliant := false
+
 compliant if {
 	filesystem.compliant
 	initial_setup.compliant

--- a/benchmarks/cis/rocky_linux_8/cis_rocky_linux_8_main.rego
+++ b/benchmarks/cis/rocky_linux_8/cis_rocky_linux_8_main.rego
@@ -1,6 +1,6 @@
-package cis_rhel9.main
+package cis_rocky_linux_8.main
 
-# Bridge: expose cis_rhel9 under the /v1/data/<framework>/main/compliance_report
+# Bridge: expose cis_rocky_linux_8 under the /v1/data/<framework>/main/compliance_report
 # convention consumed by the Generic Framework Assessment playbook
 # (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
 #
@@ -17,7 +17,7 @@ package cis_rhel9.main
 #    would overstate coverage. See "controls_basis" in the report.
 
 import rego.v1
-import data.cis_rhel9 as bench
+import data.cis_rocky_linux_8 as bench
 
 default _compliant := false
 
@@ -35,7 +35,7 @@ default _sections := {}
 
 _sections := bench.section_compliance
 
-_total_controls := 224
+_total_controls := 166
 
 _failed := count(_violations)
 
@@ -47,9 +47,9 @@ default _percentage := 0
 _percentage := round((_passed * 100000) / _total_controls) / 1000 if _total_controls > 0
 
 compliance_report := {
-	"framework": "cis_rhel9",
-	"benchmark": "CIS Red Hat Enterprise Linux 9 Benchmark v2.0.0",
-	"version": "v2.0.0",
+	"framework": "cis_rocky_linux_8",
+	"benchmark": "CIS Rocky Linux 8 Benchmark v3.0.0",
+	"version": "v3.0.0",
 	"total_controls": _total_controls,
 	"controls_basis": "distinct CIS control IDs evaluated by this policy set",
 	"passed_controls": _passed,

--- a/benchmarks/cis/rocky_linux_9/cis_rocky_linux_9_complete.rego
+++ b/benchmarks/cis/rocky_linux_9/cis_rocky_linux_9_complete.rego
@@ -25,6 +25,11 @@ import data.cis_rocky_linux_9.file_permissions
 # MAIN COMPLIANCE RULE
 # =============================================================================
 
+# Required by library rule #5: without a default, a never-firing rule is
+# undefined (not false), and an undefined field collapses the enclosing
+# object to {} at the OPA endpoint.
+default compliant := false
+
 compliant if {
 	filesystem.compliant
 	initial_setup.compliant

--- a/benchmarks/cis/rocky_linux_9/cis_rocky_linux_9_main.rego
+++ b/benchmarks/cis/rocky_linux_9/cis_rocky_linux_9_main.rego
@@ -1,6 +1,6 @@
-package cis_rhel9.main
+package cis_rocky_linux_9.main
 
-# Bridge: expose cis_rhel9 under the /v1/data/<framework>/main/compliance_report
+# Bridge: expose cis_rocky_linux_9 under the /v1/data/<framework>/main/compliance_report
 # convention consumed by the Generic Framework Assessment playbook
 # (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
 #
@@ -17,7 +17,7 @@ package cis_rhel9.main
 #    would overstate coverage. See "controls_basis" in the report.
 
 import rego.v1
-import data.cis_rhel9 as bench
+import data.cis_rocky_linux_9 as bench
 
 default _compliant := false
 
@@ -35,7 +35,7 @@ default _sections := {}
 
 _sections := bench.section_compliance
 
-_total_controls := 224
+_total_controls := 166
 
 _failed := count(_violations)
 
@@ -47,8 +47,8 @@ default _percentage := 0
 _percentage := round((_passed * 100000) / _total_controls) / 1000 if _total_controls > 0
 
 compliance_report := {
-	"framework": "cis_rhel9",
-	"benchmark": "CIS Red Hat Enterprise Linux 9 Benchmark v2.0.0",
+	"framework": "cis_rocky_linux_9",
+	"benchmark": "CIS Rocky Linux 9 Benchmark v2.0.0",
 	"version": "v2.0.0",
 	"total_controls": _total_controls,
 	"controls_basis": "distinct CIS control IDs evaluated by this policy set",

--- a/benchmarks/cis/ubuntu_20_04/cis_ubuntu_2004_main.rego
+++ b/benchmarks/cis/ubuntu_20_04/cis_ubuntu_2004_main.rego
@@ -1,6 +1,6 @@
-package cis_rhel9.main
+package cis_ubuntu_2004.main
 
-# Bridge: expose cis_rhel9 under the /v1/data/<framework>/main/compliance_report
+# Bridge: expose cis_ubuntu_20_04 under the /v1/data/<framework>/main/compliance_report
 # convention consumed by the Generic Framework Assessment playbook
 # (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
 #
@@ -17,7 +17,7 @@ package cis_rhel9.main
 #    would overstate coverage. See "controls_basis" in the report.
 
 import rego.v1
-import data.cis_rhel9 as bench
+import data.cis_ubuntu_20_04 as bench
 
 default _compliant := false
 
@@ -29,13 +29,13 @@ _section_percentage := bench.compliance_percentage
 
 default _violations := []
 
-_violations := [v | some v in bench.all_violations]
+_violations := [v | some v in bench.violations]
 
 default _sections := {}
 
-_sections := bench.section_compliance
+_sections := bench.module_status
 
-_total_controls := 224
+_total_controls := 163
 
 _failed := count(_violations)
 
@@ -47,9 +47,9 @@ default _percentage := 0
 _percentage := round((_passed * 100000) / _total_controls) / 1000 if _total_controls > 0
 
 compliance_report := {
-	"framework": "cis_rhel9",
-	"benchmark": "CIS Red Hat Enterprise Linux 9 Benchmark v2.0.0",
-	"version": "v2.0.0",
+	"framework": "cis_ubuntu_2004",
+	"benchmark": "CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0",
+	"version": "v3.0.0",
 	"total_controls": _total_controls,
 	"controls_basis": "distinct CIS control IDs evaluated by this policy set",
 	"passed_controls": _passed,

--- a/benchmarks/cis/ubuntu_22_04/cis_ubuntu_2204_main.rego
+++ b/benchmarks/cis/ubuntu_22_04/cis_ubuntu_2204_main.rego
@@ -1,6 +1,6 @@
-package cis_rhel9.main
+package cis_ubuntu_2204.main
 
-# Bridge: expose cis_rhel9 under the /v1/data/<framework>/main/compliance_report
+# Bridge: expose cis_ubuntu_22_04 under the /v1/data/<framework>/main/compliance_report
 # convention consumed by the Generic Framework Assessment playbook
 # (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
 #
@@ -17,7 +17,7 @@ package cis_rhel9.main
 #    would overstate coverage. See "controls_basis" in the report.
 
 import rego.v1
-import data.cis_rhel9 as bench
+import data.cis_ubuntu_22_04 as bench
 
 default _compliant := false
 
@@ -29,13 +29,13 @@ _section_percentage := bench.compliance_percentage
 
 default _violations := []
 
-_violations := [v | some v in bench.all_violations]
+_violations := [v | some v in bench.violations]
 
 default _sections := {}
 
-_sections := bench.section_compliance
+_sections := bench.module_status
 
-_total_controls := 224
+_total_controls := 188
 
 _failed := count(_violations)
 
@@ -47,9 +47,9 @@ default _percentage := 0
 _percentage := round((_passed * 100000) / _total_controls) / 1000 if _total_controls > 0
 
 compliance_report := {
-	"framework": "cis_rhel9",
-	"benchmark": "CIS Red Hat Enterprise Linux 9 Benchmark v2.0.0",
-	"version": "v2.0.0",
+	"framework": "cis_ubuntu_2204",
+	"benchmark": "CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0",
+	"version": "v3.0.0",
 	"total_controls": _total_controls,
 	"controls_basis": "distinct CIS control IDs evaluated by this policy set",
 	"passed_controls": _passed,

--- a/benchmarks/cis/ubuntu_24_04/cis_ubuntu_2404_main.rego
+++ b/benchmarks/cis/ubuntu_24_04/cis_ubuntu_2404_main.rego
@@ -1,6 +1,6 @@
-package cis_rhel9.main
+package cis_ubuntu_2404.main
 
-# Bridge: expose cis_rhel9 under the /v1/data/<framework>/main/compliance_report
+# Bridge: expose cis_ubuntu_24_04 under the /v1/data/<framework>/main/compliance_report
 # convention consumed by the Generic Framework Assessment playbook
 # (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
 #
@@ -17,7 +17,7 @@ package cis_rhel9.main
 #    would overstate coverage. See "controls_basis" in the report.
 
 import rego.v1
-import data.cis_rhel9 as bench
+import data.cis_ubuntu_24_04 as bench
 
 default _compliant := false
 
@@ -29,13 +29,13 @@ _section_percentage := bench.compliance_percentage
 
 default _violations := []
 
-_violations := [v | some v in bench.all_violations]
+_violations := [v | some v in bench.violations]
 
 default _sections := {}
 
-_sections := bench.section_compliance
+_sections := bench.module_status
 
-_total_controls := 224
+_total_controls := 188
 
 _failed := count(_violations)
 
@@ -47,9 +47,9 @@ default _percentage := 0
 _percentage := round((_passed * 100000) / _total_controls) / 1000 if _total_controls > 0
 
 compliance_report := {
-	"framework": "cis_rhel9",
-	"benchmark": "CIS Red Hat Enterprise Linux 9 Benchmark v2.0.0",
-	"version": "v2.0.0",
+	"framework": "cis_ubuntu_2404",
+	"benchmark": "CIS Ubuntu Linux 24.04 LTS Benchmark v1.0.0",
+	"version": "v1.0.0",
 	"total_controls": _total_controls,
 	"controls_basis": "distinct CIS control IDs evaluated by this policy set",
 	"passed_controls": _passed,

--- a/benchmarks/cis/windows_server_2019_modular/cis_windows_2019_main.rego
+++ b/benchmarks/cis/windows_server_2019_modular/cis_windows_2019_main.rego
@@ -1,6 +1,6 @@
-package cis_rhel9.main
+package cis_windows_2019.main
 
-# Bridge: expose cis_rhel9 under the /v1/data/<framework>/main/compliance_report
+# Bridge: expose cis_windows_server_2019 under the /v1/data/<framework>/main/compliance_report
 # convention consumed by the Generic Framework Assessment playbook
 # (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
 #
@@ -17,7 +17,7 @@ package cis_rhel9.main
 #    would overstate coverage. See "controls_basis" in the report.
 
 import rego.v1
-import data.cis_rhel9 as bench
+import data.cis_windows_server_2019 as bench
 
 default _compliant := false
 
@@ -35,7 +35,7 @@ default _sections := {}
 
 _sections := bench.section_compliance
 
-_total_controls := 224
+_total_controls := 179
 
 _failed := count(_violations)
 
@@ -47,9 +47,9 @@ default _percentage := 0
 _percentage := round((_passed * 100000) / _total_controls) / 1000 if _total_controls > 0
 
 compliance_report := {
-	"framework": "cis_rhel9",
-	"benchmark": "CIS Red Hat Enterprise Linux 9 Benchmark v2.0.0",
-	"version": "v2.0.0",
+	"framework": "cis_windows_2019",
+	"benchmark": "CIS Microsoft Windows Server 2019 Benchmark v4.0.0",
+	"version": "v4.0.0",
 	"total_controls": _total_controls,
 	"controls_basis": "distinct CIS control IDs evaluated by this policy set",
 	"passed_controls": _passed,

--- a/benchmarks/cis/windows_server_2019_modular/cis_windows_server_2019_complete.rego
+++ b/benchmarks/cis/windows_server_2019_modular/cis_windows_server_2019_complete.rego
@@ -21,6 +21,11 @@ import data.cis_windows_server_2019.bitlocker
 # MAIN COMPLIANCE RULE
 # =============================================================================
 
+# Required by library rule #5: without a default, a never-firing rule is
+# undefined (not false), and an undefined field collapses the enclosing
+# object to {} at the OPA endpoint.
+default compliant := false
+
 compliant if {
 	account_policies.compliant
 	local_policies.compliant

--- a/benchmarks/cis/windows_server_2022_modular/cis_windows_2022_main.rego
+++ b/benchmarks/cis/windows_server_2022_modular/cis_windows_2022_main.rego
@@ -1,6 +1,6 @@
-package cis_rhel9.main
+package cis_windows_2022.main
 
-# Bridge: expose cis_rhel9 under the /v1/data/<framework>/main/compliance_report
+# Bridge: expose cis_windows_server_2022 under the /v1/data/<framework>/main/compliance_report
 # convention consumed by the Generic Framework Assessment playbook
 # (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
 #
@@ -17,7 +17,7 @@ package cis_rhel9.main
 #    would overstate coverage. See "controls_basis" in the report.
 
 import rego.v1
-import data.cis_rhel9 as bench
+import data.cis_windows_server_2022 as bench
 
 default _compliant := false
 
@@ -35,7 +35,7 @@ default _sections := {}
 
 _sections := bench.section_compliance
 
-_total_controls := 224
+_total_controls := 196
 
 _failed := count(_violations)
 
@@ -47,9 +47,9 @@ default _percentage := 0
 _percentage := round((_passed * 100000) / _total_controls) / 1000 if _total_controls > 0
 
 compliance_report := {
-	"framework": "cis_rhel9",
-	"benchmark": "CIS Red Hat Enterprise Linux 9 Benchmark v2.0.0",
-	"version": "v2.0.0",
+	"framework": "cis_windows_2022",
+	"benchmark": "CIS Microsoft Windows Server 2022 Benchmark v5.0.0",
+	"version": "v5.0.0",
 	"total_controls": _total_controls,
 	"controls_basis": "distinct CIS control IDs evaluated by this policy set",
 	"passed_controls": _passed,

--- a/benchmarks/cis/windows_server_2022_modular/cis_windows_server_2022_complete.rego
+++ b/benchmarks/cis/windows_server_2022_modular/cis_windows_server_2022_complete.rego
@@ -25,6 +25,11 @@ import data.cis_windows_server_2022.l2
 # MAIN COMPLIANCE RULE
 # =============================================================================
 
+# Required by library rule #5: without a default, a never-firing rule is
+# undefined (not false), and an undefined field collapses the enclosing
+# object to {} at the OPA endpoint.
+default compliant := false
+
 compliant if {
 	account_policies.compliant
 	local_policies.compliant


### PR DESCRIPTION
## Problem

All 19 `cis_*` keys registered in `opa_framework_map` (compliance repo,
`ansible/vars/site_config.yml`) were unreachable via the Generic Framework
Assessment playbook, which queries
`/v1/data/<framework>/main/compliance_report`.

Proven by `opa eval`, not inferred:

    data.cis_rhel9.main.compliance_report  -> {}
    data.cis_gcp.main.compliance_report    -> undefined

Only two `<key>.main` bridges existed at all, and both were broken:

- `cis_rhel9_main.rego` referenced `passed_controls`, `failed_controls`,
  `section_results` and `violations` — none of which are defined in package
  `cis_rhel9`. One undefined field collapses the whole object literal, so the
  endpoint returned `{}`.
- `cis_gcp_main.rego` read `input.entity_name` / `input.gcp_project_id` /
  `input.assessment_date` directly in the report object, so the report went
  undefined whenever a caller omitted them.

This fails silently: the playbook stores an empty result rather than erroring,
so a launch looks like it succeeded. Same class as the `hipaa` fail-open.

## Fix

Add or repair a `<key>.main` bridge for 14 keys, each sourcing every field
through a defaulted local helper so the report can never collapse to `{}`
(library rule #5). Clamped so a mis-declared total cannot produce negative
counts, and guarded against divide-by-zero.

## Bugs surfaced while doing it

- **Amazon Linux 2023 was fail-open.** `cis_al20239_complete.rego` imported
  `data.cis_al2023.*` but the modules are `package cis_amazon_linux_2023.*`.
  Every import resolved to nothing, so `all_violations` was always empty and
  the benchmark reported **100% compliant on any input**. Imports repointed;
  it now correctly reports 63 violations / 67.7% on empty input.
- **CIS GCP declared 55 controls but implements 57**, yielding
  `passed_controls: -2` and a negative percentage. Corrected to 57.
- **7 orchestrators had no `default compliant := false`**, leaving `compliant`
  undefined rather than false.
- **`compliance_percentage` contradicted the control counts.** The
  orchestrators compute a SECTION-level percentage (e.g. 21.4% = 3/14
  sections) which was published alongside control counts implying 81%. The
  report now publishes a control-level percentage consistent with its own
  passed/failed/total, and surfaces the section-level figure separately as
  `section_compliance_percentage`.

## On `total_controls`

Set to the number of distinct CIS control IDs each policy set actually
evaluates (counted from violation messages), not the published benchmark's
headline size — reporting the latter would overstate coverage. Flagged in the
report as `controls_basis`. Note this makes visible that CIS RHEL 9 evaluates
224 distinct control IDs, not the 338 quoted in the compliance repo's
CLAUDE.md.

## Tests

`benchmarks/cis/_framework_key_tests/` asserts, for all 14 keys, that the
report is populated on EMPTY input, counts are non-negative and consistent,
percentages are in range, and empty input never reports compliant — the
regression guard for the Amazon Linux fail-open.

`opa test . --ignore .github` -> 298/298.

## Not in this PR

`cis_docker`, `cis_kubernetes`, `cis_aws`, `cis_azure` and `cis_rhel10` still
do not resolve. They declare a bare `package cis` shared with 10 unrelated
benchmarks, so bridging them requires the package-namespace split, which is
its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)