### PR TITLE
fix(cis): split the shared `package cis` namespace and make every benchmark fail closed

### DIFF
--- a/benchmarks/cis/_framework_key_tests/test_framework_key_bridges.rego
+++ b/benchmarks/cis/_framework_key_tests/test_framework_key_bridges.rego
@@ -127,3 +127,39 @@ test_derived_sets_do_not_claim_own_benchmark if {
 	not contains(data.cis_rocky_linux_9.main.compliance_report.benchmark, "CIS Rocky Linux 9")
 	not contains(data.cis_ubuntu_2404.main.compliance_report.benchmark, "CIS Ubuntu Linux 24.04")
 }
+
+# --- fail-closed on missing facts -------------------------------------------
+#
+# Most benchmarks phrase controls as "violate if the fact says X", so with NO
+# facts nothing iterates and the benchmark reported near-total compliance for
+# an assessment that evaluated nothing. Measured before the gate: cis_rhel10
+# 99.0%, cis_azure 99.2%, cis_docker 99.1%, cis_kubernetes 99.2%, cis_aws
+# 97.1%, cis_rhel9 71.9%. Two cis_rhel10 rows already in compliance_results
+# carry exactly that empty-input signature.
+
+gated_reports := array.concat(reports, [
+	data.cis_aws.main.compliance_report,
+	data.cis_azure.main.compliance_report,
+	data.cis_docker.main.compliance_report,
+	data.cis_kubernetes.main.compliance_report,
+	data.cis_rhel10.main.compliance_report,
+])
+
+test_empty_input_reports_zero_percent if {
+	every r in gated_reports { r.compliance_percentage == 0 }
+}
+
+test_empty_input_passes_no_controls if {
+	every r in gated_reports { r.passed_controls == 0 }
+}
+
+test_empty_input_fails_every_control if {
+	every r in gated_reports { r.failed_controls == r.total_controls }
+}
+
+test_empty_input_emits_explicit_fail_closed_violation if {
+	every r in gated_reports {
+		some v in r.violations
+		startswith(v, "FAIL-CLOSED: no facts supplied")
+	}
+}

--- a/benchmarks/cis/amazon_linux_2023/cis_amazon_linux_2023_main.rego
+++ b/benchmarks/cis/amazon_linux_2023/cis_amazon_linux_2023_main.rego
@@ -27,9 +27,41 @@ default _section_percentage := 0
 
 _section_percentage := bench.compliance_percentage
 
-default _violations := []
+# ---------------------------------------------------------------------------
+# FAIL-CLOSED GATE
+#
+# Most of these benchmarks express controls as "violate if the fact says X".
+# With NO facts, nothing iterates, no violation fires, and the benchmark
+# reports near-total compliance for an assessment that evaluated nothing.
+# Measured on empty input before this gate: cis_rhel10 99.0%, cis_azure 99.2%,
+# cis_docker 99.1%, cis_kubernetes 99.2%, cis_aws 97.1%, cis_rhel9 71.9%.
+#
+# Two historical rows in compliance_results for cis_rhel10 carry exactly the
+# empty-input signature (312/309/3 @ 99.04%) — this already reached the
+# database.
+#
+# A missing-facts assessment is now reported as fully non-compliant with an
+# explicit violation, never as a pass.
+#
+# LIMITATION: this gate detects a completely EMPTY input, not a partial one.
+# An input carrying one irrelevant key still evaluates normally, so sparse or
+# wrong-shaped facts can still under-report violations. Per-benchmark required-
+# key assertions would be the stronger guarantee; that is a larger design change
+# and is not attempted here.
+# ---------------------------------------------------------------------------
 
-_violations := [v | some v in bench.all_violations]
+default _facts_supplied := false
+
+_facts_supplied if count(object.keys(input)) > 0
+
+_no_facts_msg := sprintf(
+	"FAIL-CLOSED: no facts supplied for %s — the assessment could not be evaluated. This is NOT a passing result; check that fact collection ran and produced input.",
+	["cis_amazon_linux_2023"],
+)
+
+default _bench_violations := []
+
+_bench_violations := [v | some v in bench.all_violations]
 
 default _sections := {}
 
@@ -37,7 +69,14 @@ _sections := bench.section_compliance
 
 _total_controls := 195
 
-_failed := count(_violations)
+_violations := array.concat(_bench_violations, [_no_facts_msg]) if not _facts_supplied
+
+_violations := _bench_violations if _facts_supplied
+
+# No facts => every control is unverified, which counts as failed, not passed.
+_failed := _total_controls if not _facts_supplied
+
+_failed := count(_bench_violations) if _facts_supplied
 
 # Clamp: more violations than known controls must not yield a negative count.
 _passed := max([0, _total_controls - _failed])

--- a/benchmarks/cis/aws/cis_aws_foundations.rego
+++ b/benchmarks/cis/aws/cis_aws_foundations.rego
@@ -1,4 +1,4 @@
-package cis
+package cis_aws
 
 # CIS Amazon Web Services Foundations Benchmark v7.0.0
 # Center for Internet Security (CIS) AWS Foundations Benchmark

--- a/benchmarks/cis/aws/cis_aws_main.rego
+++ b/benchmarks/cis/aws/cis_aws_main.rego
@@ -1,31 +1,23 @@
-package cis_vyos.main
+package cis_aws.main
 
-# Bridge: expose cis_vyos under the /v1/data/<framework>/main/compliance_report
-# convention consumed by the Generic Framework Assessment playbook
-# (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
+# Bridge: expose cis_aws under the /v1/data/<framework>/main/compliance_report
+# convention consumed by the Generic Framework Assessment playbook.
 #
-# Two deliberate choices here:
+# Every field is sourced through a DEFAULTED local helper. An undefined field
+# inside an object literal makes the whole object undefined, which OPA returns
+# as {} — a silently empty compliance result rather than an error.
+# See library rule #5 in CLAUDE.md.
 #
-# 1. Every field is sourced through a DEFAULTED local helper. An undefined
-#    field inside an object literal makes the whole object undefined, which
-#    OPA returns as {} — a silently empty compliance result rather than an
-#    error. See library rule #5 in CLAUDE.md.
-#
-# 2. total_controls is the number of DISTINCT CIS control IDs this policy set
-#    actually evaluates (counted from the violation messages), NOT the size of
-#    the published CIS benchmark. Reporting the benchmark's headline number
-#    would overstate coverage. See "controls_basis" in the report.
+# This benchmark previously shared a bare `package cis` namespace with 13
+# unrelated benchmarks, where partial rules such as `violations` silently
+# merged across all of them. It now owns `cis_aws`.
 
 import rego.v1
-import data.cis_vyos as bench
+import data.cis_aws as bench
 
 default _compliant := false
 
 _compliant := bench.compliant
-
-default _section_percentage := 0
-
-_section_percentage := bench.compliance_percentage
 
 # ---------------------------------------------------------------------------
 # FAIL-CLOSED GATE
@@ -56,18 +48,18 @@ _facts_supplied if count(object.keys(input)) > 0
 
 _no_facts_msg := sprintf(
 	"FAIL-CLOSED: no facts supplied for %s — the assessment could not be evaluated. This is NOT a passing result; check that fact collection ran and produced input.",
-	["cis_vyos"],
+	["cis_aws"],
 )
 
 default _bench_violations := []
 
 _bench_violations := [v | some v in bench.violations]
 
-default _sections := {}
+default _summary := {}
 
-_sections := bench.compliance_assessment
+_summary := bench.compliance_summary
 
-_total_controls := 20
+_total_controls := 69
 
 _violations := array.concat(_bench_violations, [_no_facts_msg]) if not _facts_supplied
 
@@ -86,16 +78,15 @@ default _percentage := 0
 _percentage := round((_passed * 100000) / _total_controls) / 1000 if _total_controls > 0
 
 compliance_report := {
-	"framework": "cis_vyos",
-	"benchmark": "CIS VyOS Benchmark v1.0.1",
-	"version": "v1.0.1",
+	"framework": "cis_aws",
+	"benchmark": "CIS Amazon Web Services Foundations Benchmark v7.0.0",
+	"version": "v7.0.0",
 	"total_controls": _total_controls,
-	"controls_basis": "controls implemented in this device policy set",
+	"controls_basis": "controls declared by this benchmark policy set",
 	"passed_controls": _passed,
 	"failed_controls": _failed,
 	"compliance_percentage": _percentage,
-	"section_compliance_percentage": _section_percentage,
 	"compliant": _compliant,
 	"violations": _violations,
-	"section_results": _sections,
+	"section_results": _summary,
 }

--- a/benchmarks/cis/azure/cis_azure_foundations.rego
+++ b/benchmarks/cis/azure/cis_azure_foundations.rego
@@ -1,4 +1,4 @@
-package cis
+package cis_azure
 
 # CIS Microsoft Azure Foundations Benchmark v3.0.0
 # Center for Internet Security (CIS) Azure Foundations Benchmark

--- a/benchmarks/cis/azure/cis_azure_main.rego
+++ b/benchmarks/cis/azure/cis_azure_main.rego
@@ -1,31 +1,23 @@
-package cis_vyos.main
+package cis_azure.main
 
-# Bridge: expose cis_vyos under the /v1/data/<framework>/main/compliance_report
-# convention consumed by the Generic Framework Assessment playbook
-# (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
+# Bridge: expose cis_azure under the /v1/data/<framework>/main/compliance_report
+# convention consumed by the Generic Framework Assessment playbook.
 #
-# Two deliberate choices here:
+# Every field is sourced through a DEFAULTED local helper. An undefined field
+# inside an object literal makes the whole object undefined, which OPA returns
+# as {} — a silently empty compliance result rather than an error.
+# See library rule #5 in CLAUDE.md.
 #
-# 1. Every field is sourced through a DEFAULTED local helper. An undefined
-#    field inside an object literal makes the whole object undefined, which
-#    OPA returns as {} — a silently empty compliance result rather than an
-#    error. See library rule #5 in CLAUDE.md.
-#
-# 2. total_controls is the number of DISTINCT CIS control IDs this policy set
-#    actually evaluates (counted from the violation messages), NOT the size of
-#    the published CIS benchmark. Reporting the benchmark's headline number
-#    would overstate coverage. See "controls_basis" in the report.
+# This benchmark previously shared a bare `package cis` namespace with 13
+# unrelated benchmarks, where partial rules such as `violations` silently
+# merged across all of them. It now owns `cis_azure`.
 
 import rego.v1
-import data.cis_vyos as bench
+import data.cis_azure as bench
 
 default _compliant := false
 
 _compliant := bench.compliant
-
-default _section_percentage := 0
-
-_section_percentage := bench.compliance_percentage
 
 # ---------------------------------------------------------------------------
 # FAIL-CLOSED GATE
@@ -56,18 +48,18 @@ _facts_supplied if count(object.keys(input)) > 0
 
 _no_facts_msg := sprintf(
 	"FAIL-CLOSED: no facts supplied for %s — the assessment could not be evaluated. This is NOT a passing result; check that fact collection ran and produced input.",
-	["cis_vyos"],
+	["cis_azure"],
 )
 
 default _bench_violations := []
 
 _bench_violations := [v | some v in bench.violations]
 
-default _sections := {}
+default _summary := {}
 
-_sections := bench.compliance_assessment
+_summary := bench.compliance_summary
 
-_total_controls := 20
+_total_controls := 128
 
 _violations := array.concat(_bench_violations, [_no_facts_msg]) if not _facts_supplied
 
@@ -86,16 +78,15 @@ default _percentage := 0
 _percentage := round((_passed * 100000) / _total_controls) / 1000 if _total_controls > 0
 
 compliance_report := {
-	"framework": "cis_vyos",
-	"benchmark": "CIS VyOS Benchmark v1.0.1",
-	"version": "v1.0.1",
+	"framework": "cis_azure",
+	"benchmark": "CIS Microsoft Azure Foundations Benchmark v3.0.0",
+	"version": "v3.0.0",
 	"total_controls": _total_controls,
-	"controls_basis": "controls implemented in this device policy set",
+	"controls_basis": "controls declared by this benchmark policy set",
 	"passed_controls": _passed,
 	"failed_controls": _failed,
 	"compliance_percentage": _percentage,
-	"section_compliance_percentage": _section_percentage,
 	"compliant": _compliant,
 	"violations": _violations,
-	"section_results": _sections,
+	"section_results": _summary,
 }

--- a/benchmarks/cis/cloud/gcp/cis_gcp_main.rego
+++ b/benchmarks/cis/cloud/gcp/cis_gcp_main.rego
@@ -400,18 +400,49 @@ default _assessed_at := ""
 
 _assessed_at := input.assessment_date
 
+# ---------------------------------------------------------------------------
+# FAIL-CLOSED GATE
+#
+# With NO facts, nothing iterates and a benchmark can report near-total
+# compliance for an assessment that evaluated nothing. A missing-facts
+# assessment is reported as fully non-compliant with an explicit violation,
+# never as a pass.
+#
+# LIMITATION: this gate detects a completely EMPTY input, not a partial one.
+# An input carrying one irrelevant key still evaluates normally, so sparse or
+# wrong-shaped facts can still under-report violations.
+# ---------------------------------------------------------------------------
+
+default _facts_supplied := false
+
+_facts_supplied if count(object.keys(input)) > 0
+
+_no_facts_msg := sprintf(
+	"FAIL-CLOSED: no facts supplied for %s — the assessment could not be evaluated. This is NOT a passing result; check that fact collection ran and produced input.",
+	["cis_gcp"],
+)
+
 _total_controls := 57
 
 # Sets are not arrays; the report contract publishes arrays so downstream
 # JSON consumers get a stable type.
-_violations := [v | some v in violations]
+_bench_violations := [v | some v in violations]
 
-_failed := count(_violations)
+_violations := array.concat(_bench_violations, [_no_facts_msg]) if not _facts_supplied
+
+_violations := _bench_violations if _facts_supplied
+
+# No facts => every control is unverified, which counts as failed, not passed.
+_failed := _total_controls if not _facts_supplied
+
+_failed := count(_bench_violations) if _facts_supplied
 
 # Clamp: a mis-declared total must never yield a negative passed count.
 _passed := max([0, _total_controls - _failed])
 
-_percentage := round((_passed * 100000) / _total_controls) / 1000
+default _percentage := 0
+
+_percentage := round((_passed * 100000) / _total_controls) / 1000 if _total_controls > 0
 
 compliance_report := {
 	"framework": "cis_gcp",

--- a/benchmarks/cis/debian_11/cis_debian_11_main.rego
+++ b/benchmarks/cis/debian_11/cis_debian_11_main.rego
@@ -34,9 +34,41 @@ default _section_percentage := 0
 
 _section_percentage := bench.compliance_percentage
 
-default _violations := []
+# ---------------------------------------------------------------------------
+# FAIL-CLOSED GATE
+#
+# Most of these benchmarks express controls as "violate if the fact says X".
+# With NO facts, nothing iterates, no violation fires, and the benchmark
+# reports near-total compliance for an assessment that evaluated nothing.
+# Measured on empty input before this gate: cis_rhel10 99.0%, cis_azure 99.2%,
+# cis_docker 99.1%, cis_kubernetes 99.2%, cis_aws 97.1%, cis_rhel9 71.9%.
+#
+# Two historical rows in compliance_results for cis_rhel10 carry exactly the
+# empty-input signature (312/309/3 @ 99.04%) — this already reached the
+# database.
+#
+# A missing-facts assessment is now reported as fully non-compliant with an
+# explicit violation, never as a pass.
+#
+# LIMITATION: this gate detects a completely EMPTY input, not a partial one.
+# An input carrying one irrelevant key still evaluates normally, so sparse or
+# wrong-shaped facts can still under-report violations. Per-benchmark required-
+# key assertions would be the stronger guarantee; that is a larger design change
+# and is not attempted here.
+# ---------------------------------------------------------------------------
 
-_violations := [v | some v in bench.violations]
+default _facts_supplied := false
+
+_facts_supplied if count(object.keys(input)) > 0
+
+_no_facts_msg := sprintf(
+	"FAIL-CLOSED: no facts supplied for %s — the assessment could not be evaluated. This is NOT a passing result; check that fact collection ran and produced input.",
+	["cis_debian_11"],
+)
+
+default _bench_violations := []
+
+_bench_violations := [v | some v in bench.violations]
 
 default _sections := {}
 
@@ -44,7 +76,14 @@ _sections := bench.module_status
 
 _total_controls := 163
 
-_failed := count(_violations)
+_violations := array.concat(_bench_violations, [_no_facts_msg]) if not _facts_supplied
+
+_violations := _bench_violations if _facts_supplied
+
+# No facts => every control is unverified, which counts as failed, not passed.
+_failed := _total_controls if not _facts_supplied
+
+_failed := count(_bench_violations) if _facts_supplied
 
 # Clamp: more violations than known controls must not yield a negative count.
 _passed := max([0, _total_controls - _failed])

--- a/benchmarks/cis/docker/cis_docker_benchmark.rego
+++ b/benchmarks/cis/docker/cis_docker_benchmark.rego
@@ -1,4 +1,4 @@
-package cis
+package cis_docker
 
 # CIS Docker Benchmark v1.8.0
 # Center for Internet Security (CIS) Docker Benchmark

--- a/benchmarks/cis/docker/cis_docker_main.rego
+++ b/benchmarks/cis/docker/cis_docker_main.rego
@@ -1,31 +1,23 @@
-package cis_vyos.main
+package cis_docker.main
 
-# Bridge: expose cis_vyos under the /v1/data/<framework>/main/compliance_report
-# convention consumed by the Generic Framework Assessment playbook
-# (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
+# Bridge: expose cis_docker under the /v1/data/<framework>/main/compliance_report
+# convention consumed by the Generic Framework Assessment playbook.
 #
-# Two deliberate choices here:
+# Every field is sourced through a DEFAULTED local helper. An undefined field
+# inside an object literal makes the whole object undefined, which OPA returns
+# as {} — a silently empty compliance result rather than an error.
+# See library rule #5 in CLAUDE.md.
 #
-# 1. Every field is sourced through a DEFAULTED local helper. An undefined
-#    field inside an object literal makes the whole object undefined, which
-#    OPA returns as {} — a silently empty compliance result rather than an
-#    error. See library rule #5 in CLAUDE.md.
-#
-# 2. total_controls is the number of DISTINCT CIS control IDs this policy set
-#    actually evaluates (counted from the violation messages), NOT the size of
-#    the published CIS benchmark. Reporting the benchmark's headline number
-#    would overstate coverage. See "controls_basis" in the report.
+# This benchmark previously shared a bare `package cis` namespace with 13
+# unrelated benchmarks, where partial rules such as `violations` silently
+# merged across all of them. It now owns `cis_docker`.
 
 import rego.v1
-import data.cis_vyos as bench
+import data.cis_docker as bench
 
 default _compliant := false
 
 _compliant := bench.compliant
-
-default _section_percentage := 0
-
-_section_percentage := bench.compliance_percentage
 
 # ---------------------------------------------------------------------------
 # FAIL-CLOSED GATE
@@ -56,18 +48,18 @@ _facts_supplied if count(object.keys(input)) > 0
 
 _no_facts_msg := sprintf(
 	"FAIL-CLOSED: no facts supplied for %s — the assessment could not be evaluated. This is NOT a passing result; check that fact collection ran and produced input.",
-	["cis_vyos"],
+	["cis_docker"],
 )
 
 default _bench_violations := []
 
 _bench_violations := [v | some v in bench.violations]
 
-default _sections := {}
+default _summary := {}
 
-_sections := bench.compliance_assessment
+_summary := bench.compliance_summary
 
-_total_controls := 20
+_total_controls := 108
 
 _violations := array.concat(_bench_violations, [_no_facts_msg]) if not _facts_supplied
 
@@ -86,16 +78,15 @@ default _percentage := 0
 _percentage := round((_passed * 100000) / _total_controls) / 1000 if _total_controls > 0
 
 compliance_report := {
-	"framework": "cis_vyos",
-	"benchmark": "CIS VyOS Benchmark v1.0.1",
-	"version": "v1.0.1",
+	"framework": "cis_docker",
+	"benchmark": "CIS Docker Benchmark v1.8.0",
+	"version": "v1.8.0",
 	"total_controls": _total_controls,
-	"controls_basis": "controls implemented in this device policy set",
+	"controls_basis": "controls declared by this benchmark policy set",
 	"passed_controls": _passed,
 	"failed_controls": _failed,
 	"compliance_percentage": _percentage,
-	"section_compliance_percentage": _section_percentage,
 	"compliant": _compliant,
 	"violations": _violations,
-	"section_results": _sections,
+	"section_results": _summary,
 }

--- a/benchmarks/cis/gcp/cis_gcp_foundations.rego
+++ b/benchmarks/cis/gcp/cis_gcp_foundations.rego
@@ -1,4 +1,4 @@
-package cis
+package cis_gcp_foundations
 
 # CIS Google Cloud Platform Foundation Benchmark v4.0.0
 # Center for Internet Security (CIS) GCP Foundation Benchmark

--- a/benchmarks/cis/kubernetes/cis_kubernetes_benchmark.rego
+++ b/benchmarks/cis/kubernetes/cis_kubernetes_benchmark.rego
@@ -1,4 +1,4 @@
-package cis
+package cis_kubernetes
 
 # CIS Kubernetes Benchmark v2.0.0
 # Center for Internet Security (CIS) Kubernetes Benchmark

--- a/benchmarks/cis/kubernetes/cis_kubernetes_main.rego
+++ b/benchmarks/cis/kubernetes/cis_kubernetes_main.rego
@@ -1,31 +1,23 @@
-package cis_vyos.main
+package cis_kubernetes.main
 
-# Bridge: expose cis_vyos under the /v1/data/<framework>/main/compliance_report
-# convention consumed by the Generic Framework Assessment playbook
-# (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
+# Bridge: expose cis_kubernetes under the /v1/data/<framework>/main/compliance_report
+# convention consumed by the Generic Framework Assessment playbook.
 #
-# Two deliberate choices here:
+# Every field is sourced through a DEFAULTED local helper. An undefined field
+# inside an object literal makes the whole object undefined, which OPA returns
+# as {} — a silently empty compliance result rather than an error.
+# See library rule #5 in CLAUDE.md.
 #
-# 1. Every field is sourced through a DEFAULTED local helper. An undefined
-#    field inside an object literal makes the whole object undefined, which
-#    OPA returns as {} — a silently empty compliance result rather than an
-#    error. See library rule #5 in CLAUDE.md.
-#
-# 2. total_controls is the number of DISTINCT CIS control IDs this policy set
-#    actually evaluates (counted from the violation messages), NOT the size of
-#    the published CIS benchmark. Reporting the benchmark's headline number
-#    would overstate coverage. See "controls_basis" in the report.
+# This benchmark previously shared a bare `package cis` namespace with 13
+# unrelated benchmarks, where partial rules such as `violations` silently
+# merged across all of them. It now owns `cis_kubernetes`.
 
 import rego.v1
-import data.cis_vyos as bench
+import data.cis_kubernetes as bench
 
 default _compliant := false
 
 _compliant := bench.compliant
-
-default _section_percentage := 0
-
-_section_percentage := bench.compliance_percentage
 
 # ---------------------------------------------------------------------------
 # FAIL-CLOSED GATE
@@ -56,18 +48,18 @@ _facts_supplied if count(object.keys(input)) > 0
 
 _no_facts_msg := sprintf(
 	"FAIL-CLOSED: no facts supplied for %s — the assessment could not be evaluated. This is NOT a passing result; check that fact collection ran and produced input.",
-	["cis_vyos"],
+	["cis_kubernetes"],
 )
 
 default _bench_violations := []
 
 _bench_violations := [v | some v in bench.violations]
 
-default _sections := {}
+default _summary := {}
 
-_sections := bench.compliance_assessment
+_summary := bench.compliance_summary
 
-_total_controls := 20
+_total_controls := 123
 
 _violations := array.concat(_bench_violations, [_no_facts_msg]) if not _facts_supplied
 
@@ -86,16 +78,15 @@ default _percentage := 0
 _percentage := round((_passed * 100000) / _total_controls) / 1000 if _total_controls > 0
 
 compliance_report := {
-	"framework": "cis_vyos",
-	"benchmark": "CIS VyOS Benchmark v1.0.1",
-	"version": "v1.0.1",
+	"framework": "cis_kubernetes",
+	"benchmark": "CIS Kubernetes Benchmark v1.10.0",
+	"version": "v1.10.0",
 	"total_controls": _total_controls,
-	"controls_basis": "controls implemented in this device policy set",
+	"controls_basis": "controls declared by this benchmark policy set",
 	"passed_controls": _passed,
 	"failed_controls": _failed,
 	"compliance_percentage": _percentage,
-	"section_compliance_percentage": _section_percentage,
 	"compliant": _compliant,
 	"violations": _violations,
-	"section_results": _sections,
+	"section_results": _summary,
 }

--- a/benchmarks/cis/network_devices/arista/cis_arista_eos.rego
+++ b/benchmarks/cis/network_devices/arista/cis_arista_eos.rego
@@ -1,4 +1,4 @@
-package cis
+package cis_arista_eos
 
 # CIS Arista EOS Benchmark v1.2.0
 # Center for Internet Security (CIS) Arista EOS Benchmark

--- a/benchmarks/cis/network_devices/cisco/cis_cisco_ios.rego
+++ b/benchmarks/cis/network_devices/cisco/cis_cisco_ios.rego
@@ -1,4 +1,4 @@
-package cis
+package cis_cisco_ios
 
 # CIS Cisco IOS Benchmark v4.1.0
 # Center for Internet Security (CIS) Cisco IOS Benchmark

--- a/benchmarks/cis/network_devices/fortinet/cis_fortinet_fortigate.rego
+++ b/benchmarks/cis/network_devices/fortinet/cis_fortinet_fortigate.rego
@@ -1,4 +1,4 @@
-package cis
+package cis_fortinet_fortigate
 
 # CIS Fortinet FortiGate Benchmark v1.3.0
 # Center for Internet Security (CIS) Fortinet FortiGate Benchmark

--- a/benchmarks/cis/network_devices/juniper/cis_juniper_junos.rego
+++ b/benchmarks/cis/network_devices/juniper/cis_juniper_junos.rego
@@ -1,4 +1,4 @@
-package cis
+package cis_juniper_junos
 
 # CIS Juniper JunOS Benchmark v2.1.0
 # Center for Internet Security (CIS) Juniper JunOS Benchmark

--- a/benchmarks/cis/network_devices/palo_alto/cis_palo_alto_panos.rego
+++ b/benchmarks/cis/network_devices/palo_alto/cis_palo_alto_panos.rego
@@ -1,4 +1,4 @@
-package cis
+package cis_palo_alto_panos
 
 # CIS Palo Alto PAN-OS Benchmark v1.2.0
 # Center for Internet Security (CIS) Palo Alto PAN-OS Benchmark

--- a/benchmarks/cis/network_devices/pfsense/cis_pfsense_main.rego
+++ b/benchmarks/cis/network_devices/pfsense/cis_pfsense_main.rego
@@ -27,9 +27,41 @@ default _section_percentage := 0
 
 _section_percentage := bench.compliance_percentage
 
-default _violations := []
+# ---------------------------------------------------------------------------
+# FAIL-CLOSED GATE
+#
+# Most of these benchmarks express controls as "violate if the fact says X".
+# With NO facts, nothing iterates, no violation fires, and the benchmark
+# reports near-total compliance for an assessment that evaluated nothing.
+# Measured on empty input before this gate: cis_rhel10 99.0%, cis_azure 99.2%,
+# cis_docker 99.1%, cis_kubernetes 99.2%, cis_aws 97.1%, cis_rhel9 71.9%.
+#
+# Two historical rows in compliance_results for cis_rhel10 carry exactly the
+# empty-input signature (312/309/3 @ 99.04%) — this already reached the
+# database.
+#
+# A missing-facts assessment is now reported as fully non-compliant with an
+# explicit violation, never as a pass.
+#
+# LIMITATION: this gate detects a completely EMPTY input, not a partial one.
+# An input carrying one irrelevant key still evaluates normally, so sparse or
+# wrong-shaped facts can still under-report violations. Per-benchmark required-
+# key assertions would be the stronger guarantee; that is a larger design change
+# and is not attempted here.
+# ---------------------------------------------------------------------------
 
-_violations := [v | some v in bench.violations]
+default _facts_supplied := false
+
+_facts_supplied if count(object.keys(input)) > 0
+
+_no_facts_msg := sprintf(
+	"FAIL-CLOSED: no facts supplied for %s — the assessment could not be evaluated. This is NOT a passing result; check that fact collection ran and produced input.",
+	["cis_pfsense"],
+)
+
+default _bench_violations := []
+
+_bench_violations := [v | some v in bench.violations]
 
 default _sections := {}
 
@@ -37,7 +69,14 @@ _sections := bench.compliance_assessment
 
 _total_controls := 22
 
-_failed := count(_violations)
+_violations := array.concat(_bench_violations, [_no_facts_msg]) if not _facts_supplied
+
+_violations := _bench_violations if _facts_supplied
+
+# No facts => every control is unverified, which counts as failed, not passed.
+_failed := _total_controls if not _facts_supplied
+
+_failed := count(_bench_violations) if _facts_supplied
 
 # Clamp: more violations than known controls must not yield a negative count.
 _passed := max([0, _total_controls - _failed])

--- a/benchmarks/cis/os/linux/redhat/cis_policy.rego
+++ b/benchmarks/cis/os/linux/redhat/cis_policy.rego
@@ -1,4 +1,4 @@
-package cis
+package cis_redhat_legacy
 
 import rego.v1
 

--- a/benchmarks/cis/rhel_10/cis_rhel10_main.rego
+++ b/benchmarks/cis/rhel_10/cis_rhel10_main.rego
@@ -1,31 +1,23 @@
-package cis_vyos.main
+package cis_rhel10.main
 
-# Bridge: expose cis_vyos under the /v1/data/<framework>/main/compliance_report
-# convention consumed by the Generic Framework Assessment playbook
-# (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
+# Bridge: expose cis.rhel_10 under the /v1/data/<framework>/main/compliance_report
+# convention consumed by the Generic Framework Assessment playbook.
 #
-# Two deliberate choices here:
+# Every field is sourced through a DEFAULTED local helper. An undefined field
+# inside an object literal makes the whole object undefined, which OPA returns
+# as {} — a silently empty compliance result rather than an error.
+# See library rule #5 in CLAUDE.md.
 #
-# 1. Every field is sourced through a DEFAULTED local helper. An undefined
-#    field inside an object literal makes the whole object undefined, which
-#    OPA returns as {} — a silently empty compliance result rather than an
-#    error. See library rule #5 in CLAUDE.md.
-#
-# 2. total_controls is the number of DISTINCT CIS control IDs this policy set
-#    actually evaluates (counted from the violation messages), NOT the size of
-#    the published CIS benchmark. Reporting the benchmark's headline number
-#    would overstate coverage. See "controls_basis" in the report.
+# This benchmark previously shared a bare `package cis` namespace with 13
+# unrelated benchmarks, where partial rules such as `violations` silently
+# merged across all of them. It now owns `cis.rhel_10`.
 
 import rego.v1
-import data.cis_vyos as bench
+import data.cis.rhel_10 as bench
 
 default _compliant := false
 
 _compliant := bench.compliant
-
-default _section_percentage := 0
-
-_section_percentage := bench.compliance_percentage
 
 # ---------------------------------------------------------------------------
 # FAIL-CLOSED GATE
@@ -56,18 +48,18 @@ _facts_supplied if count(object.keys(input)) > 0
 
 _no_facts_msg := sprintf(
 	"FAIL-CLOSED: no facts supplied for %s — the assessment could not be evaluated. This is NOT a passing result; check that fact collection ran and produced input.",
-	["cis_vyos"],
+	["cis_rhel10"],
 )
 
 default _bench_violations := []
 
 _bench_violations := [v | some v in bench.violations]
 
-default _sections := {}
+default _summary := {}
 
-_sections := bench.compliance_assessment
+_summary := bench.compliance_summary
 
-_total_controls := 20
+_total_controls := 312
 
 _violations := array.concat(_bench_violations, [_no_facts_msg]) if not _facts_supplied
 
@@ -86,16 +78,15 @@ default _percentage := 0
 _percentage := round((_passed * 100000) / _total_controls) / 1000 if _total_controls > 0
 
 compliance_report := {
-	"framework": "cis_vyos",
-	"benchmark": "CIS VyOS Benchmark v1.0.1",
+	"framework": "cis_rhel10",
+	"benchmark": "CIS Red Hat Enterprise Linux 10 Benchmark v1.0.1",
 	"version": "v1.0.1",
 	"total_controls": _total_controls,
-	"controls_basis": "controls implemented in this device policy set",
+	"controls_basis": "controls declared by this benchmark policy set",
 	"passed_controls": _passed,
 	"failed_controls": _failed,
 	"compliance_percentage": _percentage,
-	"section_compliance_percentage": _section_percentage,
 	"compliant": _compliant,
 	"violations": _violations,
-	"section_results": _sections,
+	"section_results": _summary,
 }

--- a/benchmarks/cis/rhel_8/cis_rhel8_main.rego
+++ b/benchmarks/cis/rhel_8/cis_rhel8_main.rego
@@ -27,9 +27,41 @@ default _section_percentage := 0
 
 _section_percentage := bench.compliance_percentage
 
-default _violations := []
+# ---------------------------------------------------------------------------
+# FAIL-CLOSED GATE
+#
+# Most of these benchmarks express controls as "violate if the fact says X".
+# With NO facts, nothing iterates, no violation fires, and the benchmark
+# reports near-total compliance for an assessment that evaluated nothing.
+# Measured on empty input before this gate: cis_rhel10 99.0%, cis_azure 99.2%,
+# cis_docker 99.1%, cis_kubernetes 99.2%, cis_aws 97.1%, cis_rhel9 71.9%.
+#
+# Two historical rows in compliance_results for cis_rhel10 carry exactly the
+# empty-input signature (312/309/3 @ 99.04%) — this already reached the
+# database.
+#
+# A missing-facts assessment is now reported as fully non-compliant with an
+# explicit violation, never as a pass.
+#
+# LIMITATION: this gate detects a completely EMPTY input, not a partial one.
+# An input carrying one irrelevant key still evaluates normally, so sparse or
+# wrong-shaped facts can still under-report violations. Per-benchmark required-
+# key assertions would be the stronger guarantee; that is a larger design change
+# and is not attempted here.
+# ---------------------------------------------------------------------------
 
-_violations := [v | some v in bench.all_violations]
+default _facts_supplied := false
+
+_facts_supplied if count(object.keys(input)) > 0
+
+_no_facts_msg := sprintf(
+	"FAIL-CLOSED: no facts supplied for %s — the assessment could not be evaluated. This is NOT a passing result; check that fact collection ran and produced input.",
+	["cis_rhel8"],
+)
+
+default _bench_violations := []
+
+_bench_violations := [v | some v in bench.all_violations]
 
 default _sections := {}
 
@@ -37,7 +69,14 @@ _sections := bench.section_compliance
 
 _total_controls := 195
 
-_failed := count(_violations)
+_violations := array.concat(_bench_violations, [_no_facts_msg]) if not _facts_supplied
+
+_violations := _bench_violations if _facts_supplied
+
+# No facts => every control is unverified, which counts as failed, not passed.
+_failed := _total_controls if not _facts_supplied
+
+_failed := count(_bench_violations) if _facts_supplied
 
 # Clamp: more violations than known controls must not yield a negative count.
 _passed := max([0, _total_controls - _failed])

--- a/benchmarks/cis/rhel_9/cis_rhel9_main.rego
+++ b/benchmarks/cis/rhel_9/cis_rhel9_main.rego
@@ -27,9 +27,41 @@ default _section_percentage := 0
 
 _section_percentage := bench.compliance_percentage
 
-default _violations := []
+# ---------------------------------------------------------------------------
+# FAIL-CLOSED GATE
+#
+# Most of these benchmarks express controls as "violate if the fact says X".
+# With NO facts, nothing iterates, no violation fires, and the benchmark
+# reports near-total compliance for an assessment that evaluated nothing.
+# Measured on empty input before this gate: cis_rhel10 99.0%, cis_azure 99.2%,
+# cis_docker 99.1%, cis_kubernetes 99.2%, cis_aws 97.1%, cis_rhel9 71.9%.
+#
+# Two historical rows in compliance_results for cis_rhel10 carry exactly the
+# empty-input signature (312/309/3 @ 99.04%) — this already reached the
+# database.
+#
+# A missing-facts assessment is now reported as fully non-compliant with an
+# explicit violation, never as a pass.
+#
+# LIMITATION: this gate detects a completely EMPTY input, not a partial one.
+# An input carrying one irrelevant key still evaluates normally, so sparse or
+# wrong-shaped facts can still under-report violations. Per-benchmark required-
+# key assertions would be the stronger guarantee; that is a larger design change
+# and is not attempted here.
+# ---------------------------------------------------------------------------
 
-_violations := [v | some v in bench.all_violations]
+default _facts_supplied := false
+
+_facts_supplied if count(object.keys(input)) > 0
+
+_no_facts_msg := sprintf(
+	"FAIL-CLOSED: no facts supplied for %s — the assessment could not be evaluated. This is NOT a passing result; check that fact collection ran and produced input.",
+	["cis_rhel9"],
+)
+
+default _bench_violations := []
+
+_bench_violations := [v | some v in bench.all_violations]
 
 default _sections := {}
 
@@ -37,7 +69,14 @@ _sections := bench.section_compliance
 
 _total_controls := 224
 
-_failed := count(_violations)
+_violations := array.concat(_bench_violations, [_no_facts_msg]) if not _facts_supplied
+
+_violations := _bench_violations if _facts_supplied
+
+# No facts => every control is unverified, which counts as failed, not passed.
+_failed := _total_controls if not _facts_supplied
+
+_failed := count(_bench_violations) if _facts_supplied
 
 # Clamp: more violations than known controls must not yield a negative count.
 _passed := max([0, _total_controls - _failed])

--- a/benchmarks/cis/rocky_linux_8/cis_rocky_linux_8_main.rego
+++ b/benchmarks/cis/rocky_linux_8/cis_rocky_linux_8_main.rego
@@ -27,9 +27,41 @@ default _section_percentage := 0
 
 _section_percentage := bench.compliance_percentage
 
-default _violations := []
+# ---------------------------------------------------------------------------
+# FAIL-CLOSED GATE
+#
+# Most of these benchmarks express controls as "violate if the fact says X".
+# With NO facts, nothing iterates, no violation fires, and the benchmark
+# reports near-total compliance for an assessment that evaluated nothing.
+# Measured on empty input before this gate: cis_rhel10 99.0%, cis_azure 99.2%,
+# cis_docker 99.1%, cis_kubernetes 99.2%, cis_aws 97.1%, cis_rhel9 71.9%.
+#
+# Two historical rows in compliance_results for cis_rhel10 carry exactly the
+# empty-input signature (312/309/3 @ 99.04%) — this already reached the
+# database.
+#
+# A missing-facts assessment is now reported as fully non-compliant with an
+# explicit violation, never as a pass.
+#
+# LIMITATION: this gate detects a completely EMPTY input, not a partial one.
+# An input carrying one irrelevant key still evaluates normally, so sparse or
+# wrong-shaped facts can still under-report violations. Per-benchmark required-
+# key assertions would be the stronger guarantee; that is a larger design change
+# and is not attempted here.
+# ---------------------------------------------------------------------------
 
-_violations := [v | some v in bench.all_violations]
+default _facts_supplied := false
+
+_facts_supplied if count(object.keys(input)) > 0
+
+_no_facts_msg := sprintf(
+	"FAIL-CLOSED: no facts supplied for %s — the assessment could not be evaluated. This is NOT a passing result; check that fact collection ran and produced input.",
+	["cis_rocky_linux_8"],
+)
+
+default _bench_violations := []
+
+_bench_violations := [v | some v in bench.all_violations]
 
 default _sections := {}
 
@@ -37,7 +69,14 @@ _sections := bench.section_compliance
 
 _total_controls := 166
 
-_failed := count(_violations)
+_violations := array.concat(_bench_violations, [_no_facts_msg]) if not _facts_supplied
+
+_violations := _bench_violations if _facts_supplied
+
+# No facts => every control is unverified, which counts as failed, not passed.
+_failed := _total_controls if not _facts_supplied
+
+_failed := count(_bench_violations) if _facts_supplied
 
 # Clamp: more violations than known controls must not yield a negative count.
 _passed := max([0, _total_controls - _failed])

--- a/benchmarks/cis/rocky_linux_9/cis_rocky_linux_9_main.rego
+++ b/benchmarks/cis/rocky_linux_9/cis_rocky_linux_9_main.rego
@@ -34,9 +34,41 @@ default _section_percentage := 0
 
 _section_percentage := bench.compliance_percentage
 
-default _violations := []
+# ---------------------------------------------------------------------------
+# FAIL-CLOSED GATE
+#
+# Most of these benchmarks express controls as "violate if the fact says X".
+# With NO facts, nothing iterates, no violation fires, and the benchmark
+# reports near-total compliance for an assessment that evaluated nothing.
+# Measured on empty input before this gate: cis_rhel10 99.0%, cis_azure 99.2%,
+# cis_docker 99.1%, cis_kubernetes 99.2%, cis_aws 97.1%, cis_rhel9 71.9%.
+#
+# Two historical rows in compliance_results for cis_rhel10 carry exactly the
+# empty-input signature (312/309/3 @ 99.04%) — this already reached the
+# database.
+#
+# A missing-facts assessment is now reported as fully non-compliant with an
+# explicit violation, never as a pass.
+#
+# LIMITATION: this gate detects a completely EMPTY input, not a partial one.
+# An input carrying one irrelevant key still evaluates normally, so sparse or
+# wrong-shaped facts can still under-report violations. Per-benchmark required-
+# key assertions would be the stronger guarantee; that is a larger design change
+# and is not attempted here.
+# ---------------------------------------------------------------------------
 
-_violations := [v | some v in bench.all_violations]
+default _facts_supplied := false
+
+_facts_supplied if count(object.keys(input)) > 0
+
+_no_facts_msg := sprintf(
+	"FAIL-CLOSED: no facts supplied for %s — the assessment could not be evaluated. This is NOT a passing result; check that fact collection ran and produced input.",
+	["cis_rocky_linux_9"],
+)
+
+default _bench_violations := []
+
+_bench_violations := [v | some v in bench.all_violations]
 
 default _sections := {}
 
@@ -44,7 +76,14 @@ _sections := bench.section_compliance
 
 _total_controls := 166
 
-_failed := count(_violations)
+_violations := array.concat(_bench_violations, [_no_facts_msg]) if not _facts_supplied
+
+_violations := _bench_violations if _facts_supplied
+
+# No facts => every control is unverified, which counts as failed, not passed.
+_failed := _total_controls if not _facts_supplied
+
+_failed := count(_bench_violations) if _facts_supplied
 
 # Clamp: more violations than known controls must not yield a negative count.
 _passed := max([0, _total_controls - _failed])

--- a/benchmarks/cis/ubuntu_20_04/cis_ubuntu_2004_main.rego
+++ b/benchmarks/cis/ubuntu_20_04/cis_ubuntu_2004_main.rego
@@ -27,9 +27,41 @@ default _section_percentage := 0
 
 _section_percentage := bench.compliance_percentage
 
-default _violations := []
+# ---------------------------------------------------------------------------
+# FAIL-CLOSED GATE
+#
+# Most of these benchmarks express controls as "violate if the fact says X".
+# With NO facts, nothing iterates, no violation fires, and the benchmark
+# reports near-total compliance for an assessment that evaluated nothing.
+# Measured on empty input before this gate: cis_rhel10 99.0%, cis_azure 99.2%,
+# cis_docker 99.1%, cis_kubernetes 99.2%, cis_aws 97.1%, cis_rhel9 71.9%.
+#
+# Two historical rows in compliance_results for cis_rhel10 carry exactly the
+# empty-input signature (312/309/3 @ 99.04%) — this already reached the
+# database.
+#
+# A missing-facts assessment is now reported as fully non-compliant with an
+# explicit violation, never as a pass.
+#
+# LIMITATION: this gate detects a completely EMPTY input, not a partial one.
+# An input carrying one irrelevant key still evaluates normally, so sparse or
+# wrong-shaped facts can still under-report violations. Per-benchmark required-
+# key assertions would be the stronger guarantee; that is a larger design change
+# and is not attempted here.
+# ---------------------------------------------------------------------------
 
-_violations := [v | some v in bench.violations]
+default _facts_supplied := false
+
+_facts_supplied if count(object.keys(input)) > 0
+
+_no_facts_msg := sprintf(
+	"FAIL-CLOSED: no facts supplied for %s — the assessment could not be evaluated. This is NOT a passing result; check that fact collection ran and produced input.",
+	["cis_ubuntu_2004"],
+)
+
+default _bench_violations := []
+
+_bench_violations := [v | some v in bench.violations]
 
 default _sections := {}
 
@@ -37,7 +69,14 @@ _sections := bench.module_status
 
 _total_controls := 163
 
-_failed := count(_violations)
+_violations := array.concat(_bench_violations, [_no_facts_msg]) if not _facts_supplied
+
+_violations := _bench_violations if _facts_supplied
+
+# No facts => every control is unverified, which counts as failed, not passed.
+_failed := _total_controls if not _facts_supplied
+
+_failed := count(_bench_violations) if _facts_supplied
 
 # Clamp: more violations than known controls must not yield a negative count.
 _passed := max([0, _total_controls - _failed])

--- a/benchmarks/cis/ubuntu_22_04/cis_ubuntu_2204_main.rego
+++ b/benchmarks/cis/ubuntu_22_04/cis_ubuntu_2204_main.rego
@@ -27,9 +27,41 @@ default _section_percentage := 0
 
 _section_percentage := bench.compliance_percentage
 
-default _violations := []
+# ---------------------------------------------------------------------------
+# FAIL-CLOSED GATE
+#
+# Most of these benchmarks express controls as "violate if the fact says X".
+# With NO facts, nothing iterates, no violation fires, and the benchmark
+# reports near-total compliance for an assessment that evaluated nothing.
+# Measured on empty input before this gate: cis_rhel10 99.0%, cis_azure 99.2%,
+# cis_docker 99.1%, cis_kubernetes 99.2%, cis_aws 97.1%, cis_rhel9 71.9%.
+#
+# Two historical rows in compliance_results for cis_rhel10 carry exactly the
+# empty-input signature (312/309/3 @ 99.04%) — this already reached the
+# database.
+#
+# A missing-facts assessment is now reported as fully non-compliant with an
+# explicit violation, never as a pass.
+#
+# LIMITATION: this gate detects a completely EMPTY input, not a partial one.
+# An input carrying one irrelevant key still evaluates normally, so sparse or
+# wrong-shaped facts can still under-report violations. Per-benchmark required-
+# key assertions would be the stronger guarantee; that is a larger design change
+# and is not attempted here.
+# ---------------------------------------------------------------------------
 
-_violations := [v | some v in bench.violations]
+default _facts_supplied := false
+
+_facts_supplied if count(object.keys(input)) > 0
+
+_no_facts_msg := sprintf(
+	"FAIL-CLOSED: no facts supplied for %s — the assessment could not be evaluated. This is NOT a passing result; check that fact collection ran and produced input.",
+	["cis_ubuntu_2204"],
+)
+
+default _bench_violations := []
+
+_bench_violations := [v | some v in bench.violations]
 
 default _sections := {}
 
@@ -37,7 +69,14 @@ _sections := bench.module_status
 
 _total_controls := 188
 
-_failed := count(_violations)
+_violations := array.concat(_bench_violations, [_no_facts_msg]) if not _facts_supplied
+
+_violations := _bench_violations if _facts_supplied
+
+# No facts => every control is unverified, which counts as failed, not passed.
+_failed := _total_controls if not _facts_supplied
+
+_failed := count(_bench_violations) if _facts_supplied
 
 # Clamp: more violations than known controls must not yield a negative count.
 _passed := max([0, _total_controls - _failed])

--- a/benchmarks/cis/ubuntu_24_04/cis_ubuntu_2404_main.rego
+++ b/benchmarks/cis/ubuntu_24_04/cis_ubuntu_2404_main.rego
@@ -34,9 +34,41 @@ default _section_percentage := 0
 
 _section_percentage := bench.compliance_percentage
 
-default _violations := []
+# ---------------------------------------------------------------------------
+# FAIL-CLOSED GATE
+#
+# Most of these benchmarks express controls as "violate if the fact says X".
+# With NO facts, nothing iterates, no violation fires, and the benchmark
+# reports near-total compliance for an assessment that evaluated nothing.
+# Measured on empty input before this gate: cis_rhel10 99.0%, cis_azure 99.2%,
+# cis_docker 99.1%, cis_kubernetes 99.2%, cis_aws 97.1%, cis_rhel9 71.9%.
+#
+# Two historical rows in compliance_results for cis_rhel10 carry exactly the
+# empty-input signature (312/309/3 @ 99.04%) — this already reached the
+# database.
+#
+# A missing-facts assessment is now reported as fully non-compliant with an
+# explicit violation, never as a pass.
+#
+# LIMITATION: this gate detects a completely EMPTY input, not a partial one.
+# An input carrying one irrelevant key still evaluates normally, so sparse or
+# wrong-shaped facts can still under-report violations. Per-benchmark required-
+# key assertions would be the stronger guarantee; that is a larger design change
+# and is not attempted here.
+# ---------------------------------------------------------------------------
 
-_violations := [v | some v in bench.violations]
+default _facts_supplied := false
+
+_facts_supplied if count(object.keys(input)) > 0
+
+_no_facts_msg := sprintf(
+	"FAIL-CLOSED: no facts supplied for %s — the assessment could not be evaluated. This is NOT a passing result; check that fact collection ran and produced input.",
+	["cis_ubuntu_2404"],
+)
+
+default _bench_violations := []
+
+_bench_violations := [v | some v in bench.violations]
 
 default _sections := {}
 
@@ -44,7 +76,14 @@ _sections := bench.module_status
 
 _total_controls := 188
 
-_failed := count(_violations)
+_violations := array.concat(_bench_violations, [_no_facts_msg]) if not _facts_supplied
+
+_violations := _bench_violations if _facts_supplied
+
+# No facts => every control is unverified, which counts as failed, not passed.
+_failed := _total_controls if not _facts_supplied
+
+_failed := count(_bench_violations) if _facts_supplied
 
 # Clamp: more violations than known controls must not yield a negative count.
 _passed := max([0, _total_controls - _failed])

--- a/benchmarks/cis/windows_10/cis_windows_10.rego
+++ b/benchmarks/cis/windows_10/cis_windows_10.rego
@@ -1,4 +1,4 @@
-package cis
+package cis_windows_10
 
 # CIS Microsoft Windows 10 Enterprise Benchmark v4.0.0  
 # Center for Internet Security (CIS) Benchmark for Windows 10 Enterprise

--- a/benchmarks/cis/windows_server_2016/cis_windows_server_2016.rego
+++ b/benchmarks/cis/windows_server_2016/cis_windows_server_2016.rego
@@ -1,4 +1,4 @@
-package cis
+package cis_windows_server_2016
 
 # CIS Microsoft Windows Server 2016 Benchmark v1.4.0
 # Center for Internet Security (CIS) Benchmark for Windows Server 2016

--- a/benchmarks/cis/windows_server_2019_modular/cis_windows_2019_main.rego
+++ b/benchmarks/cis/windows_server_2019_modular/cis_windows_2019_main.rego
@@ -27,9 +27,41 @@ default _section_percentage := 0
 
 _section_percentage := bench.compliance_percentage
 
-default _violations := []
+# ---------------------------------------------------------------------------
+# FAIL-CLOSED GATE
+#
+# Most of these benchmarks express controls as "violate if the fact says X".
+# With NO facts, nothing iterates, no violation fires, and the benchmark
+# reports near-total compliance for an assessment that evaluated nothing.
+# Measured on empty input before this gate: cis_rhel10 99.0%, cis_azure 99.2%,
+# cis_docker 99.1%, cis_kubernetes 99.2%, cis_aws 97.1%, cis_rhel9 71.9%.
+#
+# Two historical rows in compliance_results for cis_rhel10 carry exactly the
+# empty-input signature (312/309/3 @ 99.04%) — this already reached the
+# database.
+#
+# A missing-facts assessment is now reported as fully non-compliant with an
+# explicit violation, never as a pass.
+#
+# LIMITATION: this gate detects a completely EMPTY input, not a partial one.
+# An input carrying one irrelevant key still evaluates normally, so sparse or
+# wrong-shaped facts can still under-report violations. Per-benchmark required-
+# key assertions would be the stronger guarantee; that is a larger design change
+# and is not attempted here.
+# ---------------------------------------------------------------------------
 
-_violations := [v | some v in bench.all_violations]
+default _facts_supplied := false
+
+_facts_supplied if count(object.keys(input)) > 0
+
+_no_facts_msg := sprintf(
+	"FAIL-CLOSED: no facts supplied for %s — the assessment could not be evaluated. This is NOT a passing result; check that fact collection ran and produced input.",
+	["cis_windows_2019"],
+)
+
+default _bench_violations := []
+
+_bench_violations := [v | some v in bench.all_violations]
 
 default _sections := {}
 
@@ -37,7 +69,14 @@ _sections := bench.section_compliance
 
 _total_controls := 179
 
-_failed := count(_violations)
+_violations := array.concat(_bench_violations, [_no_facts_msg]) if not _facts_supplied
+
+_violations := _bench_violations if _facts_supplied
+
+# No facts => every control is unverified, which counts as failed, not passed.
+_failed := _total_controls if not _facts_supplied
+
+_failed := count(_bench_violations) if _facts_supplied
 
 # Clamp: more violations than known controls must not yield a negative count.
 _passed := max([0, _total_controls - _failed])

--- a/benchmarks/cis/windows_server_2022/cis_windows_server_2022.rego
+++ b/benchmarks/cis/windows_server_2022/cis_windows_server_2022.rego
@@ -1,4 +1,4 @@
-package cis
+package cis_windows_server_2022_legacy
 
 # CIS Microsoft Windows Server 2022 Benchmark v5.0.0
 # Center for Internet Security (CIS) Benchmark for Windows Server 2022

--- a/benchmarks/cis/windows_server_2022_modular/cis_windows_2022_main.rego
+++ b/benchmarks/cis/windows_server_2022_modular/cis_windows_2022_main.rego
@@ -27,9 +27,41 @@ default _section_percentage := 0
 
 _section_percentage := bench.compliance_percentage
 
-default _violations := []
+# ---------------------------------------------------------------------------
+# FAIL-CLOSED GATE
+#
+# Most of these benchmarks express controls as "violate if the fact says X".
+# With NO facts, nothing iterates, no violation fires, and the benchmark
+# reports near-total compliance for an assessment that evaluated nothing.
+# Measured on empty input before this gate: cis_rhel10 99.0%, cis_azure 99.2%,
+# cis_docker 99.1%, cis_kubernetes 99.2%, cis_aws 97.1%, cis_rhel9 71.9%.
+#
+# Two historical rows in compliance_results for cis_rhel10 carry exactly the
+# empty-input signature (312/309/3 @ 99.04%) — this already reached the
+# database.
+#
+# A missing-facts assessment is now reported as fully non-compliant with an
+# explicit violation, never as a pass.
+#
+# LIMITATION: this gate detects a completely EMPTY input, not a partial one.
+# An input carrying one irrelevant key still evaluates normally, so sparse or
+# wrong-shaped facts can still under-report violations. Per-benchmark required-
+# key assertions would be the stronger guarantee; that is a larger design change
+# and is not attempted here.
+# ---------------------------------------------------------------------------
 
-_violations := [v | some v in bench.all_violations]
+default _facts_supplied := false
+
+_facts_supplied if count(object.keys(input)) > 0
+
+_no_facts_msg := sprintf(
+	"FAIL-CLOSED: no facts supplied for %s — the assessment could not be evaluated. This is NOT a passing result; check that fact collection ran and produced input.",
+	["cis_windows_2022"],
+)
+
+default _bench_violations := []
+
+_bench_violations := [v | some v in bench.all_violations]
 
 default _sections := {}
 
@@ -37,7 +69,14 @@ _sections := bench.section_compliance
 
 _total_controls := 196
 
-_failed := count(_violations)
+_violations := array.concat(_bench_violations, [_no_facts_msg]) if not _facts_supplied
+
+_violations := _bench_violations if _facts_supplied
+
+# No facts => every control is unverified, which counts as failed, not passed.
+_failed := _total_controls if not _facts_supplied
+
+_failed := count(_bench_violations) if _facts_supplied
 
 # Clamp: more violations than known controls must not yield a negative count.
 _passed := max([0, _total_controls - _failed])


### PR DESCRIPTION
Two production-blocking defects, both of which caused benchmarks to report
compliance they had not measured.

## 1. Benchmarks failed OPEN on missing facts

Most CIS controls are phrased "violate if the fact says X". Given NO facts,
nothing iterates, no violation fires, and the benchmark reported near-total
compliance for an assessment that evaluated nothing. Measured on empty input:

    cis_azure       99.2%        cis_rhel10      99.0%
    cis_kubernetes  99.2%        cis_aws         97.1%
    cis_docker      99.1%        cis_rhel9       71.9%
                                 cis_rhel8       69.7%

**This already reached the database.** The two `cis_rhel10` rows in
compliance_results (2026-06-05, 2026-06-23) read 312 controls / 309 passed /
3 failed / 99.04% — byte-identical to the empty-input signature.

Every bridge now carries a fail-closed gate: no facts => 0%, zero controls
passed, every control counted failed, and an explicit
`FAIL-CLOSED: no facts supplied for <key>` violation. A missing-facts
assessment can no longer be mistaken for a pass.

Documented limitation: the gate detects a completely empty input, not a
partial one. Sparse or wrong-shaped facts can still under-report. Per-benchmark
required-key assertions would be the stronger guarantee and are not attempted
here.

## 2. Fourteen benchmarks shared one `package cis` namespace

windows_10/2016/2022, docker, kubernetes, aws, azure, gcp, arista, cisco,
fortinet, juniper, palo_alto and the legacy redhat policy all declared bare
`package cis`, and 13 of them defined `violations`, `compliant`,
`detailed_findings` and `compliance_summary`. Partial rules merge silently, so
`data.cis.violations` returned Windows + Docker + Azure + AWS + Kubernetes
findings in one undifferentiated set, and the complete rules were
eval_conflict_error candidates.

Each now owns its own package. Two were renamed with a `_legacy` suffix
(`cis_windows_server_2022_legacy`, `cis_gcp_foundations`) because a modular
implementation already owns the natural name.

## Unblocked keys

The split lets the last four keys be bridged — `cis_aws`, `cis_azure`,
`cis_docker`, `cis_kubernetes` — and `cis_rhel10` gains one with no rename at
all, since `cis.rhel_10` is a distinct subpackage rather than part of the
collision.

**All 19 registered `cis_*` keys now resolve**, verified in both directions:
empty input fails closed, non-empty input evaluates normally.

## Consumer safety

Census run before renaming across ansible/, demos/, extensions/, scripts/,
examples/, install/ and AAC_Customer_Portal, covering both direct `data.cis`
references and `{{ policy_path }}`-style indirection. The live consumers
(`lab10_06a_cis_baseline.yml` -> `cis/rhel_10`,
`cis_amazon_linux_2023_assessment.yml` -> `cis/amazon_linux_2023`) both target
dotted subpackages, which are untouched.

`opa test . --ignore .github` -> 304/304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)