### PR TITLE
docs(cis): label debian_11, rocky_linux_9 and ubuntu_24_04 as derived policy sets

### DIFF
--- a/benchmarks/cis/_framework_key_tests/test_framework_key_bridges.rego
+++ b/benchmarks/cis/_framework_key_tests/test_framework_key_bridges.rego
@@ -99,3 +99,31 @@ test_empty_input_is_not_compliant if {
 test_amazon2023_detects_violations_on_empty_input if {
 	data.cis_amazon_linux_2023.main.compliance_report.failed_controls > 0
 }
+
+# --- derived policy sets must stay flagged -----------------------------------
+#
+# debian_11, rocky_linux_9 and ubuntu_24_04 contain copies of another
+# platform's controls (verified byte-identical by diff). They must never
+# advertise a benchmark version they do not implement, and consumers must be
+# able to detect the derivation programmatically.
+
+derived_reports := [
+	data.cis_debian_11.main.compliance_report,
+	data.cis_rocky_linux_9.main.compliance_report,
+	data.cis_ubuntu_2404.main.compliance_report,
+]
+
+test_derived_sets_are_flagged if {
+	every r in derived_reports {
+		r.derived == true
+		is_string(r.derived_from)
+		is_string(r.applied_to)
+		startswith(r.benchmark, "DERIVED from ")
+	}
+}
+
+test_derived_sets_do_not_claim_own_benchmark if {
+	not contains(data.cis_debian_11.main.compliance_report.benchmark, "CIS Debian")
+	not contains(data.cis_rocky_linux_9.main.compliance_report.benchmark, "CIS Rocky Linux 9")
+	not contains(data.cis_ubuntu_2404.main.compliance_report.benchmark, "CIS Ubuntu Linux 24.04")
+}

--- a/benchmarks/cis/debian_11/README.md
+++ b/benchmarks/cis/debian_11/README.md
@@ -1,0 +1,35 @@
+# Debian 11 — DERIVED policy set
+
+**These controls are not authored against the Debian 11 CIS Benchmark.**
+
+Every rule in this directory is a copy of `benchmarks/cis/ubuntu_20_04/`, with only the
+package name and display strings changed. Verified by diff — the control logic is
+byte-identical:
+
+```bash
+diff <(cat benchmarks/cis/ubuntu_20_04/*.rego) <(cat benchmarks/cis/debian_11/*.rego) \
+  | grep '^[<>]' | grep -vE '^[<>] *(package |#|import )'
+# only package/import renames and display strings differ
+```
+
+## What this means
+
+| | |
+|---|---|
+| Control logic actually implemented | **CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0** |
+| Platform it is applied to | Debian 11 |
+| A Debian 11-specific CIS benchmark | **not implemented** |
+
+The previous headers claimed a Debian 11 benchmark version that no rule in this
+directory implements. That claim has been removed rather than left to imply
+coverage we cannot substantiate.
+
+## Before relying on this for Debian 11
+
+The source and target platforms genuinely diverge — RHEL 8 to 9 changed crypto
+policies and default services; Ubuntu LTS releases move defaults between
+versions. Treat results as an approximate baseline, not a Debian 11 CIS
+attestation.
+
+Authoring real controls requires the published CIS Debian 11 Benchmark, which is
+gated behind CIS SecureSuite membership.

--- a/benchmarks/cis/debian_11/apparmor_validation.rego
+++ b/benchmarks/cis/debian_11/apparmor_validation.rego
@@ -1,6 +1,6 @@
 package cis_debian_11.apparmor
 
-# CIS Debian Linux 11 Benchmark v2.0.0 - Section 1.6: Mandatory Access Controls
+# DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 — applied to Debian 11 (provenance: see README) - Section 1.6: Mandatory Access Controls
 # Ubuntu uses AppArmor instead of SELinux
 
 import rego.v1
@@ -93,5 +93,5 @@ report := {
 	"apparmor_status": apparmor_status,
 	"controls_checked": 4,
 	"section": "1.6 Mandatory Access Controls (AppArmor)",
-	"benchmark": "CIS Debian 11 v2.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 (applied to Debian 11)",
 }

--- a/benchmarks/cis/debian_11/auditd_validation.rego
+++ b/benchmarks/cis/debian_11/auditd_validation.rego
@@ -1,6 +1,6 @@
 package cis_debian_11.auditd
 
-# CIS Debian Linux 11 Benchmark v2.0.0 - Section 4.1: Configure System Accounting (auditd)
+# DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 — applied to Debian 11 (provenance: see README) - Section 4.1: Configure System Accounting (auditd)
 
 import rego.v1
 
@@ -192,5 +192,5 @@ report := {
 	"controls_checked": 38,
 	"rules_checked": count(required_rules),
 	"section": "4.1 Configure System Accounting (auditd)",
-	"benchmark": "CIS Debian 11 v2.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 (applied to Debian 11)",
 }

--- a/benchmarks/cis/debian_11/boot_security_validation.rego
+++ b/benchmarks/cis/debian_11/boot_security_validation.rego
@@ -1,6 +1,6 @@
 package cis_debian_11.boot_security
 
-# CIS Debian Linux 11 Benchmark v2.0.0 - Sections 1.3-1.5: Boot Security and Process Hardening
+# DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 — applied to Debian 11 (provenance: see README) - Sections 1.3-1.5: Boot Security and Process Hardening
 
 import rego.v1
 
@@ -109,5 +109,5 @@ report := {
 	"process_hardening_violations": count(process_hardening_violations),
 	"controls_checked": 12,
 	"section": "1.3-1.5 Boot Security and Process Hardening",
-	"benchmark": "CIS Debian 11 v2.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 (applied to Debian 11)",
 }

--- a/benchmarks/cis/debian_11/cis_debian_11_complete.rego
+++ b/benchmarks/cis/debian_11/cis_debian_11_complete.rego
@@ -2,7 +2,7 @@ package cis_debian_11
 
 # CIS Debian 11 Benchmark - Complete Compliance Assessment
 # Master orchestrator that aggregates all modular validation policies
-# Benchmark Version: CIS Debian Linux 11 Benchmark v2.0.0
+# Benchmark Version: DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 — applied to Debian 11 (provenance: see README)
 
 import rego.v1
 
@@ -145,7 +145,7 @@ module_status := [
 
 compliance_assessment := {
 	"assessment_metadata": {
-		"benchmark": "CIS Debian Linux 11 LTS Benchmark v2.0.0",
+		"benchmark": "DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 — applied to Debian 11 (see README)",
 		"target_platform": "Debian 11 LTS",
 		"assessment_time": time.now_ns(),
 		"hostname": input.system_info.hostname,

--- a/benchmarks/cis/debian_11/cis_debian_11_main.rego
+++ b/benchmarks/cis/debian_11/cis_debian_11_main.rego
@@ -16,6 +16,13 @@ package cis_debian_11.main
 #    the published CIS benchmark. Reporting the benchmark's headline number
 #    would overstate coverage. See "controls_basis" in the report.
 
+# PROVENANCE: this policy set is DERIVED — its controls are a copy of
+# CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0, relabelled for Debian 11. There is no
+# Debian 11-specific CIS benchmark implemented here. The report therefore
+# publishes the version of the benchmark it ACTUALLY implements, plus
+# derived/derived_from/applied_to so consumers can detect this.
+# See README.md in this directory.
+
 import rego.v1
 import data.cis_debian_11 as bench
 
@@ -48,8 +55,11 @@ _percentage := round((_passed * 100000) / _total_controls) / 1000 if _total_cont
 
 compliance_report := {
 	"framework": "cis_debian_11",
-	"benchmark": "CIS Debian Linux 11 Benchmark v2.0.0",
-	"version": "v2.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 — applied to Debian 11 (provenance: see README)",
+	"version": "v3.0.0",
+	"derived": true,
+	"derived_from": "CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0",
+	"applied_to": "Debian 11",
 	"total_controls": _total_controls,
 	"controls_basis": "distinct CIS control IDs evaluated by this policy set",
 	"passed_controls": _passed,

--- a/benchmarks/cis/debian_11/cron_validation.rego
+++ b/benchmarks/cis/debian_11/cron_validation.rego
@@ -1,6 +1,6 @@
 package cis_debian_11.cron
 
-# CIS Debian Linux 11 Benchmark v2.0.0 - Section 5.1: Configure time-based job schedulers
+# DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 — applied to Debian 11 (provenance: see README) - Section 5.1: Configure time-based job schedulers
 
 import rego.v1
 
@@ -141,5 +141,5 @@ report := {
 	"violations": violations,
 	"controls_checked": 9,
 	"section": "5.1 Configure time-based job schedulers",
-	"benchmark": "CIS Debian 11 v2.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 (applied to Debian 11)",
 }

--- a/benchmarks/cis/debian_11/file_permissions_validation.rego
+++ b/benchmarks/cis/debian_11/file_permissions_validation.rego
@@ -1,6 +1,6 @@
 package cis_debian_11.file_permissions
 
-# CIS Debian Linux 11 Benchmark v2.0.0 - Section 6.1: System File Permissions
+# DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 — applied to Debian 11 (provenance: see README) - Section 6.1: System File Permissions
 
 import rego.v1
 
@@ -150,5 +150,5 @@ report := {
 		"non_compliant_critical_files": input.critical_files.non_compliant_count,
 	},
 	"section": "6.1 System File Permissions",
-	"benchmark": "CIS Debian 11 v2.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 (applied to Debian 11)",
 }

--- a/benchmarks/cis/debian_11/initial_setup_validation.rego
+++ b/benchmarks/cis/debian_11/initial_setup_validation.rego
@@ -1,6 +1,6 @@
 package cis_debian_11.initial_setup
 
-# CIS Debian Linux 11 Benchmark v2.0.0 - Sections 1.2, 1.7, 1.8: Initial System Setup
+# DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 — applied to Debian 11 (provenance: see README) - Sections 1.2, 1.7, 1.8: Initial System Setup
 
 import rego.v1
 
@@ -174,5 +174,5 @@ report := {
 	"violations": violations,
 	"controls_checked": 24,
 	"section": "1.2-1.8 Initial System Setup",
-	"benchmark": "CIS Debian 11 v2.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 (applied to Debian 11)",
 }

--- a/benchmarks/cis/debian_11/logging_validation.rego
+++ b/benchmarks/cis/debian_11/logging_validation.rego
@@ -1,6 +1,6 @@
 package cis_debian_11.logging
 
-# CIS Debian Linux 11 Benchmark v2.0.0 - Section 4.2: Logging Configuration
+# DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 — applied to Debian 11 (provenance: see README) - Section 4.2: Logging Configuration
 
 import rego.v1
 
@@ -130,5 +130,5 @@ report := {
 		"forward_to_syslog": input.journald.forward_to_syslog,
 	},
 	"section": "4.2 Logging Configuration",
-	"benchmark": "CIS Debian 11 v2.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 (applied to Debian 11)",
 }

--- a/benchmarks/cis/debian_11/network_validation.rego
+++ b/benchmarks/cis/debian_11/network_validation.rego
@@ -1,6 +1,6 @@
 package cis_debian_11.network
 
-# CIS Debian Linux 11 Benchmark v2.0.0 - Sections 3.1/3.2/3.3: Network Configuration
+# DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 — applied to Debian 11 (provenance: see README) - Sections 3.1/3.2/3.3: Network Configuration
 
 import rego.v1
 
@@ -177,5 +177,5 @@ report := {
 	"network_interface_violations": count(network_interface_violations),
 	"firewall": {"type": input.firewall.type, "active": input.firewall.active},
 	"section": "3.1-3.3 Network Configuration",
-	"benchmark": "CIS Debian 11 v2.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 (applied to Debian 11)",
 }

--- a/benchmarks/cis/debian_11/pam_validation.rego
+++ b/benchmarks/cis/debian_11/pam_validation.rego
@@ -1,6 +1,6 @@
 package cis_debian_11.pam
 
-# CIS Debian Linux 11 Benchmark v2.0.0 - Sections 5.4-5.5: PAM and Password Policies
+# DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 — applied to Debian 11 (provenance: see README) - Sections 5.4-5.5: PAM and Password Policies
 
 import rego.v1
 
@@ -147,5 +147,5 @@ report := {
 	"account_violations": count(account_violations),
 	"controls_checked": 17,
 	"section": "5.4-5.5 PAM and Password Policies",
-	"benchmark": "CIS Debian 11 v2.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 (applied to Debian 11)",
 }

--- a/benchmarks/cis/debian_11/services_validation.rego
+++ b/benchmarks/cis/debian_11/services_validation.rego
@@ -1,6 +1,6 @@
 package cis_debian_11.services
 
-# CIS Debian Linux 11 Benchmark v2.0.0 - Sections 2.1.x, 2.2.x, 2.3.x: Service Configuration
+# DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 — applied to Debian 11 (provenance: see README) - Sections 2.1.x, 2.2.x, 2.3.x: Service Configuration
 
 import rego.v1
 
@@ -176,5 +176,5 @@ report := {
 	"package_violations": count(package_violations),
 	"controls_checked": 18,
 	"section": "2.1-2.3 Service Configuration",
-	"benchmark": "CIS Debian 11 v2.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 (applied to Debian 11)",
 }

--- a/benchmarks/cis/debian_11/ssh_validation.rego
+++ b/benchmarks/cis/debian_11/ssh_validation.rego
@@ -1,6 +1,6 @@
 package cis_debian_11.ssh
 
-# CIS Debian Linux 11 Benchmark v2.0.0 - Section 5.2: Configure SSH Server
+# DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 — applied to Debian 11 (provenance: see README) - Section 5.2: Configure SSH Server
 
 import rego.v1
 
@@ -211,5 +211,5 @@ report := {
 	"permission_violations": count(permission_violations),
 	"controls_checked": 22,
 	"section": "5.2 Configure SSH Server",
-	"benchmark": "CIS Debian 11 v2.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 (applied to Debian 11)",
 }

--- a/benchmarks/cis/debian_11/sudo_validation.rego
+++ b/benchmarks/cis/debian_11/sudo_validation.rego
@@ -1,6 +1,6 @@
 package cis_debian_11.sudo
 
-# CIS Debian Linux 11 Benchmark v2.0.0 - Section 5.3: Configure Sudo
+# DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 — applied to Debian 11 (provenance: see README) - Section 5.3: Configure Sudo
 
 import rego.v1
 
@@ -83,5 +83,5 @@ report := {
 	"violations": violations,
 	"controls_checked": 8,
 	"section": "5.3 Configure Sudo",
-	"benchmark": "CIS Debian 11 v2.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 (applied to Debian 11)",
 }

--- a/benchmarks/cis/debian_11/user_group_validation.rego
+++ b/benchmarks/cis/debian_11/user_group_validation.rego
@@ -1,6 +1,6 @@
 package cis_debian_11.user_group
 
-# CIS Debian Linux 11 Benchmark v2.0.0 - Section 6.2: User and Group Settings
+# DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 — applied to Debian 11 (provenance: see README) - Section 6.2: User and Group Settings
 
 import rego.v1
 
@@ -157,5 +157,5 @@ report := {
 	"violations": violations,
 	"controls_checked": 16,
 	"section": "6.2 User and Group Settings",
-	"benchmark": "CIS Debian 11 v2.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 (applied to Debian 11)",
 }

--- a/benchmarks/cis/rocky_linux_9/README.md
+++ b/benchmarks/cis/rocky_linux_9/README.md
@@ -1,0 +1,35 @@
+# Rocky Linux 9 — DERIVED policy set
+
+**These controls are not authored against the Rocky Linux 9 CIS Benchmark.**
+
+Every rule in this directory is a copy of `benchmarks/cis/rocky_linux_8/`, with only the
+package name and display strings changed. Verified by diff — the control logic is
+byte-identical:
+
+```bash
+diff <(cat benchmarks/cis/rocky_linux_8/*.rego) <(cat benchmarks/cis/rocky_linux_9/*.rego) \
+  | grep '^[<>]' | grep -vE '^[<>] *(package |#|import )'
+# only package/import renames and display strings differ
+```
+
+## What this means
+
+| | |
+|---|---|
+| Control logic actually implemented | **CIS Rocky Linux 8 Benchmark v3.0.0** |
+| Platform it is applied to | Rocky Linux 9 |
+| A Rocky Linux 9-specific CIS benchmark | **not implemented** |
+
+The previous headers claimed a Rocky Linux 9 benchmark version that no rule in this
+directory implements. That claim has been removed rather than left to imply
+coverage we cannot substantiate.
+
+## Before relying on this for Rocky Linux 9
+
+The source and target platforms genuinely diverge — RHEL 8 to 9 changed crypto
+policies and default services; Ubuntu LTS releases move defaults between
+versions. Treat results as an approximate baseline, not a Rocky Linux 9 CIS
+attestation.
+
+Authoring real controls requires the published CIS Rocky Linux 9 Benchmark, which is
+gated behind CIS SecureSuite membership.

--- a/benchmarks/cis/rocky_linux_9/auditd_validation.rego
+++ b/benchmarks/cis/rocky_linux_9/auditd_validation.rego
@@ -1,6 +1,6 @@
 package cis_rocky_linux_9.auditd
 
-# CIS Rocky Linux 9 Benchmark v2.0.0 - Section 4.1: Configure System Accounting (auditd)
+# DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 — applied to Rocky Linux 9 (provenance: see README) - Section 4.1: Configure System Accounting (auditd)
 # Validates auditd service, configuration, and audit rules
 
 import rego.v1
@@ -202,5 +202,5 @@ report := {
 	"controls_checked": 40,
 	"rules_checked": count(required_rules),
 	"section": "4.1 Configure System Accounting (auditd)",
-	"benchmark": "CIS Rocky Linux 9 v2.0.0",
+	"benchmark": "DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 (applied to Rocky Linux 9)",
 }

--- a/benchmarks/cis/rocky_linux_9/cis_rocky_linux_9_complete.rego
+++ b/benchmarks/cis/rocky_linux_9/cis_rocky_linux_9_complete.rego
@@ -1,6 +1,6 @@
 package cis_rocky_linux_9
 
-# CIS Rocky Linux 9 Benchmark v2.0.0 - Complete Validation
+# DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 — applied to Rocky Linux 9 (provenance: see README) - Complete Validation
 # MODULAR architecture with validation modules
 # Coverage: ~300+ controls
 

--- a/benchmarks/cis/rocky_linux_9/cis_rocky_linux_9_main.rego
+++ b/benchmarks/cis/rocky_linux_9/cis_rocky_linux_9_main.rego
@@ -16,6 +16,13 @@ package cis_rocky_linux_9.main
 #    the published CIS benchmark. Reporting the benchmark's headline number
 #    would overstate coverage. See "controls_basis" in the report.
 
+# PROVENANCE: this policy set is DERIVED — its controls are a copy of
+# CIS Rocky Linux 8 Benchmark v3.0.0, relabelled for Rocky Linux 9. There is no
+# Rocky Linux 9-specific CIS benchmark implemented here. The report therefore
+# publishes the version of the benchmark it ACTUALLY implements, plus
+# derived/derived_from/applied_to so consumers can detect this.
+# See README.md in this directory.
+
 import rego.v1
 import data.cis_rocky_linux_9 as bench
 
@@ -48,8 +55,11 @@ _percentage := round((_passed * 100000) / _total_controls) / 1000 if _total_cont
 
 compliance_report := {
 	"framework": "cis_rocky_linux_9",
-	"benchmark": "CIS Rocky Linux 9 Benchmark v2.0.0",
-	"version": "v2.0.0",
+	"benchmark": "DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 — applied to Rocky Linux 9 (provenance: see README)",
+	"version": "v3.0.0",
+	"derived": true,
+	"derived_from": "CIS Rocky Linux 8 Benchmark v3.0.0",
+	"applied_to": "Rocky Linux 9",
 	"total_controls": _total_controls,
 	"controls_basis": "distinct CIS control IDs evaluated by this policy set",
 	"passed_controls": _passed,

--- a/benchmarks/cis/rocky_linux_9/cron_validation.rego
+++ b/benchmarks/cis/rocky_linux_9/cron_validation.rego
@@ -1,6 +1,6 @@
 package cis_rocky_linux_9.cron
 
-# CIS Rocky Linux 9 Benchmark v2.0.0 - Section 5.1: Configure time-based job schedulers
+# DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 — applied to Rocky Linux 9 (provenance: see README) - Section 5.1: Configure time-based job schedulers
 
 import rego.v1
 
@@ -141,5 +141,5 @@ report := {
 	"violations": violations,
 	"controls_checked": 9,
 	"section": "5.1 Configure time-based job schedulers",
-	"benchmark": "CIS Rocky Linux 9 v2.0.0",
+	"benchmark": "DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 (applied to Rocky Linux 9)",
 }

--- a/benchmarks/cis/rocky_linux_9/file_permissions_validation.rego
+++ b/benchmarks/cis/rocky_linux_9/file_permissions_validation.rego
@@ -1,6 +1,6 @@
 package cis_rocky_linux_9.file_permissions
 
-# CIS Rocky Linux 9 Benchmark v2.0.0 - Section 6.1: System File Permissions
+# DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 — applied to Rocky Linux 9 (provenance: see README) - Section 6.1: System File Permissions
 
 import rego.v1
 
@@ -134,5 +134,5 @@ report := {
 		"non_compliant_critical_files": input.critical_files.non_compliant_count,
 	},
 	"section": "6.1 System File Permissions",
-	"benchmark": "CIS Rocky Linux 9 v2.0.0",
+	"benchmark": "DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 (applied to Rocky Linux 9)",
 }

--- a/benchmarks/cis/rocky_linux_9/initial_setup_validation.rego
+++ b/benchmarks/cis/rocky_linux_9/initial_setup_validation.rego
@@ -1,6 +1,6 @@
 package cis_rocky_linux_9.initial_setup
 
-# CIS Rocky Linux 9 Benchmark v2.0.0 - Sections 1.2, 1.7, 1.8, 1.9: Initial System Setup
+# DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 — applied to Rocky Linux 9 (provenance: see README) - Sections 1.2, 1.7, 1.8, 1.9: Initial System Setup
 
 import rego.v1
 
@@ -220,5 +220,5 @@ report := {
 	"violations": violations,
 	"controls_checked": 22,
 	"section": "1.2, 1.7-1.9 Initial System Setup",
-	"benchmark": "CIS Rocky Linux 9 v2.0.0",
+	"benchmark": "DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 (applied to Rocky Linux 9)",
 }

--- a/benchmarks/cis/rocky_linux_9/logging_validation.rego
+++ b/benchmarks/cis/rocky_linux_9/logging_validation.rego
@@ -1,6 +1,6 @@
 package cis_rocky_linux_9.logging
 
-# CIS Rocky Linux 9 Benchmark v2.0.0 - Section 4.2: Logging Configuration
+# DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 — applied to Rocky Linux 9 (provenance: see README) - Section 4.2: Logging Configuration
 # Validates rsyslog, journald, and log file permissions
 
 import rego.v1
@@ -118,5 +118,5 @@ report := {
 		"forward_to_syslog": input.journald.forward_to_syslog,
 	},
 	"section": "4.2 Logging Configuration",
-	"benchmark": "CIS Rocky Linux 9 v2.0.0",
+	"benchmark": "DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 (applied to Rocky Linux 9)",
 }

--- a/benchmarks/cis/rocky_linux_9/network_validation.rego
+++ b/benchmarks/cis/rocky_linux_9/network_validation.rego
@@ -1,6 +1,6 @@
 package cis_rocky_linux_9.network
 
-# CIS Rocky Linux 9 Benchmark v2.0.0 - Sections 3.1/3.2/3.3: Network Configuration
+# DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 — applied to Rocky Linux 9 (provenance: see README) - Sections 3.1/3.2/3.3: Network Configuration
 # Validates kernel network parameters, IP forwarding, ICMP settings, and IPv6
 
 import rego.v1
@@ -161,5 +161,5 @@ report := {
 	},
 	"firewall": {"type": input.firewall.type, "active": input.firewall.active},
 	"section": "3.1-3.3 Network Configuration",
-	"benchmark": "CIS Rocky Linux 9 v2.0.0",
+	"benchmark": "DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 (applied to Rocky Linux 9)",
 }

--- a/benchmarks/cis/rocky_linux_9/pam_validation.rego
+++ b/benchmarks/cis/rocky_linux_9/pam_validation.rego
@@ -1,6 +1,6 @@
 package cis_rocky_linux_9.pam
 
-# CIS Rocky Linux 9 Benchmark v2.0.0 - Section 5.4/5.5: PAM and User Accounts
+# DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 — applied to Rocky Linux 9 (provenance: see README) - Section 5.4/5.5: PAM and User Accounts
 # Password Authentication Module configuration validation
 
 import rego.v1
@@ -206,5 +206,5 @@ report := {
 	"total_violations": count(violations),
 	"controls_checked": 17,
 	"section": "5.4-5.5 PAM and User Accounts",
-	"benchmark": "CIS Rocky Linux 9 v2.0.0",
+	"benchmark": "DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 (applied to Rocky Linux 9)",
 }

--- a/benchmarks/cis/rocky_linux_9/selinux_validation.rego
+++ b/benchmarks/cis/rocky_linux_9/selinux_validation.rego
@@ -1,6 +1,6 @@
 package cis_rocky_linux_9.selinux
 
-# CIS Rocky Linux 9 Benchmark v2.0.0 - Section 1.6: Mandatory Access Controls (SELinux)
+# DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 — applied to Rocky Linux 9 (provenance: see README) - Section 1.6: Mandatory Access Controls (SELinux)
 
 import rego.v1
 
@@ -119,5 +119,5 @@ report := {
 	"total_violations": count(violations),
 	"controls_checked": 8,
 	"section": "1.6 Mandatory Access Controls",
-	"benchmark": "CIS Rocky Linux 9 v2.0.0",
+	"benchmark": "DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 (applied to Rocky Linux 9)",
 }

--- a/benchmarks/cis/rocky_linux_9/services_validation.rego
+++ b/benchmarks/cis/rocky_linux_9/services_validation.rego
@@ -1,6 +1,6 @@
 package cis_rocky_linux_9.services
 
-# CIS Rocky Linux 9 Benchmark v2.0.0 - Sections 1.1.23, 2.1.x, 2.2.x, 2.3.x: Service Configuration
+# DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 — applied to Rocky Linux 9 (provenance: see README) - Sections 1.1.23, 2.1.x, 2.2.x, 2.3.x: Service Configuration
 
 import rego.v1
 
@@ -186,5 +186,5 @@ report := {
 	"package_violations": count(package_violations),
 	"controls_checked": 20,
 	"section": "1.1.23, 2.1-2.3 Service Configuration",
-	"benchmark": "CIS Rocky Linux 9 v2.0.0",
+	"benchmark": "DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 (applied to Rocky Linux 9)",
 }

--- a/benchmarks/cis/rocky_linux_9/ssh_validation.rego
+++ b/benchmarks/cis/rocky_linux_9/ssh_validation.rego
@@ -1,6 +1,6 @@
 package cis_rocky_linux_9.ssh
 
-# CIS Rocky Linux 9 Benchmark v2.0.0 - Section 5.2: SSH Server Configuration
+# DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 — applied to Rocky Linux 9 (provenance: see README) - Section 5.2: SSH Server Configuration
 # Validates SSH daemon configuration for security hardening
 
 import rego.v1
@@ -222,5 +222,5 @@ report := {
 	"crypto_violations": count(crypto_violations),
 	"controls_checked": 21,
 	"section": "5.2 SSH Server Configuration",
-	"benchmark": "CIS Rocky Linux 9 v2.0.0",
+	"benchmark": "DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 (applied to Rocky Linux 9)",
 }

--- a/benchmarks/cis/rocky_linux_9/sudo_validation.rego
+++ b/benchmarks/cis/rocky_linux_9/sudo_validation.rego
@@ -1,6 +1,6 @@
 package cis_rocky_linux_9.sudo
 
-# CIS Rocky Linux 9 Benchmark v2.0.0 - Section 5.3: Configure privilege escalation
+# DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 — applied to Rocky Linux 9 (provenance: see README) - Section 5.3: Configure privilege escalation
 # Sudo configuration validation
 
 import rego.v1
@@ -123,5 +123,5 @@ report := {
 	"total_violations": count(violations),
 	"controls_checked": 8,
 	"section": "5.3 Configure Privilege Escalation",
-	"benchmark": "CIS Rocky Linux 9 v2.0.0",
+	"benchmark": "DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 (applied to Rocky Linux 9)",
 }

--- a/benchmarks/cis/rocky_linux_9/user_group_validation.rego
+++ b/benchmarks/cis/rocky_linux_9/user_group_validation.rego
@@ -1,6 +1,6 @@
 package cis_rocky_linux_9.user_group
 
-# CIS Rocky Linux 9 Benchmark v2.0.0 - Section 6.2: User and Group Settings
+# DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 — applied to Rocky Linux 9 (provenance: see README) - Section 6.2: User and Group Settings
 
 import rego.v1
 
@@ -162,5 +162,5 @@ report := {
 	"violations": violations,
 	"controls_checked": 16,
 	"section": "6.2 User and Group Settings",
-	"benchmark": "CIS Rocky Linux 9 v2.0.0",
+	"benchmark": "DERIVED from CIS Rocky Linux 8 Benchmark v3.0.0 (applied to Rocky Linux 9)",
 }

--- a/benchmarks/cis/ubuntu_24_04/README.md
+++ b/benchmarks/cis/ubuntu_24_04/README.md
@@ -1,0 +1,35 @@
+# Ubuntu 24.04 LTS — DERIVED policy set
+
+**These controls are not authored against the Ubuntu 24.04 LTS CIS Benchmark.**
+
+Every rule in this directory is a copy of `benchmarks/cis/ubuntu_22_04/`, with only the
+package name and display strings changed. Verified by diff — the control logic is
+byte-identical:
+
+```bash
+diff <(cat benchmarks/cis/ubuntu_22_04/*.rego) <(cat benchmarks/cis/ubuntu_24_04/*.rego) \
+  | grep '^[<>]' | grep -vE '^[<>] *(package |#|import )'
+# only package/import renames and display strings differ
+```
+
+## What this means
+
+| | |
+|---|---|
+| Control logic actually implemented | **CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0** |
+| Platform it is applied to | Ubuntu 24.04 LTS |
+| A Ubuntu 24.04 LTS-specific CIS benchmark | **not implemented** |
+
+The previous headers claimed a Ubuntu 24.04 LTS benchmark version that no rule in this
+directory implements. That claim has been removed rather than left to imply
+coverage we cannot substantiate.
+
+## Before relying on this for Ubuntu 24.04 LTS
+
+The source and target platforms genuinely diverge — RHEL 8 to 9 changed crypto
+policies and default services; Ubuntu LTS releases move defaults between
+versions. Treat results as an approximate baseline, not a Ubuntu 24.04 LTS CIS
+attestation.
+
+Authoring real controls requires the published CIS Ubuntu 24.04 LTS Benchmark, which is
+gated behind CIS SecureSuite membership.

--- a/benchmarks/cis/ubuntu_24_04/apparmor_validation.rego
+++ b/benchmarks/cis/ubuntu_24_04/apparmor_validation.rego
@@ -1,6 +1,6 @@
 package cis_ubuntu_24_04.apparmor
 
-# CIS Ubuntu 24.04 LTS Benchmark v1.0.0 - Section 1.6: Mandatory Access Controls
+# DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 — applied to Ubuntu 24.04 LTS (see README) - Section 1.6: Mandatory Access Controls
 # Ubuntu uses AppArmor instead of SELinux
 
 import rego.v1
@@ -93,5 +93,5 @@ report := {
 	"apparmor_status": apparmor_status,
 	"controls_checked": 4,
 	"section": "1.6 Mandatory Access Controls (AppArmor)",
-	"benchmark": "CIS Ubuntu 24.04 v1.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 (applied to Ubuntu 24.04 LTS)",
 }

--- a/benchmarks/cis/ubuntu_24_04/auditd_validation.rego
+++ b/benchmarks/cis/ubuntu_24_04/auditd_validation.rego
@@ -1,6 +1,6 @@
 package cis_ubuntu_24_04.auditd
 
-# CIS Ubuntu 24.04 LTS Benchmark v1.0.0 - Section 4.1: Configure System Accounting (auditd)
+# DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 — applied to Ubuntu 24.04 LTS (see README) - Section 4.1: Configure System Accounting (auditd)
 
 import rego.v1
 
@@ -192,5 +192,5 @@ report := {
 	"controls_checked": 38,
 	"rules_checked": count(required_rules),
 	"section": "4.1 Configure System Accounting (auditd)",
-	"benchmark": "CIS Ubuntu 24.04 v1.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 (applied to Ubuntu 24.04 LTS)",
 }

--- a/benchmarks/cis/ubuntu_24_04/boot_security_validation.rego
+++ b/benchmarks/cis/ubuntu_24_04/boot_security_validation.rego
@@ -1,6 +1,6 @@
 package cis_ubuntu_24_04.boot_security
 
-# CIS Ubuntu 24.04 LTS Benchmark v1.0.0 - Sections 1.3-1.5: Boot Security and Process Hardening
+# DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 — applied to Ubuntu 24.04 LTS (see README) - Sections 1.3-1.5: Boot Security and Process Hardening
 
 import rego.v1
 
@@ -109,5 +109,5 @@ report := {
 	"process_hardening_violations": count(process_hardening_violations),
 	"controls_checked": 12,
 	"section": "1.3-1.5 Boot Security and Process Hardening",
-	"benchmark": "CIS Ubuntu 24.04 v1.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 (applied to Ubuntu 24.04 LTS)",
 }

--- a/benchmarks/cis/ubuntu_24_04/cis_ubuntu_2404_main.rego
+++ b/benchmarks/cis/ubuntu_24_04/cis_ubuntu_2404_main.rego
@@ -16,6 +16,13 @@ package cis_ubuntu_2404.main
 #    the published CIS benchmark. Reporting the benchmark's headline number
 #    would overstate coverage. See "controls_basis" in the report.
 
+# PROVENANCE: this policy set is DERIVED — its controls are a copy of
+# CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0, relabelled for Ubuntu 24.04 LTS. There is no
+# Ubuntu 24.04 LTS-specific CIS benchmark implemented here. The report therefore
+# publishes the version of the benchmark it ACTUALLY implements, plus
+# derived/derived_from/applied_to so consumers can detect this.
+# See README.md in this directory.
+
 import rego.v1
 import data.cis_ubuntu_24_04 as bench
 
@@ -48,8 +55,11 @@ _percentage := round((_passed * 100000) / _total_controls) / 1000 if _total_cont
 
 compliance_report := {
 	"framework": "cis_ubuntu_2404",
-	"benchmark": "CIS Ubuntu Linux 24.04 LTS Benchmark v1.0.0",
-	"version": "v1.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 — applied to Ubuntu 24.04 LTS (provenance: see README)",
+	"version": "v3.0.0",
+	"derived": true,
+	"derived_from": "CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0",
+	"applied_to": "Ubuntu 24.04 LTS",
 	"total_controls": _total_controls,
 	"controls_basis": "distinct CIS control IDs evaluated by this policy set",
 	"passed_controls": _passed,

--- a/benchmarks/cis/ubuntu_24_04/cis_ubuntu_24_04_complete.rego
+++ b/benchmarks/cis/ubuntu_24_04/cis_ubuntu_24_04_complete.rego
@@ -2,7 +2,7 @@ package cis_ubuntu_24_04
 
 # CIS Ubuntu 24.04 LTS Benchmark - Complete Compliance Assessment
 # Master orchestrator that aggregates all modular validation policies
-# Benchmark Version: CIS Ubuntu Linux 24.04 LTS Benchmark v1.0.0
+# Benchmark Version: DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 — applied to Ubuntu 24.04 LTS (provenance: see README)
 
 import rego.v1
 
@@ -149,7 +149,7 @@ module_status := [
 
 compliance_assessment := {
 	"assessment_metadata": {
-		"benchmark": "CIS Ubuntu Linux 24.04 LTS Benchmark v1.1.0",
+		"benchmark": "DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 — applied to Ubuntu 24.04 LTS (see README)",
 		"target_platform": "Ubuntu 24.04 LTS",
 		"assessment_time": time.now_ns(),
 		"hostname": input.system_info.hostname,

--- a/benchmarks/cis/ubuntu_24_04/cron_validation.rego
+++ b/benchmarks/cis/ubuntu_24_04/cron_validation.rego
@@ -1,6 +1,6 @@
 package cis_ubuntu_24_04.cron
 
-# CIS Ubuntu 24.04 LTS Benchmark v1.0.0 - Section 5.1: Configure time-based job schedulers
+# DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 — applied to Ubuntu 24.04 LTS (see README) - Section 5.1: Configure time-based job schedulers
 
 import rego.v1
 
@@ -141,5 +141,5 @@ report := {
 	"violations": violations,
 	"controls_checked": 9,
 	"section": "5.1 Configure time-based job schedulers",
-	"benchmark": "CIS Ubuntu 24.04 v1.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 (applied to Ubuntu 24.04 LTS)",
 }

--- a/benchmarks/cis/ubuntu_24_04/file_permissions_validation.rego
+++ b/benchmarks/cis/ubuntu_24_04/file_permissions_validation.rego
@@ -1,6 +1,6 @@
 package cis_ubuntu_24_04.file_permissions
 
-# CIS Ubuntu 24.04 LTS Benchmark v1.0.0 - Section 6.1: System File Permissions
+# DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 — applied to Ubuntu 24.04 LTS (see README) - Section 6.1: System File Permissions
 
 import rego.v1
 
@@ -150,5 +150,5 @@ report := {
 		"non_compliant_critical_files": input.critical_files.non_compliant_count,
 	},
 	"section": "6.1 System File Permissions",
-	"benchmark": "CIS Ubuntu 24.04 v1.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 (applied to Ubuntu 24.04 LTS)",
 }

--- a/benchmarks/cis/ubuntu_24_04/initial_setup_validation.rego
+++ b/benchmarks/cis/ubuntu_24_04/initial_setup_validation.rego
@@ -1,6 +1,6 @@
 package cis_ubuntu_24_04.initial_setup
 
-# CIS Ubuntu 24.04 LTS Benchmark v1.0.0 - Sections 1.2, 1.7, 1.8: Initial System Setup
+# DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 — applied to Ubuntu 24.04 LTS (see README) - Sections 1.2, 1.7, 1.8: Initial System Setup
 
 import rego.v1
 
@@ -174,5 +174,5 @@ report := {
 	"violations": violations,
 	"controls_checked": 24,
 	"section": "1.2-1.8 Initial System Setup",
-	"benchmark": "CIS Ubuntu 24.04 v1.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 (applied to Ubuntu 24.04 LTS)",
 }

--- a/benchmarks/cis/ubuntu_24_04/l2_validation.rego
+++ b/benchmarks/cis/ubuntu_24_04/l2_validation.rego
@@ -1,6 +1,6 @@
 package cis_ubuntu_2404.l2
 
-# CIS Ubuntu Linux 24.04 LTS Benchmark v1.0.0 - Level 2 Additional Controls
+# DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 — applied to Ubuntu 24.04 LTS (provenance: see README) - Level 2 Additional Controls
 # Level 2 extends Level 1 with stricter settings suited for high-security
 # environments (FedRAMP High, CMMC Level 2/3, DoD, financial services).
 
@@ -253,7 +253,7 @@ l2_total_controls := 38
 
 compliance_report := {
 	"profile":           "level2",
-	"benchmark":         "CIS Ubuntu Linux 24.04 LTS Benchmark v1.0.0",
+	"benchmark":         "DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 — applied to Ubuntu 24.04 LTS (provenance: see README)",
 	"l2_controls":       l2_total_controls,
 	"l2_violations":     count(violations),
 	"l2_compliant":      compliant,

--- a/benchmarks/cis/ubuntu_24_04/logging_validation.rego
+++ b/benchmarks/cis/ubuntu_24_04/logging_validation.rego
@@ -1,6 +1,6 @@
 package cis_ubuntu_24_04.logging
 
-# CIS Ubuntu 24.04 LTS Benchmark v1.0.0 - Section 4.2: Logging Configuration
+# DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 — applied to Ubuntu 24.04 LTS (see README) - Section 4.2: Logging Configuration
 
 import rego.v1
 
@@ -130,5 +130,5 @@ report := {
 		"forward_to_syslog": input.journald.forward_to_syslog,
 	},
 	"section": "4.2 Logging Configuration",
-	"benchmark": "CIS Ubuntu 24.04 v1.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 (applied to Ubuntu 24.04 LTS)",
 }

--- a/benchmarks/cis/ubuntu_24_04/network_validation.rego
+++ b/benchmarks/cis/ubuntu_24_04/network_validation.rego
@@ -1,6 +1,6 @@
 package cis_ubuntu_24_04.network
 
-# CIS Ubuntu 24.04 LTS Benchmark v1.0.0 - Sections 3.1/3.2/3.3: Network Configuration
+# DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 — applied to Ubuntu 24.04 LTS (see README) - Sections 3.1/3.2/3.3: Network Configuration
 
 import rego.v1
 
@@ -177,5 +177,5 @@ report := {
 	"network_interface_violations": count(network_interface_violations),
 	"firewall": {"type": input.firewall.type, "active": input.firewall.active},
 	"section": "3.1-3.3 Network Configuration",
-	"benchmark": "CIS Ubuntu 24.04 v1.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 (applied to Ubuntu 24.04 LTS)",
 }

--- a/benchmarks/cis/ubuntu_24_04/pam_validation.rego
+++ b/benchmarks/cis/ubuntu_24_04/pam_validation.rego
@@ -1,6 +1,6 @@
 package cis_ubuntu_24_04.pam
 
-# CIS Ubuntu 24.04 LTS Benchmark v1.0.0 - Sections 5.4-5.5: PAM and Password Policies
+# DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 — applied to Ubuntu 24.04 LTS (see README) - Sections 5.4-5.5: PAM and Password Policies
 
 import rego.v1
 
@@ -147,5 +147,5 @@ report := {
 	"account_violations": count(account_violations),
 	"controls_checked": 17,
 	"section": "5.4-5.5 PAM and Password Policies",
-	"benchmark": "CIS Ubuntu 24.04 v1.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 (applied to Ubuntu 24.04 LTS)",
 }

--- a/benchmarks/cis/ubuntu_24_04/services_validation.rego
+++ b/benchmarks/cis/ubuntu_24_04/services_validation.rego
@@ -1,6 +1,6 @@
 package cis_ubuntu_24_04.services
 
-# CIS Ubuntu 24.04 LTS Benchmark v1.0.0 - Sections 2.1.x, 2.2.x, 2.3.x: Service Configuration
+# DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 — applied to Ubuntu 24.04 LTS (see README) - Sections 2.1.x, 2.2.x, 2.3.x: Service Configuration
 
 import rego.v1
 
@@ -176,5 +176,5 @@ report := {
 	"package_violations": count(package_violations),
 	"controls_checked": 18,
 	"section": "2.1-2.3 Service Configuration",
-	"benchmark": "CIS Ubuntu 24.04 v1.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 (applied to Ubuntu 24.04 LTS)",
 }

--- a/benchmarks/cis/ubuntu_24_04/ssh_validation.rego
+++ b/benchmarks/cis/ubuntu_24_04/ssh_validation.rego
@@ -1,6 +1,6 @@
 package cis_ubuntu_24_04.ssh
 
-# CIS Ubuntu 24.04 LTS Benchmark v1.0.0 - Section 5.2: Configure SSH Server
+# DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 — applied to Ubuntu 24.04 LTS (see README) - Section 5.2: Configure SSH Server
 
 import rego.v1
 
@@ -211,5 +211,5 @@ report := {
 	"permission_violations": count(permission_violations),
 	"controls_checked": 22,
 	"section": "5.2 Configure SSH Server",
-	"benchmark": "CIS Ubuntu 24.04 v1.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 (applied to Ubuntu 24.04 LTS)",
 }

--- a/benchmarks/cis/ubuntu_24_04/sudo_validation.rego
+++ b/benchmarks/cis/ubuntu_24_04/sudo_validation.rego
@@ -1,6 +1,6 @@
 package cis_ubuntu_24_04.sudo
 
-# CIS Ubuntu 24.04 LTS Benchmark v1.0.0 - Section 5.3: Configure Sudo
+# DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 — applied to Ubuntu 24.04 LTS (see README) - Section 5.3: Configure Sudo
 
 import rego.v1
 
@@ -83,5 +83,5 @@ report := {
 	"violations": violations,
 	"controls_checked": 8,
 	"section": "5.3 Configure Sudo",
-	"benchmark": "CIS Ubuntu 24.04 v1.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 (applied to Ubuntu 24.04 LTS)",
 }

--- a/benchmarks/cis/ubuntu_24_04/user_group_validation.rego
+++ b/benchmarks/cis/ubuntu_24_04/user_group_validation.rego
@@ -1,6 +1,6 @@
 package cis_ubuntu_24_04.user_group
 
-# CIS Ubuntu 24.04 LTS Benchmark v1.0.0 - Section 6.2: User and Group Settings
+# DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 — applied to Ubuntu 24.04 LTS (see README) - Section 6.2: User and Group Settings
 
 import rego.v1
 
@@ -157,5 +157,5 @@ report := {
 	"violations": violations,
 	"controls_checked": 16,
 	"section": "6.2 User and Group Settings",
-	"benchmark": "CIS Ubuntu 24.04 v1.0.0",
+	"benchmark": "DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 (applied to Ubuntu 24.04 LTS)",
 }


### PR DESCRIPTION
These three directories do not implement the benchmark they claimed. Each is a
copy of another platform's controls with the package name and display strings
changed — verified by diff, where every differing line is a package/import
rename or a display string and no control logic differs at all:

    debian_11      <- ubuntu_20_04   (2277 / 2277 lines)
    rocky_linux_9  <- rocky_linux_8  (2320 / 2320 lines)
    ubuntu_24_04   <- ubuntu_22_04   (2568 / 2568 lines)

So the version labels described nothing: `ubuntu_24_04` advertised "CIS Ubuntu
24.04 LTS Benchmark v1.0.0" while containing Ubuntu 22.04 v3.0.0 controls, and
`rocky_linux_9` advertised v2.0.0 while containing Rocky 8 v3.0.0 controls.
RHEL 8 -> 9 changed crypto policies and default services, so that substitution
is not neutral.

## What changed

- Every "CIS <target platform> Benchmark vX.Y.Z" string in these three trees now
  reads "DERIVED from <source benchmark> — applied to <platform>".
- `version` in each compliance_report now reports the benchmark ACTUALLY
  implemented (the source's), not the target platform's.
- Added machine-readable `derived: true`, `derived_from` and `applied_to` so a
  consumer can detect the derivation without string-matching.
- Added a README.md per directory with the diff command that proves the
  provenance and a warning against treating results as an attestation.

The keys stay registered and the platforms stay assessable — results are a
reasonable approximate baseline. What is removed is the implication that we
implement a benchmark we do not.

Authoring real controls for these three needs the published CIS benchmarks,
which are gated behind SecureSuite membership.

## Tests

Two guards added to `_framework_key_tests`: derived sets must carry the
provenance fields, and must not advertise their own platform's benchmark.

`opa test . --ignore .github` -> 300/300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)