### PR TITLE
feat(critical-infrastructure): TSA Pipeline Security Directives (SD Pipeline-2021-01G + 02G)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ frameworks/                    Regulatory + management frameworks
 ├── privacy/                   GDPR, HIPAA, ISO 27701, CCPA
 ├── compliance/                NCSC CAF, NIS2
 ├── critical_infrastructure/   NERC-CIP, AMI/NIST IR 7628, IEC 62443,
-│                              NIST 800-82
+│                              NIST 800-82, TSA Pipeline Security Directives
 ├── regulatory/                CFR Part 11
 └── sovereignty/               Digital Sovereignty
 
@@ -69,7 +69,7 @@ threat_detection/              Behavioral threat patterns
 └── crypto_mining/             Crypto-miner indicators
 ```
 
-Headline count: **532 policy files** (613 including tests) across the above directories.
+Headline count: **545 policy files** (628 including tests) across the above directories.
 Count it, never quote it — `git ls-tree -r HEAD --name-only | grep '\.rego$' | grep -vcE '(^|/)(test_|.*_test\.rego$)'` — the number drifts with every merge.
 
 ## Skill: Rego v1 syntax (MANDATORY)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rego Policy Libraries
 
-> **532 production-ready OPA policies** covering CIS Benchmarks (with Level 2 hardening profiles), DISA STIGs, NIST, SOC 2, PCI-DSS, ISO 27001, NERC-CIP (with full data-source reference), IEC 62443, HIPAA, FedRAMP, CSA CCM, CCPA/CPRA, EU AI Act, GEISA, and more — all in Rego v1 syntax, ready to load into any OPA instance.
+> **545 production-ready OPA policies** covering CIS Benchmarks (with Level 2 hardening profiles), DISA STIGs, NIST, SOC 2, PCI-DSS, ISO 27001, NERC-CIP (with full data-source reference), IEC 62443, HIPAA, FedRAMP, CSA CCM, CCPA/CPRA, EU AI Act, GEISA, and more — all in Rego v1 syntax, ready to load into any OPA instance.
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![OPA](https://img.shields.io/badge/OPA-v0.60%2B-blue)](https://www.openpolicyagent.org/)
@@ -18,7 +18,7 @@ This library gives you a **complete, working policy set on day one**, covering 2
 
 - Use **Rego v1 syntax** (`import rego.v1`) — no deprecation warnings, forward-compatible
 - Return **structured JSON reports** (compliant, score, violations list) — wire directly to dashboards or CI
-- Are **independently loadable** — use one framework or all 532 policies; no coupling
+- Are **independently loadable** — use one framework or all 545 policies; no coupling
 - Are **Apache 2.0 licensed** — use commercially without restriction
 
 > **Why not build your own?** You can — but CIS RHEL 9 alone has 338 controls across 14 sections. NERC-CIP covers 14 standards (CIP-002 through CIP-015) with 200+ requirements. IEC 62443 adds 51 System Requirements across 7 Foundational Requirements. Starting from scratch takes months. This library is that months-of-work already done.
@@ -64,6 +64,7 @@ This library gives you a **complete, working policy set on day one**, covering 2
 | **NIST SP 800-171 Rev 3** | `frameworks/federal/nist/sp_800_171/` | 14 families, 110 CUI requirements |
 | **CCPA / CPRA** | `frameworks/privacy/ccpa/` | Consumer rights, sensitive PI, data practices |
 | **EU AI Act (2024/1689)** | `governance/eu_ai_act/` | Prohibited, High-Risk, Transparency, GPAI, Governance |
+| **TSA Pipeline Security Directives** | `frameworks/critical_infrastructure/tsa_pipeline/` | SD Pipeline-2021-01G + 02G, 12 sections, 112 requirements |
 
 ---
 
@@ -72,7 +73,7 @@ This library gives you a **complete, working policy set on day one**, covering 2
 | Domain | Policies | Coverage |
 |--------|----------|----------|
 | **CIS Benchmarks + DISA STIGs** | 273 | 22 platforms: Linux, Windows, Cloud, Containers, Databases, Network + RHEL 8/9 & Windows 2022 STIGs. CIS benchmark versions updated to May 2026 releases; **Level 2 hardening profiles** for high-value targets (RHEL 9, Ubuntu 22.04, Windows Server 2022) |
-| **Regulatory Frameworks** | 225 | ISO 27001, SOC 2, PCI-DSS, SOX, FISMA, FedRAMP, CMMC, GDPR, HIPAA, NERC-CIP, IEC 62443, DORA, NIS2, NY DFS, SEC Cyber, SWIFT CSP, HITRUST, TISAX, CFR Part 11, NCSC CAF, Digital Sovereignty, CSA CCM v4.0, ISO 27701, NIST SP 800-171 r3, CCPA/CPRA |
+| **Regulatory Frameworks** | 238 | ISO 27001, SOC 2, PCI-DSS, SOX, FISMA, FedRAMP, CMMC, GDPR, HIPAA, NERC-CIP, IEC 62443, DORA, NIS2, NY DFS, SEC Cyber, SWIFT CSP, HITRUST, TISAX, CFR Part 11, NCSC CAF, Digital Sovereignty, CSA CCM v4.0, ISO 27701, NIST SP 800-171 r3, CCPA/CPRA |
 | **Enforcement** | 14 | Ansible, Terraform, Dockerfile, Kubernetes admission, Git approval/playbook docs, **CI/CD pipeline gating**, **SLSA supply-chain governance** |
 | **Governance** | 19 | AI agent authorization, MCP tool-call enforcement, GEISA (API/ADM/LEE/VEE), **EU AI Act (Regulation 2024/1689)** suite, **OIDC token validation**, **FinOps tagging** |
 | **Threat Detection** | 1 | Cryptocurrency miner detection |
@@ -99,7 +100,7 @@ This library gives you a **complete, working policy set on day one**, covering 2
 Pull the pre-built bundle directly from GitHub Container Registry — no clone needed:
 
 ```bash
-# Pull the full 532-policy bundle
+# Pull the full 545-policy bundle
 oras pull ghcr.io/ynotbhatc/rego_policy_libraries:latest
 
 # Start OPA with the bundle
@@ -169,7 +170,8 @@ rego_policy_libraries/
 │   ├── financial/               # PCI-DSS, SOX, SWIFT CSP, NY DFS, SEC Cyber
 │   ├── privacy/                 # GDPR, HIPAA, HITRUST, CFR Part 11, TISAX
 │   ├── regulatory/              # DORA, NIS2
-│   ├── critical_infrastructure/ # NERC-CIP (CIP-002–CIP-015), IEC 62443, NIST IR 7628
+│   ├── critical_infrastructure/ # NERC-CIP (CIP-002–CIP-015), IEC 62443, NIST IR 7628,
+│   │                            # NIST 800-82, TSA Pipeline Security Directives
 │   └── sovereignty/             # Digital Sovereignty (7 domains)
 │
 ├── enforcement/                 # Gate-style policy enforcement
@@ -254,6 +256,47 @@ Full library for IEC 62443 Industrial Automation and Control Systems (IACS) Secu
   }
 }
 ```
+
+---
+
+## TSA Pipeline Security Directives Coverage
+
+Both currently-effective TSA pipeline cybersecurity directives, in
+`frameworks/critical_infrastructure/tsa_pipeline/` — 12 section modules plus an
+orchestrator, covering 112 directive subparagraphs.
+
+| Directive | Effective | Sections covered |
+|---|---|---|
+| **SD Pipeline-2021-01G** — *Enhancing Pipeline Cybersecurity* | 2026-01-16 → 2027-01-15 | II.B Cybersecurity Coordinator · II.C Incident reporting to CISA · II.D Vulnerability assessment |
+| **SD Pipeline-2021-02G** — *Pipeline Cybersecurity Mitigation Actions, Contingency Planning, and Testing* | 2026-05-03 → 2027-05-02 | II.A/III.A Critical Cyber Systems · II.B/VI Implementation Plan + amendments · III.B Network segmentation · III.C Access control · III.D Continuous monitoring · III.E Patch management · III.F Incident Response Plan · III.G Assessment Plan · IV/V Records + SSI |
+
+**OPA endpoint:** `POST /v1/data/tsa_pipeline/main/compliance_report`
+
+The directives are largely deadline-driven, and the deadlines are what these
+policies assert — each is pinned by a test in
+`tests/test_tsa_pipeline_deadlines.rego`:
+
+| Clock | Directive |
+|---|---|
+| 72 hours — report incident to CISA | SD-01G II.C.3 |
+| 24 hours — supplemental information | SD-01G II.C.5.f |
+| 7 days — Coordinator info change | SD-01G II.B.1.e |
+| 60 days — "no Critical Cyber Systems" notice | SD-02G II.A.5 |
+| 45 / 50 / 30 days — permanent change · amendment filing · reconsideration petition | SD-02G VI.C / VI.D / VI.F |
+| 12 months, ≥ 2 objectives — Incident Response Plan exercise | SD-02G III.F.1.e |
+| 24 months — cybersecurity architecture design review | SD-02G III.G.2.b |
+| ⅓ per year, 100% over 3 years — assessment coverage | SD-02G III.G.2.d |
+| 12 months — Assessment Plan and report submission | SD-02G III.G.3–4 |
+| 24 hours — maximum packet capture period | SD-02G IV.C.2.e.ii |
+
+> **No fact source exists yet.** Both directives are overwhelmingly plan-,
+> attestation-, and recordkeeping-driven ("is there a TSA-approved Cybersecurity
+> Implementation Plan", "was the Assessment Plan submitted within 12 months").
+> None of that comes from host fact-gathering, and nothing currently emits the
+> `input` documented in each module header. On absent input this framework
+> reports **fully non-compliant across all 12 sections** — correct fail-closed
+> behavior for an audit framework, but not a working assessment until an
+> attestation intake or GRC export is wired up. Don't demo it as one.
 
 ---
 

--- a/frameworks/critical_infrastructure/tsa_pipeline/sd01_cybersecurity_coordinator.rego
+++ b/frameworks/critical_infrastructure/tsa_pipeline/sd01_cybersecurity_coordinator.rego
@@ -1,0 +1,226 @@
+package tsa_pipeline.sd01_coordinator
+
+import rego.v1
+
+# =============================================================================
+# TSA Security Directive Pipeline-2021-01G — "Enhancing Pipeline Cybersecurity"
+# Section II.B — Cybersecurity Coordinator
+#
+# Directive:  SD Pipeline-2021-01G
+# Effective:  January 16, 2026 through January 15, 2027
+# Supersedes: SD Pipeline-2021-01F
+# Authority:  49 U.S.C. 114(d), (f), (l), and (m)
+# Applies to: Owner/Operators of a hazardous liquid and natural gas pipeline or
+#             a liquefied natural gas facility notified by TSA that their
+#             pipeline system or facility is critical
+#
+# Requirements evaluated: II.B.1.a through II.B.2.d (12 subparagraphs)
+#
+# NOTE ON THE 01G REVISION: Section II.B.1.c is the substantive change in this
+# revision. Any non-U.S. citizen serving as a primary or alternate Cybersecurity
+# Coordinator must be a current member of NEXUS, Global Entry, or another
+# program TSA determines includes a comparable security threat assessment.
+#
+# --- INPUT CONTRACT ----------------------------------------------------------
+# input.cybersecurity_coordinator: {
+#   "primary": {
+#     "name":                     string,
+#     "title":                    string,
+#     "phone":                    string,
+#     "email":                    string,
+#     "corporate_level":          boolean,   # designated at the corporate level
+#     "us_citizen":               boolean,
+#     "clearance_eligible":       boolean,   # eligible for a security clearance
+#     "trusted_traveler_program": string,    # "NEXUS" | "Global Entry" | other
+#     "known_traveler_number":    string     # NEXUS PASS ID / KTN
+#   },
+#   "alternates": [ { ...same shape... } ],
+#   "submitted_to_tsa":                     boolean,
+#   "information_current":                  boolean,
+#   "days_since_information_change":        number,   # days since new operations
+#                                                    # commenced or info changed
+#   "us_citizen_primary_intelligence_contact": boolean,
+#   "us_person_restricted_info_procedures":    boolean,
+#   "primary_contact_for_tsa_cisa":            boolean,
+#   "available_24x7":                          boolean,
+#   "internal_coordination_documented":        boolean,
+#   "law_enforcement_liaison_established":     boolean
+# }
+#
+# NO FACT SOURCE EXISTS YET. Nothing in the compliance repo emits
+# input.cybersecurity_coordinator — these are attestation/document facts, not
+# host facts. Absent input this module reports fully non-compliant, which is
+# the correct fail-closed behavior for an audit framework. Do not present it as
+# a working assessment until a fact source is wired up.
+#
+# OPA endpoint: POST <opa_ot_url>/v1/data/tsa_pipeline/sd01_coordinator
+# =============================================================================
+
+# `input` is UNDEFINED (not {}) when OPA receives an empty request body. Routing
+# every lookup through this defaulted alias makes an absent fact evaluate to the
+# fail-closed default instead of silently skipping the violation rule entirely.
+default facts := {}
+
+facts := input
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+# ── Coordinator roster helpers ───────────────────────────────────────────────
+
+# Total: an absent or non-object "primary" yields an empty array, not undefined.
+primary_list := [c |
+	some c in [object.get(facts, ["cybersecurity_coordinator", "primary"], null)]
+	is_object(c)
+]
+
+alternate_list := [c |
+	some c in object.get(facts, ["cybersecurity_coordinator", "alternates"], [])
+	is_object(c)
+]
+
+all_coordinators := array.concat(primary_list, alternate_list)
+
+coordinator_name(c) := name if {
+	name := object.get(c, "name", "unnamed")
+}
+
+# A coordinator counts as a trusted-traveler member only with a non-empty
+# program AND a non-empty identifier — a program name alone proves nothing.
+has_trusted_traveler_membership(c) if {
+	object.get(c, "trusted_traveler_program", "") != ""
+	object.get(c, "known_traveler_number", "") != ""
+}
+
+us_citizen_clearance_eligible_present if {
+	some c in all_coordinators
+	object.get(c, "us_citizen", false) == true
+	object.get(c, "clearance_eligible", false) == true
+}
+
+# ── II.B.1.a — Designation ───────────────────────────────────────────────────
+
+violations contains msg if {
+	count(primary_list) == 0
+	msg := "TSA SD Pipeline-2021-01G II.B.1.a: No primary Cybersecurity Coordinator designated — Owner/Operators must designate and use a primary Cybersecurity Coordinator at the corporate level"
+}
+
+violations contains msg if {
+	count(alternate_list) == 0
+	msg := "TSA SD Pipeline-2021-01G II.B.1.a: No alternate Cybersecurity Coordinator designated — at least one alternate is required at the corporate level"
+}
+
+violations contains msg if {
+	some c in all_coordinators
+	object.get(c, "corporate_level", false) == false
+	msg := sprintf("TSA SD Pipeline-2021-01G II.B.1.a: Cybersecurity Coordinator '%s' is not designated at the corporate level", [coordinator_name(c)])
+}
+
+# ── II.B.1.b — U.S. citizen eligible for a security clearance ────────────────
+
+violations contains msg if {
+	count(all_coordinators) > 0
+	not us_citizen_clearance_eligible_present
+	msg := "TSA SD Pipeline-2021-01G II.B.1.b: Neither the Cybersecurity Coordinator nor any alternate is a U.S. citizen eligible for a security clearance"
+}
+
+# ── II.B.1.c — Non-U.S. citizen coordinators ─────────────────────────────────
+
+non_us_citizen_designated if {
+	some c in all_coordinators
+	object.get(c, "us_citizen", false) == false
+}
+
+violations contains msg if {
+	non_us_citizen_designated
+	object.get(facts, ["cybersecurity_coordinator", "us_citizen_primary_intelligence_contact"], false) == false
+	msg := "TSA SD Pipeline-2021-01G II.B.1.c.i: A non-U.S. citizen is designated as a Cybersecurity Coordinator, but the U.S. citizen Coordinator is not established as the primary contact for cyber-related intelligence information restricted to U.S. persons"
+}
+
+violations contains msg if {
+	some c in all_coordinators
+	object.get(c, "us_citizen", false) == false
+	not has_trusted_traveler_membership(c)
+	msg := sprintf("TSA SD Pipeline-2021-01G II.B.1.c.ii: Cybersecurity Coordinator '%s' is a non-U.S. citizen but is not a current member of NEXUS, Global Entry, or another TSA-determined comparable security threat assessment program", [coordinator_name(c)])
+}
+
+violations contains msg if {
+	non_us_citizen_designated
+	object.get(facts, ["cybersecurity_coordinator", "us_person_restricted_info_procedures"], false) == false
+	msg := "TSA SD Pipeline-2021-01G II.B.1.c.iii: No established and implemented procedures ensuring U.S.-person-restricted information is not shared with, or maintained on any system accessible by, a non-U.S. person"
+}
+
+# ── II.B.1.d — Written submission to TSA ─────────────────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["cybersecurity_coordinator", "submitted_to_tsa"], false) == false
+	msg := "TSA SD Pipeline-2021-01G II.B.1.d: Cybersecurity Coordinator information not provided in writing to TSA (SurfOps-SD@tsa.dhs.gov) — names, titles, phone numbers, and email addresses are required for all primary and alternate Coordinators"
+}
+
+violations contains msg if {
+	some c in all_coordinators
+	some field in ["name", "title", "phone", "email"]
+	object.get(c, field, "") == ""
+	msg := sprintf("TSA SD Pipeline-2021-01G II.B.1.d: Cybersecurity Coordinator '%s' is missing required submission field '%s'", [coordinator_name(c), field])
+}
+
+violations contains msg if {
+	some c in all_coordinators
+	object.get(c, "us_citizen", false) == false
+	object.get(c, "known_traveler_number", "") == ""
+	msg := sprintf("TSA SD Pipeline-2021-01G II.B.1.d: Non-U.S. citizen Cybersecurity Coordinator '%s' has no NEXUS PASS ID (Known Traveler Number) or other applicable program number on file with TSA", [coordinator_name(c)])
+}
+
+# ── II.B.1.e — Currency of information (7-day deadline) ──────────────────────
+
+violations contains msg if {
+	object.get(facts, ["cybersecurity_coordinator", "information_current"], false) == false
+	msg := "TSA SD Pipeline-2021-01G II.B.1.e: Cybersecurity Coordinator information on file with TSA is not current"
+}
+
+violations contains msg if {
+	days := object.get(facts, ["cybersecurity_coordinator", "days_since_information_change"], 0)
+	is_number(days)
+	days > 7
+	msg := sprintf("TSA SD Pipeline-2021-01G II.B.1.e: Cybersecurity Coordinator information change is %d days old — updates must be provided to TSA within 7 days of the commencement of new operations or a change in any required information", [days])
+}
+
+# ── II.B.2 — Coordinator duties ──────────────────────────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["cybersecurity_coordinator", "primary_contact_for_tsa_cisa"], false) == false
+	msg := "TSA SD Pipeline-2021-01G II.B.2.a: Cybersecurity Coordinator is not established as the primary contact for cybersecurity-related activities and communications with TSA and CISA"
+}
+
+violations contains msg if {
+	object.get(facts, ["cybersecurity_coordinator", "available_24x7"], false) == false
+	msg := "TSA SD Pipeline-2021-01G II.B.2.b: Cybersecurity Coordinator and alternate(s) are not accessible to TSA and CISA 24 hours a day, seven days a week, including when the U.S. Government is closed"
+}
+
+violations contains msg if {
+	object.get(facts, ["cybersecurity_coordinator", "internal_coordination_documented"], false) == false
+	msg := "TSA SD Pipeline-2021-01G II.B.2.c: No documented process for the Cybersecurity Coordinator to coordinate cyber and related security practices and procedures internally"
+}
+
+violations contains msg if {
+	object.get(facts, ["cybersecurity_coordinator", "law_enforcement_liaison_established"], false) == false
+	msg := "TSA SD Pipeline-2021-01G II.B.2.d: Cybersecurity Coordinator has no established working relationship with appropriate law enforcement and emergency response agencies"
+}
+
+# ── Compliance report ────────────────────────────────────────────────────────
+
+compliance_report := {
+	"directive": "TSA SD Pipeline-2021-01G",
+	"section": "II.B",
+	"name": "Cybersecurity Coordinator",
+	"effective_date": "2026-01-16",
+	"expiration_date": "2027-01-15",
+	"requirements_evaluated": 12,
+	"coordinators_designated": count(all_coordinators),
+	"compliant": compliant,
+	"violations": violations,
+	"violation_count": count(violations),
+}

--- a/frameworks/critical_infrastructure/tsa_pipeline/sd01_incident_reporting.rego
+++ b/frameworks/critical_infrastructure/tsa_pipeline/sd01_incident_reporting.rego
@@ -1,0 +1,174 @@
+package tsa_pipeline.sd01_reporting
+
+import rego.v1
+
+# =============================================================================
+# TSA Security Directive Pipeline-2021-01G — "Enhancing Pipeline Cybersecurity"
+# Section II.C — Reporting Cybersecurity Incidents
+#
+# Directive:  SD Pipeline-2021-01G
+# Effective:  January 16, 2026 through January 15, 2027
+#
+# Requirements evaluated: II.C.2 through II.C.5 (16 subparagraphs)
+#
+# NOTE: Section II.C of the published directive has no subparagraph "1" — the
+# section begins at II.C.2. Citations below reflect the directive as published.
+#
+# THE CLOCK: II.C.3 requires reporting "as soon as practicable, but no later
+# than 72 hours after the Owner/Operator identifies a cybersecurity incident."
+# II.C.5.f requires supplemental information within 24 hours of it becoming
+# available when the initial report was incomplete. Secondary summaries citing
+# a 12-hour deadline are wrong; 72 hours is the directive text.
+#
+# --- INPUT CONTRACT ----------------------------------------------------------
+# input.incident_reporting: {
+#   "procedure_documented":         boolean,
+#   "reports_to_cisa_central":      boolean,  # CISA Incident Reporting System
+#                                             # (cisa.gov/report) or 844-729-2472
+#   "covered_incident_categories":  [string], # see required_categories below
+#   "required_report_fields":       [string], # see required_report_fields below
+#   "supplemental_within_24h_procedure": boolean,
+#   "incidents": [ {
+#       "id":                 string,
+#       "identified_at":      string,   # RFC3339
+#       "hours_to_report":    number,   # identification -> CISA report
+#       "reported_to_cisa":   boolean,
+#       "sd_reporting_stated": boolean, # report explicitly states it is filed to
+#                                       # satisfy this SD's requirements (II.C.5.a)
+#       "initial_report_incomplete":       boolean,
+#       "supplemental_hours_after_available": number
+#   } ]
+# }
+#
+# NO FACT SOURCE EXISTS YET — see sd01_cybersecurity_coordinator.rego.
+#
+# OPA endpoint: POST <opa_ot_url>/v1/data/tsa_pipeline/sd01_reporting
+# =============================================================================
+
+# `input` is UNDEFINED (not {}) when OPA receives an empty request body. Routing
+# every lookup through this defaulted alias makes an absent fact evaluate to the
+# fail-closed default instead of silently skipping the violation rule entirely.
+default facts := {}
+
+facts := input
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+# ── Reference sets (II.C.2.a–e and II.C.5.a–f) ───────────────────────────────
+
+required_categories := {
+	"unauthorized_access": "II.C.2.a: Unauthorized access of an Information or Operational Technology system",
+	"malicious_software": "II.C.2.b: Discovery of malicious software on an Information or Operational Technology system",
+	"denial_of_service": "II.C.2.c: Activity resulting in a denial of service to any Information or Operational Technology system",
+	"physical_attack": "II.C.2.d: A physical attack against the Owner/Operator's network infrastructure",
+	"operational_disruption_potential": "II.C.2.e: Any other cybersecurity incident that results in, or has the potential to result in, operational disruption",
+}
+
+required_report_fields := {
+	"reporter_contact": "II.C.5.a: Name of the reporting individual and contact information",
+	"affected_assets": "II.C.5.b: The affected pipeline(s) and/or facilities, including identifying information and location",
+	"threat_description": "II.C.5.c: Description of the threat, incident, or activity (earliest known date of compromise, date of detection, who was notified, observed indicators, known threat information)",
+	"impact_assessment": "II.C.5.d: Description of the incident's impact or potential impact on Information or Operational Technology systems and operations",
+	"planned_response": "II.C.5.e: Description of all responses planned or under consideration",
+	"additional_information": "II.C.5.f: Any additional relevant information",
+}
+
+declared_categories := {c | some c in object.get(facts, ["incident_reporting", "covered_incident_categories"], [])}
+
+declared_report_fields := {f | some f in object.get(facts, ["incident_reporting", "required_report_fields"], [])}
+
+incidents := [i |
+	some i in object.get(facts, ["incident_reporting", "incidents"], [])
+	is_object(i)
+]
+
+incident_id(i) := id if {
+	id := object.get(i, "id", "unidentified")
+}
+
+# ── II.C.2 — Reportable incident categories ──────────────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["incident_reporting", "procedure_documented"], false) == false
+	msg := "TSA SD Pipeline-2021-01G II.C: No documented procedure for reporting cybersecurity incidents to CISA for systems the Owner/Operator has responsibility to operate and/or maintain"
+}
+
+violations contains msg if {
+	some category, description in required_categories
+	not category in declared_categories
+	msg := sprintf("TSA SD Pipeline-2021-01G %s — this incident category is not covered by the Owner/Operator's CISA reporting procedure", [description])
+}
+
+# ── II.C.3 — 72-hour reporting deadline ──────────────────────────────────────
+
+violations contains msg if {
+	some i in incidents
+	object.get(i, "reported_to_cisa", false) == false
+	msg := sprintf("TSA SD Pipeline-2021-01G II.C.3: Cybersecurity incident '%s' was never reported to CISA — reporting is mandatory for all incidents described in Section II.C.2", [incident_id(i)])
+}
+
+violations contains msg if {
+	some i in incidents
+	object.get(i, "reported_to_cisa", false) == true
+	hours := object.get(i, "hours_to_report", 0)
+	is_number(hours)
+	hours > 72
+	msg := sprintf("TSA SD Pipeline-2021-01G II.C.3: Cybersecurity incident '%s' was reported to CISA %v hours after identification — reports must be made as soon as practicable but no later than 72 hours", [incident_id(i), hours])
+}
+
+# ── II.C.4 — Reporting channel ───────────────────────────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["incident_reporting", "reports_to_cisa_central"], false) == false
+	msg := "TSA SD Pipeline-2021-01G II.C.4: Reports are not made to CISA Central using CISA's Incident Reporting System (https://www.cisa.gov/report) or by calling (844) 729-2472"
+}
+
+# ── II.C.5 — Required report content ─────────────────────────────────────────
+
+violations contains msg if {
+	some field, description in required_report_fields
+	not field in declared_report_fields
+	msg := sprintf("TSA SD Pipeline-2021-01G %s — this element is not included in the Owner/Operator's CISA report content", [description])
+}
+
+violations contains msg if {
+	some i in incidents
+	object.get(i, "reported_to_cisa", false) == true
+	object.get(i, "sd_reporting_stated", false) == false
+	msg := sprintf("TSA SD Pipeline-2021-01G II.C.5.a: Report for incident '%s' does not explicitly specify that the information is being reported to satisfy the reporting requirements in this Security Directive", [incident_id(i)])
+}
+
+# ── II.C.5.f — 24-hour supplemental reporting ────────────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["incident_reporting", "supplemental_within_24h_procedure"], false) == false
+	msg := "TSA SD Pipeline-2021-01G II.C.5.f: No procedure to submit an initial report within the required timeframe and provide supplemental information within 24 hours of it becoming available"
+}
+
+violations contains msg if {
+	some i in incidents
+	object.get(i, "initial_report_incomplete", false) == true
+	hours := object.get(i, "supplemental_hours_after_available", 0)
+	is_number(hours)
+	hours > 24
+	msg := sprintf("TSA SD Pipeline-2021-01G II.C.5.f: Supplemental information for incident '%s' was provided %v hours after becoming available — it must be provided within 24 hours", [incident_id(i), hours])
+}
+
+# ── Compliance report ────────────────────────────────────────────────────────
+
+compliance_report := {
+	"directive": "TSA SD Pipeline-2021-01G",
+	"section": "II.C",
+	"name": "Reporting Cybersecurity Incidents",
+	"reporting_deadline_hours": 72,
+	"supplemental_deadline_hours": 24,
+	"requirements_evaluated": 16,
+	"incidents_assessed": count(incidents),
+	"compliant": compliant,
+	"violations": violations,
+	"violation_count": count(violations),
+}

--- a/frameworks/critical_infrastructure/tsa_pipeline/sd01_vulnerability_assessment.rego
+++ b/frameworks/critical_infrastructure/tsa_pipeline/sd01_vulnerability_assessment.rego
@@ -1,0 +1,111 @@
+package tsa_pipeline.sd01_vulnerability_assessment
+
+import rego.v1
+
+# =============================================================================
+# TSA Security Directive Pipeline-2021-01G — "Enhancing Pipeline Cybersecurity"
+# Section II.D — Cybersecurity Vulnerability Assessment
+#
+# Directive:  SD Pipeline-2021-01G
+# Effective:  January 16, 2026 through January 15, 2027
+#
+# Requirements evaluated: II.D.1 through II.D.3 (6 subparagraphs)
+#
+# The assessment is performed against Section 7 of TSA's 2018 Pipeline Security
+# Guidelines (with Change 1, April 2021), using TSA Form 1604 "Pipeline
+# Cybersecurity Self-Assessment". The completed form becomes Sensitive Security
+# Information under 49 CFR part 1520 once any question is answered.
+#
+# --- INPUT CONTRACT ----------------------------------------------------------
+# input.vulnerability_assessment: {
+#   "guidelines_section_7_reviewed":  boolean,
+#   "alignment_assessed":             boolean,  # IT and OT cyber risk practices
+#   "gaps_identified":                boolean,
+#   "remediation_measures_identified": boolean,
+#   "remediation_timeline_defined":   boolean,
+#   "tsa_form_1604_used":             boolean,
+#   "submitted_to_tsa":               boolean,
+#   "ssi_protected_transmission":     boolean   # 49 CFR part 1520 handling
+# }
+#
+# NO FACT SOURCE EXISTS YET — see sd01_cybersecurity_coordinator.rego.
+#
+# OPA endpoint: POST <opa_ot_url>/v1/data/tsa_pipeline/sd01_vulnerability_assessment
+# =============================================================================
+
+# `input` is UNDEFINED (not {}) when OPA receives an empty request body. Routing
+# every lookup through this defaulted alias makes an absent fact evaluate to the
+# fail-closed default instead of silently skipping the violation rule entirely.
+default facts := {}
+
+facts := input
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+va_flag(field) := value if {
+	value := object.get(facts, ["vulnerability_assessment", field], false)
+}
+
+# ── II.D.1 — Assessment against the 2018 Pipeline Security Guidelines ────────
+
+violations contains msg if {
+	va_flag("guidelines_section_7_reviewed") == false
+	msg := "TSA SD Pipeline-2021-01G II.D.1: Section 7 of TSA's 2018 Pipeline Security Guidelines (with Change 1, April 2021) has not been reviewed"
+}
+
+violations contains msg if {
+	va_flag("alignment_assessed") == false
+	msg := "TSA SD Pipeline-2021-01G II.D.1.a: No assessment of whether current practices and activities addressing cyber risks to Information and Operational Technology systems align with the Pipeline Security Guidelines"
+}
+
+violations contains msg if {
+	va_flag("gaps_identified") == false
+	msg := "TSA SD Pipeline-2021-01G II.D.1.b: Gaps between current practices and the Pipeline Security Guidelines have not been identified"
+}
+
+violations contains msg if {
+	va_flag("remediation_measures_identified") == false
+	msg := "TSA SD Pipeline-2021-01G II.D.1.c: Remediation measures to fill identified gaps have not been identified"
+}
+
+violations contains msg if {
+	va_flag("remediation_timeline_defined") == false
+	msg := "TSA SD Pipeline-2021-01G II.D.1.c: No timeline defined for implementing the identified remediation measures"
+}
+
+# ── II.D.2 — TSA-provided form ───────────────────────────────────────────────
+
+violations contains msg if {
+	va_flag("tsa_form_1604_used") == false
+	msg := "TSA SD Pipeline-2021-01G II.D.2: The assessment and gap identification were not completed using the form provided by TSA (TSA Form 1604, Pipeline Cybersecurity Self-Assessment)"
+}
+
+# ── II.D.3 — Submission to TSA with SSI protection ───────────────────────────
+
+violations contains msg if {
+	va_flag("submitted_to_tsa") == false
+	msg := "TSA SD Pipeline-2021-01G II.D.3: The completed vulnerability assessment form and remediation plan have not been submitted to TSA (SurfOps-SD@tsa.dhs.gov)"
+}
+
+violations contains msg if {
+	va_flag("ssi_protected_transmission") == false
+	msg := "TSA SD Pipeline-2021-01G II.D.3: The vulnerability assessment and remediation plan are not transmitted using methods appropriate to protect Sensitive Security Information under 49 CFR part 1520"
+}
+
+# ── Compliance report ────────────────────────────────────────────────────────
+
+compliance_report := {
+	"directive": "TSA SD Pipeline-2021-01G",
+	"section": "II.D",
+	"name": "Cybersecurity Vulnerability Assessment",
+	"assessment_baseline": "TSA 2018 Pipeline Security Guidelines, Section 7 (with Change 1, April 2021)",
+	"assessment_form": "TSA Form 1604 — Pipeline Cybersecurity Self-Assessment",
+	"requirements_evaluated": 6,
+	"compliant": compliant,
+	"violations": violations,
+	"violation_count": count(violations),
+}

--- a/frameworks/critical_infrastructure/tsa_pipeline/sd02_access_control.rego
+++ b/frameworks/critical_infrastructure/tsa_pipeline/sd02_access_control.rego
@@ -1,0 +1,213 @@
+package tsa_pipeline.sd02_access_control
+
+import rego.v1
+
+# =============================================================================
+# TSA Security Directive Pipeline-2021-02G
+# Section III.C — Access Control Measures
+#
+# Directive:  SD Pipeline-2021-02G
+# Effective:  May 3, 2026 through May 2, 2027
+#
+# Requirements evaluated: III.C.1.a–b, III.C.2, III.C.3, III.C.4.a–b,
+#                         III.C.5 (8 subparagraphs)
+#
+# III.C requires access control measures, "including for local and remote
+# access, to secure and prevent unauthorized access to Critical Cyber Systems."
+#
+# Two carve-outs in the directive text are modeled as conditional compensating
+# control requirements rather than hard failures:
+#   - III.C.2: an Owner/Operator that does not apply MFA to industrial control
+#     workstations in control rooms regulated under 49 CFR parts 192 or 195
+#     "shall specify what compensating controls are used to manage access."
+#   - III.C.3: where least privilege and separation of duties are not
+#     technically feasible, the policies must describe the compensating controls.
+#
+# --- INPUT CONTRACT ----------------------------------------------------------
+# input.access_control: {
+#   "policy_documented":       boolean,
+#   "covers_local_and_remote": boolean,
+#   "identification_authentication": {
+#       "policy_documented":            boolean,
+#       "password_reset_schedule_defined": boolean,   # III.C.1.a
+#       "components_exempt_from_reset": [ {           # III.C.1.b
+#           "name":                  string,
+#           "mitigations_documented": boolean,
+#           "mitigation_timeframe_defined": boolean
+#       } ]
+#   },
+#   "multi_factor_authentication": {                   # III.C.2
+#       "implemented":                    boolean,
+#       "control_room_workstations_exempt": boolean,   # 49 CFR parts 192/195
+#       "compensating_controls_specified": boolean
+#   },
+#   "least_privilege": {                               # III.C.3
+#       "implemented":                    boolean,
+#       "separation_of_duties":           boolean,
+#       "not_technically_feasible":       boolean,
+#       "compensating_controls_described": boolean
+#   },
+#   "shared_accounts": {                               # III.C.4
+#       "policy_documented":              boolean,
+#       "limited_to_operations_critical": boolean,
+#       "accounts": [ {
+#           "name":                        string,
+#           "operations_critical":         boolean,
+#           "least_privilege_managed":     boolean,   # III.C.4.a
+#           "credential_rotated_on_departure": boolean # III.C.4.b
+#       } ]
+#   },
+#   "domain_trusts": {                                 # III.C.5
+#       "review_schedule_defined":  boolean,
+#       "management_policy_defined": boolean
+#   }
+# }
+#
+# NO FACT SOURCE EXISTS YET — see sd01_cybersecurity_coordinator.rego.
+#
+# OPA endpoint: POST <opa_ot_url>/v1/data/tsa_pipeline/sd02_access_control
+# =============================================================================
+
+# `input` is UNDEFINED (not {}) when OPA receives an empty request body. Routing
+# every lookup through this defaulted alias makes an absent fact evaluate to the
+# fail-closed default instead of silently skipping the violation rule entirely.
+default facts := {}
+
+facts := input
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+exempt_components := [c |
+	some c in object.get(facts, ["access_control", "identification_authentication", "components_exempt_from_reset"], [])
+	is_object(c)
+]
+
+shared_accounts := [a |
+	some a in object.get(facts, ["access_control", "shared_accounts", "accounts"], [])
+	is_object(a)
+]
+
+# ── III.C — Access control measures exist ────────────────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["access_control", "policy_documented"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.C: No documented access control measures to secure and prevent unauthorized access to Critical Cyber Systems"
+}
+
+violations contains msg if {
+	object.get(facts, ["access_control", "covers_local_and_remote"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.C: Access control measures do not cover both local and remote access to Critical Cyber Systems"
+}
+
+# ── III.C.1 — Identification and authentication ──────────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["access_control", "identification_authentication", "policy_documented"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.C.1: No identification and authentication policies and procedures designed to prevent unauthorized access to Critical Cyber Systems"
+}
+
+violations contains msg if {
+	object.get(facts, ["access_control", "identification_authentication", "password_reset_schedule_defined"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.C.1.a: No schedule defined for memorized secret authenticator resets"
+}
+
+violations contains msg if {
+	some c in exempt_components
+	object.get(c, "mitigations_documented", false) == false
+	msg := sprintf("TSA SD Pipeline-2021-02G III.C.1.b: Critical Cyber System component '%s' is exempt from the password reset schedule but has no documented and defined mitigation measures", [object.get(c, "name", "unnamed")])
+}
+
+violations contains msg if {
+	some c in exempt_components
+	object.get(c, "mitigation_timeframe_defined", false) == false
+	msg := sprintf("TSA SD Pipeline-2021-02G III.C.1.b: Critical Cyber System component '%s' is exempt from the password reset schedule but has no timeframe to complete its mitigations", [object.get(c, "name", "unnamed")])
+}
+
+# ── III.C.2 — Multi-factor authentication ────────────────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["access_control", "multi_factor_authentication", "implemented"], false) == false
+	object.get(facts, ["access_control", "multi_factor_authentication", "control_room_workstations_exempt"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.C.2: Multi-factor authentication — or other logical and physical security controls supplementing password authentication to provide commensurate risk mitigation — is not implemented"
+}
+
+violations contains msg if {
+	object.get(facts, ["access_control", "multi_factor_authentication", "control_room_workstations_exempt"], false) == true
+	object.get(facts, ["access_control", "multi_factor_authentication", "compensating_controls_specified"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.C.2: Multi-factor authentication is not applied to industrial control workstations in control rooms regulated under 49 CFR parts 192 or 195, and the compensating controls used to manage access are not specified"
+}
+
+# ── III.C.3 — Least privilege and separation of duties ───────────────────────
+
+violations contains msg if {
+	object.get(facts, ["access_control", "least_privilege", "implemented"], false) == false
+	object.get(facts, ["access_control", "least_privilege", "not_technically_feasible"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.C.3: No policies and procedures to manage access rights based on the principle of least privilege"
+}
+
+violations contains msg if {
+	object.get(facts, ["access_control", "least_privilege", "separation_of_duties"], false) == false
+	object.get(facts, ["access_control", "least_privilege", "not_technically_feasible"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.C.3: No policies and procedures to manage access rights based on the principle of separation of duties"
+}
+
+violations contains msg if {
+	object.get(facts, ["access_control", "least_privilege", "not_technically_feasible"], false) == true
+	object.get(facts, ["access_control", "least_privilege", "compensating_controls_described"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.C.3: Least privilege and separation of duties are declared not technically feasible, but the policies and procedures do not describe the compensating controls the Owner/Operator will apply"
+}
+
+# ── III.C.4 — Shared accounts ────────────────────────────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["access_control", "shared_accounts", "policy_documented"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.C.4: No enforced standards limiting the availability and use of shared accounts"
+}
+
+violations contains msg if {
+	some a in shared_accounts
+	object.get(a, "operations_critical", false) == false
+	msg := sprintf("TSA SD Pipeline-2021-02G III.C.4: Shared account '%s' is not critical for operations — shared accounts must be limited to those critical for operations, and then only if absolutely necessary", [object.get(a, "name", "unnamed")])
+}
+
+violations contains msg if {
+	some a in shared_accounts
+	object.get(a, "least_privilege_managed", false) == false
+	msg := sprintf("TSA SD Pipeline-2021-02G III.C.4.a: Access to shared account '%s' is not limited through account management that uses the principles of least privilege and separation of duties", [object.get(a, "name", "unnamed")])
+}
+
+violations contains msg if {
+	some a in shared_accounts
+	object.get(a, "credential_rotated_on_departure", false) == false
+	msg := sprintf("TSA SD Pipeline-2021-02G III.C.4.b: Shared account '%s' has no process ensuring individuals who no longer need access do not retain knowledge of the password", [object.get(a, "name", "unnamed")])
+}
+
+# ── III.C.5 — Domain trust relationships ─────────────────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["access_control", "domain_trusts", "review_schedule_defined"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.C.5: No schedule for review of existing domain trust relationships to ensure their necessity"
+}
+
+violations contains msg if {
+	object.get(facts, ["access_control", "domain_trusts", "management_policy_defined"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.C.5: No policies to manage domain trusts"
+}
+
+# ── Compliance report ────────────────────────────────────────────────────────
+
+compliance_report := {
+	"directive": "TSA SD Pipeline-2021-02G",
+	"section": "III.C",
+	"name": "Access Control Measures",
+	"requirements_evaluated": 8,
+	"shared_accounts_assessed": count(shared_accounts),
+	"reset_exempt_components_assessed": count(exempt_components),
+	"compliant": compliant,
+	"violations": violations,
+	"violation_count": count(violations),
+}

--- a/frameworks/critical_infrastructure/tsa_pipeline/sd02_assessment_plan.rego
+++ b/frameworks/critical_infrastructure/tsa_pipeline/sd02_assessment_plan.rego
@@ -1,0 +1,215 @@
+package tsa_pipeline.sd02_assessment_plan
+
+import rego.v1
+
+# =============================================================================
+# TSA Security Directive Pipeline-2021-02G
+# Section III.G — Cybersecurity Assessment Plan
+#
+# Directive:  SD Pipeline-2021-02G
+# Effective:  May 3, 2026 through May 2, 2027
+#
+# Requirements evaluated: III.G.1, III.G.2.a–e, III.G.3, III.G.4
+#                         (10 subparagraphs)
+#
+# THE CLOCKS in this section:
+#   III.G.2.b — cybersecurity architecture design review at least once every
+#               TWO years
+#   III.G.2.d — schedule must assess at least ONE-THIRD of the policies,
+#               procedures, measures, and capabilities in the TSA-approved
+#               Cybersecurity Implementation Plan each year, with 100 percent
+#               assessed over any THREE-year period
+#   III.G.3   — Cybersecurity Assessment Plan submitted annually, no later than
+#               12 months from the date of TSA's approval of the previous Plan
+#   III.G.4   — Assessment Plan report submitted no later than 12 months from
+#               the date of TSA's approval of the most recent Assessment Plan
+#
+# --- INPUT CONTRACT ----------------------------------------------------------
+# input.assessment_plan: {
+#   "exists":                     boolean,
+#   "assesses_critical_cyber_systems": boolean,
+#   "implementation_plan_effectiveness_assessed": boolean,   # III.G.2.a
+#   "architecture_design_review": {                          # III.G.2.b
+#       "conducted":                    boolean,
+#       "months_since_last_review":     number,   # must be <= 24
+#       "network_traffic_verified":     boolean,
+#       "system_log_review_conducted":  boolean
+#   },
+#   "other_assessment_capabilities": {                       # III.G.2.c
+#       "penetration_testing":  boolean,
+#       "red_or_purple_team":   boolean
+#   },
+#   "schedule": {                                            # III.G.2.d
+#       "defined":                        boolean,
+#       "annual_coverage_percent":        number,   # must be >= 33
+#       "three_year_coverage_percent":    number    # must be 100
+#   },
+#   "annual_report": {                                       # III.G.2.e, III.G.4
+#       "submitted":                    boolean,
+#       "months_since_plan_approval":   number,   # must be <= 12
+#       "methods_documented":           boolean,  # G.2.e.i
+#       "results_documented":           boolean   # G.2.e.ii
+#   },
+#   "submission": {                                          # III.G.3
+#       "submitted_to_tsa":             boolean,
+#       "months_since_previous_approval": number   # must be <= 12
+#   }
+# }
+#
+# NO FACT SOURCE EXISTS YET — see sd01_cybersecurity_coordinator.rego.
+#
+# OPA endpoint: POST <opa_ot_url>/v1/data/tsa_pipeline/sd02_assessment_plan
+# =============================================================================
+
+# `input` is UNDEFINED (not {}) when OPA receives an empty request body. Routing
+# every lookup through this defaulted alias makes an absent fact evaluate to the
+# fail-closed default instead of silently skipping the violation rule entirely.
+default facts := {}
+
+facts := input
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+cap_flag(path) := value if {
+	value := object.get(facts, array.concat(["assessment_plan"], path), false)
+}
+
+cap_number(path, fallback) := value if {
+	raw := object.get(facts, array.concat(["assessment_plan"], path), fallback)
+	is_number(raw)
+	value := raw
+}
+
+cap_number(path, fallback) := fallback if {
+	raw := object.get(facts, array.concat(["assessment_plan"], path), fallback)
+	not is_number(raw)
+}
+
+# ── III.G.1 — Plan exists ────────────────────────────────────────────────────
+
+violations contains msg if {
+	cap_flag(["exists"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.G.1: No Cybersecurity Assessment Plan developed for proactively assessing and auditing cybersecurity measures"
+}
+
+violations contains msg if {
+	cap_flag(["assesses_critical_cyber_systems"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.G.1: The Cybersecurity Assessment Plan does not proactively assess Critical Cyber Systems to ascertain the effectiveness of cybersecurity measures and to identify and resolve device, network, and/or system vulnerabilities"
+}
+
+# ── III.G.2.a — Effectiveness of the Implementation Plan ─────────────────────
+
+violations contains msg if {
+	cap_flag(["implementation_plan_effectiveness_assessed"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.G.2.a: The Cybersecurity Assessment Plan does not assess the effectiveness of the Owner/Operator's TSA-approved Cybersecurity Implementation Plan"
+}
+
+# ── III.G.2.b — Architecture design review (every 2 years) ───────────────────
+
+violations contains msg if {
+	cap_flag(["architecture_design_review", "conducted"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.G.2.b: No cybersecurity architecture design review — one is required at least once every two years"
+}
+
+violations contains msg if {
+	months := cap_number(["architecture_design_review", "months_since_last_review"], 0)
+	months > 24
+	msg := sprintf("TSA SD Pipeline-2021-02G III.G.2.b: The last cybersecurity architecture design review was %v months ago — a review is required at least once every two years (24 months)", [months])
+}
+
+violations contains msg if {
+	cap_flag(["architecture_design_review", "network_traffic_verified"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.G.2.b: The cybersecurity architecture design review does not include verification and validation of network traffic"
+}
+
+violations contains msg if {
+	cap_flag(["architecture_design_review", "system_log_review_conducted"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.G.2.b: The cybersecurity architecture design review does not include system log review and analysis to identify vulnerabilities related to network design, configuration, and inter-connectivity to internal and external systems"
+}
+
+# ── III.G.2.c — Other assessment capabilities ────────────────────────────────
+
+violations contains msg if {
+	cap_flag(["other_assessment_capabilities", "penetration_testing"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.G.2.c: The Cybersecurity Assessment Plan does not incorporate penetration testing of Information Technology systems"
+}
+
+violations contains msg if {
+	cap_flag(["other_assessment_capabilities", "red_or_purple_team"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.G.2.c: The Cybersecurity Assessment Plan does not incorporate 'red' or 'purple' team (adversarial perspective) testing"
+}
+
+# ── III.G.2.d — Assessment schedule and coverage ─────────────────────────────
+
+violations contains msg if {
+	cap_flag(["schedule", "defined"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.G.2.d: No schedule for assessing and auditing the specific cybersecurity measures and actions required by III.G.2.a through III.G.2.c"
+}
+
+violations contains msg if {
+	coverage := cap_number(["schedule", "annual_coverage_percent"], 0)
+	coverage < 33
+	msg := sprintf("TSA SD Pipeline-2021-02G III.G.2.d: The assessment schedule covers %v percent of the policies, procedures, measures, and capabilities in the TSA-approved Cybersecurity Implementation Plan each year — at least one-third must be assessed annually", [coverage])
+}
+
+violations contains msg if {
+	coverage := cap_number(["schedule", "three_year_coverage_percent"], 0)
+	coverage < 100
+	msg := sprintf("TSA SD Pipeline-2021-02G III.G.2.d: The assessment schedule reaches %v percent coverage over a three-year period — 100 percent must be assessed over any three-year period", [coverage])
+}
+
+# ── III.G.2.e / III.G.4 — Annual report ──────────────────────────────────────
+
+violations contains msg if {
+	cap_flag(["annual_report", "submitted"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.G.2.e: The Cybersecurity Assessment Plan annual report of assessment results has not been submitted to TSA"
+}
+
+violations contains msg if {
+	cap_flag(["annual_report", "methods_documented"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.G.2.e.i: The annual report does not indicate which assessment method(s) were used in the previous 12 months to determine whether the policies, procedures, and capabilities described in the Cybersecurity Implementation Plan are effective"
+}
+
+violations contains msg if {
+	cap_flag(["annual_report", "results_documented"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.G.2.e.ii: The annual report does not include the results of the individual assessments conducted in the previous 12 months"
+}
+
+violations contains msg if {
+	months := cap_number(["annual_report", "months_since_plan_approval"], 0)
+	months > 12
+	msg := sprintf("TSA SD Pipeline-2021-02G III.G.4: The Cybersecurity Assessment Plan report was submitted %v months from the date of TSA's approval of the most recent Assessment Plan — it must be submitted no later than 12 months", [months])
+}
+
+# ── III.G.3 — Annual plan submission ─────────────────────────────────────────
+
+violations contains msg if {
+	cap_flag(["submission", "submitted_to_tsa"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.G.3: The Cybersecurity Assessment Plan has not been submitted to TSA for approval — submission is required on an annual basis"
+}
+
+violations contains msg if {
+	months := cap_number(["submission", "months_since_previous_approval"], 0)
+	months > 12
+	msg := sprintf("TSA SD Pipeline-2021-02G III.G.3: The Cybersecurity Assessment Plan was submitted %v months from the date of TSA's approval of the previous Plan — it must be submitted no later than 12 months", [months])
+}
+
+# ── Compliance report ────────────────────────────────────────────────────────
+
+compliance_report := {
+	"directive": "TSA SD Pipeline-2021-02G",
+	"section": "III.G",
+	"name": "Cybersecurity Assessment Plan",
+	"architecture_review_interval_months": 24,
+	"minimum_annual_coverage_percent": 33,
+	"required_three_year_coverage_percent": 100,
+	"plan_submission_interval_months": 12,
+	"requirements_evaluated": 10,
+	"compliant": compliant,
+	"violations": violations,
+	"violation_count": count(violations),
+}

--- a/frameworks/critical_infrastructure/tsa_pipeline/sd02_continuous_monitoring.rego
+++ b/frameworks/critical_infrastructure/tsa_pipeline/sd02_continuous_monitoring.rego
@@ -1,0 +1,133 @@
+package tsa_pipeline.sd02_continuous_monitoring
+
+import rego.v1
+
+# =============================================================================
+# TSA Security Directive Pipeline-2021-02G
+# Section III.D — Continuous Monitoring and Detection
+#
+# Directive:  SD Pipeline-2021-02G
+# Effective:  May 3, 2026 through May 2, 2027
+#
+# Requirements evaluated: III.D.1.a–e, III.D.2.a–d, III.D.3.a–b,
+#                         III.D.4 (12 subparagraphs)
+#
+# III.D requires "continuous monitoring and detection policies and procedures
+# that are designed to prevent, detect, and respond to cybersecurity threats and
+# anomalies affecting Critical Cyber Systems."
+#
+# --- INPUT CONTRACT ----------------------------------------------------------
+# input.continuous_monitoring: {
+#   "policy_documented": boolean,
+#   "capabilities": [string],   # III.D.1 — see required_capabilities below
+#   "procedures":   [string],   # III.D.2 — see required_procedures below
+#   "logging": {                # III.D.3
+#       "continuous_collection_and_analysis": boolean,
+#       "retention_days":                     number,
+#       "retention_sufficient_for_investigation": boolean
+#   },
+#   "ics_isolation": {          # III.D.4
+#       "capability_exists":     boolean,
+#       "manual_controls_documented": boolean
+#   }
+# }
+#
+# NO FACT SOURCE EXISTS YET — see sd01_cybersecurity_coordinator.rego.
+#
+# OPA endpoint: POST <opa_ot_url>/v1/data/tsa_pipeline/sd02_continuous_monitoring
+# =============================================================================
+
+# `input` is UNDEFINED (not {}) when OPA receives an empty request body. Routing
+# every lookup through this defaulted alias makes an absent fact evaluate to the
+# fail-closed default instead of silently skipping the violation rule entirely.
+default facts := {}
+
+facts := input
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+# ── III.D.1 — Required capabilities ──────────────────────────────────────────
+
+required_capabilities := {
+	"malicious_email_prevention": "III.D.1.a: Prevent malicious email, such as spam and phishing emails, from adversely impacting operations",
+	"malicious_ip_blocking": "III.D.1.b: Prohibit ingress and egress communications with known or suspected malicious Internet Protocol addresses",
+	"malicious_domain_control": "III.D.1.c: Control impact of known or suspected malicious web domains or web applications",
+	"unauthorized_code_blocking": "III.D.1.d: Block and prevent unauthorized code, including macro scripts, from executing",
+	"command_and_control_monitoring": "III.D.1.e: Monitor and/or block connections from known or suspected malicious command and control servers (such as Tor exit nodes and other anonymization services)",
+}
+
+# ── III.D.2 — Required procedures ────────────────────────────────────────────
+
+required_procedures := {
+	"domain_access_auditing": "III.D.2.a: Audit unauthorized access to internet domains and addresses",
+	"baseline_deviation_auditing": "III.D.2.b: Document and audit any communications between the Operational Technology system and an external system that deviates from the identified baseline of communications",
+	"unauthorized_code_response": "III.D.2.c: Identify and respond to execution of unauthorized code, including macro scripts",
+	"soar_capability": "III.D.2.d: Implement capabilities (such as Security, Orchestration, Automation, and Response) to define, prioritize, and drive standardized incident response activities",
+}
+
+declared_capabilities := {c | some c in object.get(facts, ["continuous_monitoring", "capabilities"], [])}
+
+declared_procedures := {p | some p in object.get(facts, ["continuous_monitoring", "procedures"], [])}
+
+# ── III.D — Policy exists ────────────────────────────────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["continuous_monitoring", "policy_documented"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.D: No continuous monitoring and detection policies and procedures designed to prevent, detect, and respond to cybersecurity threats and anomalies affecting Critical Cyber Systems"
+}
+
+violations contains msg if {
+	some capability, description in required_capabilities
+	not capability in declared_capabilities
+	msg := sprintf("TSA SD Pipeline-2021-02G %s — capability not implemented", [description])
+}
+
+violations contains msg if {
+	some procedure, description in required_procedures
+	not procedure in declared_procedures
+	msg := sprintf("TSA SD Pipeline-2021-02G %s — procedure not established", [description])
+}
+
+# ── III.D.3 — Logging policies ───────────────────────────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["continuous_monitoring", "logging", "continuous_collection_and_analysis"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.D.3.a: Logging policies do not require continuous collection and analyzing of data for potential intrusions and anomalous behavior"
+}
+
+violations contains msg if {
+	object.get(facts, ["continuous_monitoring", "logging", "retention_sufficient_for_investigation"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.D.3.b: Logging policies do not ensure data is maintained for sufficient periods to allow for effective investigation of cybersecurity incidents"
+}
+
+# ── III.D.4 — Industrial control system isolation ────────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["continuous_monitoring", "ics_isolation", "capability_exists"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.D.4: No mitigation measures or manual controls to ensure industrial control systems can be isolated when a cybersecurity incident in the Information Technology system creates risk to the safety and reliability of the Operational Technology system"
+}
+
+violations contains msg if {
+	object.get(facts, ["continuous_monitoring", "ics_isolation", "manual_controls_documented"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.D.4: Manual controls for isolating industrial control systems are not documented"
+}
+
+# ── Compliance report ────────────────────────────────────────────────────────
+
+compliance_report := {
+	"directive": "TSA SD Pipeline-2021-02G",
+	"section": "III.D",
+	"name": "Continuous Monitoring and Detection",
+	"requirements_evaluated": 12,
+	"capabilities_required": count(required_capabilities),
+	"capabilities_implemented": count(declared_capabilities & {c | some c, _ in required_capabilities}),
+	"procedures_required": count(required_procedures),
+	"procedures_established": count(declared_procedures & {p | some p, _ in required_procedures}),
+	"compliant": compliant,
+	"violations": violations,
+	"violation_count": count(violations),
+}

--- a/frameworks/critical_infrastructure/tsa_pipeline/sd02_critical_cyber_systems.rego
+++ b/frameworks/critical_infrastructure/tsa_pipeline/sd02_critical_cyber_systems.rego
@@ -1,0 +1,195 @@
+package tsa_pipeline.sd02_critical_cyber_systems
+
+import rego.v1
+
+# =============================================================================
+# TSA Security Directive Pipeline-2021-02G — "Pipeline Cybersecurity Mitigation
+# Actions, Contingency Planning, and Testing"
+# Sections II.A.3–II.A.5 and III.A — Scope and Critical Cyber System identification
+#
+# Directive:  SD Pipeline-2021-02G
+# Effective:  May 3, 2026 through May 2, 2027
+# Supersedes: SD Pipeline-2021-02F
+# Authority:  49 U.S.C. 114(d), (f), (l), and (m)
+#
+# Requirements evaluated: II.A.3, II.A.4, II.A.5, III.A (7 subparagraphs)
+#
+# DEFINITION (§VII.C): "Critical Cyber System means any Information or
+# Operational Technology system or data that, if compromised or exploited,
+# could result in operational disruption. Critical Cyber Systems include
+# business services that, if compromised or exploited, could result in
+# operational disruption."
+#
+# The requirements of SD Pipeline-2021-02G apply to the covered Owner/Operator's
+# Critical Cyber Systems (§II.A.5). An Owner/Operator determining it has NO
+# Critical Cyber Systems must notify TSA in writing within 60 days of the
+# effective date, and must re-evaluate and notify within 60 days of any change
+# in its method of operations.
+#
+# --- INPUT CONTRACT ----------------------------------------------------------
+# input.critical_cyber_systems: {
+#   "identified":            boolean,
+#   "identification_methodology_documented": boolean,
+#   "systems": [ {
+#       "name":              string,
+#       "type":              string,   # "information_technology" | "operational_technology"
+#       "operational_disruption_impact": boolean,
+#       "included_in_implementation_plan": boolean
+#   } ],
+#   "business_services_evaluated": boolean,
+#   "none_determination": {
+#       "declared":                    boolean,
+#       "tsa_notified_in_writing":     boolean,
+#       "days_since_effective_date":   number,
+#       "operations_changed":          boolean,
+#       "days_since_operations_change": number,
+#       "reevaluated_after_change":    boolean
+#   },
+#   "managed_security_service_providers": [ {
+#       "name":                       string,
+#       "responsibility_retained":    boolean   # Owner/Operator retains sole
+#                                               # responsibility for compliance
+#   } ],
+#   "authorized_representatives": [ {
+#       "name":                    string,
+#       "liability_acknowledged":  boolean
+#   } ]
+# }
+#
+# NO FACT SOURCE EXISTS YET — see sd01_cybersecurity_coordinator.rego.
+#
+# OPA endpoint: POST <opa_ot_url>/v1/data/tsa_pipeline/sd02_critical_cyber_systems
+# =============================================================================
+
+# `input` is UNDEFINED (not {}) when OPA receives an empty request body. Routing
+# every lookup through this defaulted alias makes an absent fact evaluate to the
+# fail-closed default instead of silently skipping the violation rule entirely.
+default facts := {}
+
+facts := input
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+ccs_systems := [s |
+	some s in object.get(facts, ["critical_cyber_systems", "systems"], [])
+	is_object(s)
+]
+
+mssps := [m |
+	some m in object.get(facts, ["critical_cyber_systems", "managed_security_service_providers"], [])
+	is_object(m)
+]
+
+authorized_representatives := [a |
+	some a in object.get(facts, ["critical_cyber_systems", "authorized_representatives"], [])
+	is_object(a)
+]
+
+# MUST be defaulted: none_declared is referenced directly in compliance_report,
+# and an undefined field collapses the entire object to {} at the endpoint.
+default none_declared := false
+
+none_declared if {
+	object.get(facts, ["critical_cyber_systems", "none_determination", "declared"], false) == true
+}
+
+# ── III.A — Identification of Critical Cyber Systems ─────────────────────────
+
+violations contains msg if {
+	not none_declared
+	object.get(facts, ["critical_cyber_systems", "identified"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.A: Critical Cyber Systems have not been identified as defined in Section VII of the Security Directive"
+}
+
+violations contains msg if {
+	not none_declared
+	count(ccs_systems) == 0
+	msg := "TSA SD Pipeline-2021-02G III.A: No Critical Cyber Systems are enumerated, and no written determination of 'no Critical Cyber Systems' has been declared under Section II.A.5"
+}
+
+violations contains msg if {
+	object.get(facts, ["critical_cyber_systems", "identification_methodology_documented"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.A: The methodology and rationale used to identify Critical Cyber Systems are not documented — TSA may require this information if it disagrees with the Owner/Operator's determination"
+}
+
+# Per §VII.C, business services that could result in operational disruption are
+# themselves Critical Cyber Systems — a scope that is routinely missed.
+violations contains msg if {
+	not none_declared
+	object.get(facts, ["critical_cyber_systems", "business_services_evaluated"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.A (see VII.C): Business services were not evaluated for inclusion as Critical Cyber Systems — the definition includes business services that, if compromised or exploited, could result in operational disruption"
+}
+
+violations contains msg if {
+	some s in ccs_systems
+	object.get(s, "included_in_implementation_plan", false) == false
+	msg := sprintf("TSA SD Pipeline-2021-02G III.A: Critical Cyber System '%s' is identified but is not included in the Cybersecurity Implementation Plan", [object.get(s, "name", "unnamed")])
+}
+
+# ── II.A.5 Note — "No Critical Cyber Systems" determination ──────────────────
+
+violations contains msg if {
+	none_declared
+	object.get(facts, ["critical_cyber_systems", "none_determination", "tsa_notified_in_writing"], false) == false
+	msg := "TSA SD Pipeline-2021-02G II.A.5: The Owner/Operator determined it has no Critical Cyber Systems but has not notified TSA in writing"
+}
+
+violations contains msg if {
+	none_declared
+	days := object.get(facts, ["critical_cyber_systems", "none_determination", "days_since_effective_date"], 0)
+	is_number(days)
+	days > 60
+	msg := sprintf("TSA SD Pipeline-2021-02G II.A.5: A 'no Critical Cyber Systems' determination must be notified to TSA in writing within 60 days of the Security Directive's effective date — %d days have elapsed", [days])
+}
+
+violations contains msg if {
+	none_declared
+	object.get(facts, ["critical_cyber_systems", "none_determination", "operations_changed"], false) == true
+	object.get(facts, ["critical_cyber_systems", "none_determination", "reevaluated_after_change"], false) == false
+	msg := "TSA SD Pipeline-2021-02G II.A.5: The Owner/Operator's method of operations changed but Critical Cyber Systems were not re-evaluated"
+}
+
+violations contains msg if {
+	none_declared
+	object.get(facts, ["critical_cyber_systems", "none_determination", "operations_changed"], false) == true
+	days := object.get(facts, ["critical_cyber_systems", "none_determination", "days_since_operations_change"], 0)
+	is_number(days)
+	days > 60
+	msg := sprintf("TSA SD Pipeline-2021-02G II.A.5: TSA must be notified within 60 days of a change in method of operations to determine the compliance schedule — %d days have elapsed", [days])
+}
+
+# ── II.A.3 — Managed Security Service Providers ──────────────────────────────
+
+violations contains msg if {
+	some m in mssps
+	object.get(m, "responsibility_retained", false) == false
+	msg := sprintf("TSA SD Pipeline-2021-02G II.A.3: Security measures are delegated to or shared with Managed Security Service Provider '%s' without the Owner/Operator documenting that it retains sole responsibility for compliance with its TSA-approved Cybersecurity Implementation Plan", [object.get(m, "name", "unnamed")])
+}
+
+# ── II.A.4 — Authorized Representatives ──────────────────────────────────────
+
+violations contains msg if {
+	some a in authorized_representatives
+	object.get(a, "liability_acknowledged", false) == false
+	msg := sprintf("TSA SD Pipeline-2021-02G II.A.4: Authorized Representative '%s' has no documented acknowledgement of liability — both the Owner/Operator and the Authorized Representative are liable for non-compliance", [object.get(a, "name", "unnamed")])
+}
+
+# ── Compliance report ────────────────────────────────────────────────────────
+
+compliance_report := {
+	"directive": "TSA SD Pipeline-2021-02G",
+	"section": "II.A / III.A",
+	"name": "Scope and Critical Cyber System Identification",
+	"effective_date": "2026-05-03",
+	"expiration_date": "2027-05-02",
+	"requirements_evaluated": 7,
+	"critical_cyber_systems_identified": count(ccs_systems),
+	"no_critical_cyber_systems_declared": none_declared,
+	"compliant": compliant,
+	"violations": violations,
+	"violation_count": count(violations),
+}

--- a/frameworks/critical_infrastructure/tsa_pipeline/sd02_implementation_plan.rego
+++ b/frameworks/critical_infrastructure/tsa_pipeline/sd02_implementation_plan.rego
@@ -1,0 +1,211 @@
+package tsa_pipeline.sd02_implementation_plan
+
+import rego.v1
+
+# =============================================================================
+# TSA Security Directive Pipeline-2021-02G
+# Section II.B — Cybersecurity Implementation Plan
+# Section VI  — Amendments to Cybersecurity Implementation Plan
+#
+# Directive:  SD Pipeline-2021-02G
+# Effective:  May 3, 2026 through May 2, 2027
+#
+# Requirements evaluated: II.B.1, II.B.2, VI.A, VI.B.1–2, VI.C, VI.D, VI.F
+#                         (8 subparagraphs)
+#
+# The Cybersecurity Implementation Plan is the spine of this directive: it "sets
+# the security measures and requirements against which TSA inspects for
+# compliance" (§I). It must provide the information required by Sections III.A
+# through III.E and describe in detail the Owner/Operator's defense-in-depth
+# plan, including physical AND logical security controls.
+#
+# THE AMENDMENT CLOCKS:
+#   VI.C — a "permanent change" is one intended to be in effect for 45 or more
+#          calendar days
+#   VI.D — the amendment request must be filed with TSA no later than 50
+#          calendar days after the permanent change takes effect, unless TSA
+#          allows a longer period
+#   VI.F — a petition for reconsideration of a denial must be filed no later
+#          than 30 calendar days after receiving the denial (49 CFR 1570.119)
+#
+# --- INPUT CONTRACT ----------------------------------------------------------
+# input.implementation_plan: {
+#   "exists":                 boolean,
+#   "tsa_approved":           boolean,
+#   "covers_sections_iii_a_to_iii_e": boolean,
+#   "defense_in_depth_described":     boolean,
+#   "physical_controls_described":    boolean,
+#   "logical_controls_described":     boolean,
+#   "measures_implemented":           boolean,   # II.B.2
+#   "schedule_met":                   boolean,   # II.B.2
+#   "amendments": {
+#       "ownership_or_control_changed":   boolean,   # VI.A
+#       "ownership_amendment_requested":  boolean,
+#       "measure_determined_ineffective": boolean,   # VI.B.1
+#       "ineffective_amendment_requested": boolean,
+#       "new_capabilities_obtained":      boolean,   # VI.B.2
+#       "new_capability_amendment_requested": boolean,
+#       "pending_permanent_changes": [ {
+#           "description":              string,
+#           "duration_days":            number,   # >= 45 makes it "permanent"
+#           "days_since_effective":     number,   # request due within 50 days
+#           "amendment_filed":          boolean
+#       } ],
+#       "denials": [ {
+#           "description":                string,
+#           "days_since_denial":          number,   # petition due within 30 days
+#           "petition_filed":             boolean,
+#           "reconsideration_intended":   boolean
+#       } ]
+#   }
+# }
+#
+# NO FACT SOURCE EXISTS YET — see sd01_cybersecurity_coordinator.rego.
+#
+# OPA endpoint: POST <opa_ot_url>/v1/data/tsa_pipeline/sd02_implementation_plan
+# =============================================================================
+
+# `input` is UNDEFINED (not {}) when OPA receives an empty request body. Routing
+# every lookup through this defaulted alias makes an absent fact evaluate to the
+# fail-closed default instead of silently skipping the violation rule entirely.
+default facts := {}
+
+facts := input
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+cip_flag(path) := value if {
+	value := object.get(facts, array.concat(["implementation_plan"], path), false)
+}
+
+pending_changes := [c |
+	some c in object.get(facts, ["implementation_plan", "amendments", "pending_permanent_changes"], [])
+	is_object(c)
+]
+
+denials := [d |
+	some d in object.get(facts, ["implementation_plan", "amendments", "denials"], [])
+	is_object(d)
+]
+
+# ── II.B.1 — Plan contents ───────────────────────────────────────────────────
+
+violations contains msg if {
+	cip_flag(["exists"]) == false
+	msg := "TSA SD Pipeline-2021-02G II.B.1: No Cybersecurity Implementation Plan — all covered Owner/Operators must submit one for TSA approval"
+}
+
+violations contains msg if {
+	cip_flag(["tsa_approved"]) == false
+	msg := "TSA SD Pipeline-2021-02G II.B.2: The Cybersecurity Implementation Plan has not been approved by TSA"
+}
+
+violations contains msg if {
+	cip_flag(["covers_sections_iii_a_to_iii_e"]) == false
+	msg := "TSA SD Pipeline-2021-02G II.B.1: The Cybersecurity Implementation Plan does not provide the information required by Sections III.A through III.E of the Security Directive"
+}
+
+violations contains msg if {
+	cip_flag(["defense_in_depth_described"]) == false
+	msg := "TSA SD Pipeline-2021-02G II.B.1: The Cybersecurity Implementation Plan does not describe in detail the Owner/Operator's defense-in-depth plan for meeting the requirements in Sections III.A through III.E"
+}
+
+violations contains msg if {
+	cip_flag(["physical_controls_described"]) == false
+	msg := "TSA SD Pipeline-2021-02G II.B.1: The Cybersecurity Implementation Plan's defense-in-depth description omits physical security controls"
+}
+
+violations contains msg if {
+	cip_flag(["logical_controls_described"]) == false
+	msg := "TSA SD Pipeline-2021-02G II.B.1: The Cybersecurity Implementation Plan's defense-in-depth description omits logical security controls"
+}
+
+# ── II.B.2 — Implementation and maintenance ──────────────────────────────────
+
+violations contains msg if {
+	cip_flag(["tsa_approved"]) == true
+	cip_flag(["measures_implemented"]) == false
+	msg := "TSA SD Pipeline-2021-02G II.B.2: Not all measures in the TSA-approved Cybersecurity Implementation Plan are implemented and maintained"
+}
+
+violations contains msg if {
+	cip_flag(["tsa_approved"]) == true
+	cip_flag(["schedule_met"]) == false
+	msg := "TSA SD Pipeline-2021-02G II.B.2: The schedule stipulated in the TSA-approved Cybersecurity Implementation Plan is not being met"
+}
+
+# ── VI.A — Changes to ownership or control ───────────────────────────────────
+
+violations contains msg if {
+	cip_flag(["amendments", "ownership_or_control_changed"]) == true
+	cip_flag(["amendments", "ownership_amendment_requested"]) == false
+	msg := "TSA SD Pipeline-2021-02G VI.A: Ownership or control of the operation changed after approval, but no request to amend the Cybersecurity Implementation Plan has been submitted"
+}
+
+# ── VI.B — Changes to conditions affecting security ──────────────────────────
+
+violations contains msg if {
+	cip_flag(["amendments", "measure_determined_ineffective"]) == true
+	cip_flag(["amendments", "ineffective_amendment_requested"]) == false
+	msg := "TSA SD Pipeline-2021-02G VI.B.1: A policy, procedure, or measure in the Cybersecurity Implementation Plan was determined ineffective based on the audits and assessments required under Section III.G, but no amendment has been requested"
+}
+
+violations contains msg if {
+	cip_flag(["amendments", "new_capabilities_obtained"]) == true
+	cip_flag(["amendments", "new_capability_amendment_requested"]) == false
+	msg := "TSA SD Pipeline-2021-02G VI.B.2: New or additional capabilities for meeting the Security Directive's requirements were identified or obtained but not previously approved by TSA, and no amendment has been requested"
+}
+
+# ── VI.C / VI.D — Permanent change definition and 50-day filing deadline ─────
+
+violations contains msg if {
+	some c in pending_changes
+	duration := object.get(c, "duration_days", 0)
+	is_number(duration)
+	duration >= 45
+	object.get(c, "amendment_filed", false) == false
+	msg := sprintf("TSA SD Pipeline-2021-02G VI.C: Change '%s' is intended to be in effect for %v days, making it a permanent change requiring a Cybersecurity Implementation Plan amendment — none has been filed", [object.get(c, "description", "unnamed"), duration])
+}
+
+violations contains msg if {
+	some c in pending_changes
+	duration := object.get(c, "duration_days", 0)
+	is_number(duration)
+	duration >= 45
+	elapsed := object.get(c, "days_since_effective", 0)
+	is_number(elapsed)
+	elapsed > 50
+	msg := sprintf("TSA SD Pipeline-2021-02G VI.D: The amendment request for permanent change '%s' is %v days past the change taking effect — it must be filed with TSA no later than 50 calendar days", [object.get(c, "description", "unnamed"), elapsed])
+}
+
+# ── VI.F — Petition for reconsideration (30 days) ────────────────────────────
+
+violations contains msg if {
+	some d in denials
+	object.get(d, "reconsideration_intended", false) == true
+	object.get(d, "petition_filed", false) == false
+	days := object.get(d, "days_since_denial", 0)
+	is_number(days)
+	days > 30
+	msg := sprintf("TSA SD Pipeline-2021-02G VI.F: A petition for reconsideration of the denied amendment '%s' was not filed within 30 calendar days of receiving the denial (%v days elapsed) — see 49 CFR 1570.119", [object.get(d, "description", "unnamed"), days])
+}
+
+# ── Compliance report ────────────────────────────────────────────────────────
+
+compliance_report := {
+	"directive": "TSA SD Pipeline-2021-02G",
+	"section": "II.B / VI",
+	"name": "Cybersecurity Implementation Plan and Amendments",
+	"permanent_change_threshold_days": 45,
+	"amendment_filing_deadline_days": 50,
+	"reconsideration_petition_deadline_days": 30,
+	"requirements_evaluated": 8,
+	"pending_changes_assessed": count(pending_changes),
+	"compliant": compliant,
+	"violations": violations,
+	"violation_count": count(violations),
+}

--- a/frameworks/critical_infrastructure/tsa_pipeline/sd02_incident_response_plan.rego
+++ b/frameworks/critical_infrastructure/tsa_pipeline/sd02_incident_response_plan.rego
@@ -1,0 +1,199 @@
+package tsa_pipeline.sd02_incident_response_plan
+
+import rego.v1
+
+# =============================================================================
+# TSA Security Directive Pipeline-2021-02G
+# Section III.F — Cybersecurity Incident Response Plan
+#
+# Directive:  SD Pipeline-2021-02G
+# Effective:  May 3, 2026 through May 2, 2027
+#
+# Requirements evaluated: III.F.1.a–e (incl. b.i–iv, e.i–ii), III.F.2
+#                         (13 subparagraphs)
+#
+# III.F requires an up-to-date Cybersecurity Incident Response Plan for the
+# Critical Cyber Systems "that include measures to reduce the risk of
+# operational disruption, or the risk of other significant impacts on business
+# critical functions should the covered pipeline or facility experience a
+# cybersecurity incident."
+#
+# THE EXERCISE CLOCK (III.F.1.e): exercises must be held no less than annually,
+# must test at least TWO of the objectives in III.F.1.a–III.F.1.d, and must
+# include the employees identified by position in III.F.2 as active participants.
+#
+# --- INPUT CONTRACT ----------------------------------------------------------
+# input.incident_response_plan: {
+#   "exists":       boolean,
+#   "up_to_date":   boolean,
+#   "covers_critical_cyber_systems": boolean,
+#   "objectives": {
+#       "prompt_containment":  boolean,   # III.F.1.a
+#       "segregation": {                  # III.F.1.b
+#           "infected_devices":        boolean,   # b.i
+#           "shared_network_devices":  boolean,   # b.ii
+#           "volatile_memory_preserved": boolean, # b.iii
+#           "isolation_and_labeling":  boolean    # b.iv
+#       },
+#       "backup_integrity": {             # III.F.1.c
+#           "backups_secured":        boolean,
+#           "stored_separately":      boolean,
+#           "malicious_code_free_verified": boolean
+#       },
+#       "it_ot_isolation_governance": boolean  # III.F.1.d
+#   },
+#   "exercises": {                        # III.F.1.e
+#       "conducted_within_last_12_months": boolean,
+#       "months_since_last_exercise":      number,
+#       "objectives_tested":               number,   # must be >= 2
+#       "responsible_personnel_participated": boolean
+#   },
+#   "responsibilities": {                 # III.F.2
+#       "assigned_by_position": boolean,
+#       "resources_identified": boolean
+#   }
+# }
+#
+# NO FACT SOURCE EXISTS YET — see sd01_cybersecurity_coordinator.rego.
+#
+# OPA endpoint: POST <opa_ot_url>/v1/data/tsa_pipeline/sd02_incident_response_plan
+# =============================================================================
+
+# `input` is UNDEFINED (not {}) when OPA receives an empty request body. Routing
+# every lookup through this defaulted alias makes an absent fact evaluate to the
+# fail-closed default instead of silently skipping the violation rule entirely.
+default facts := {}
+
+facts := input
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+irp_flag(path) := value if {
+	value := object.get(facts, array.concat(["incident_response_plan"], path), false)
+}
+
+# ── III.F.1 — Plan exists and is current ─────────────────────────────────────
+
+violations contains msg if {
+	irp_flag(["exists"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.F.1: No Cybersecurity Incident Response Plan for the Critical Cyber Systems"
+}
+
+violations contains msg if {
+	irp_flag(["up_to_date"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.F.1: The Cybersecurity Incident Response Plan is not up to date"
+}
+
+violations contains msg if {
+	irp_flag(["covers_critical_cyber_systems"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.F.1: The Cybersecurity Incident Response Plan does not cover the Owner/Operator's Critical Cyber Systems"
+}
+
+# ── III.F.1.a — Prompt containment ───────────────────────────────────────────
+
+violations contains msg if {
+	irp_flag(["objectives", "prompt_containment"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.F.1.a: The Cybersecurity Incident Response Plan provides no specific measures for prompt containment of an infected server or device"
+}
+
+# ── III.F.1.b — Segregation of the infected network or devices ───────────────
+
+violations contains msg if {
+	irp_flag(["objectives", "segregation", "infected_devices"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.F.1.b.i: No measures for segregating (removing from the network) infected devices"
+}
+
+violations contains msg if {
+	irp_flag(["objectives", "segregation", "shared_network_devices"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.F.1.b.ii: No measures for segregating other devices that shared a network with the infected device(s)"
+}
+
+violations contains msg if {
+	irp_flag(["objectives", "segregation", "volatile_memory_preserved"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.F.1.b.iii: No measures for preserving volatile memory by collecting a forensic memory image of affected device(s) before powering off or moving them"
+}
+
+violations contains msg if {
+	irp_flag(["objectives", "segregation", "isolation_and_labeling"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.F.1.b.iv: No measures for isolating and securing all infected and potentially infected devices, including clearly labeling equipment affected by malicious code"
+}
+
+# ── III.F.1.c — Security and integrity of backed-up data ─────────────────────
+
+violations contains msg if {
+	irp_flag(["objectives", "backup_integrity", "backups_secured"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.F.1.c: No measures to secure backups as part of ensuring the security and integrity of backed-up data"
+}
+
+violations contains msg if {
+	irp_flag(["objectives", "backup_integrity", "stored_separately"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.F.1.c: Backup data is not stored separate from the system"
+}
+
+violations contains msg if {
+	irp_flag(["objectives", "backup_integrity", "malicious_code_free_verified"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.F.1.c: No procedures to ensure backup data is free of known malicious code both when the backup is made and when it is tested for restoral"
+}
+
+# ── III.F.1.d — IT/OT isolation capability and governance ────────────────────
+
+violations contains msg if {
+	irp_flag(["objectives", "it_ot_isolation_governance"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.F.1.d: No established capability and governance for isolating the Information and Operational Technology systems in the event of a cybersecurity incident that results, or could result, in operational disruption"
+}
+
+# ── III.F.1.e — Annual exercises ─────────────────────────────────────────────
+
+violations contains msg if {
+	irp_flag(["exercises", "conducted_within_last_12_months"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.F.1.e: No exercise conducted to test the effectiveness of the Cybersecurity Incident Response Plan procedures and personnel — exercises are required no less than annually"
+}
+
+violations contains msg if {
+	months := object.get(facts, ["incident_response_plan", "exercises", "months_since_last_exercise"], 0)
+	is_number(months)
+	months > 12
+	msg := sprintf("TSA SD Pipeline-2021-02G III.F.1.e: The last Cybersecurity Incident Response Plan exercise was %v months ago — exercises must be conducted no less than annually", [months])
+}
+
+violations contains msg if {
+	tested := object.get(facts, ["incident_response_plan", "exercises", "objectives_tested"], 0)
+	is_number(tested)
+	tested < 2
+	msg := sprintf("TSA SD Pipeline-2021-02G III.F.1.e.i: Annual exercises tested %v of the objectives required by III.F.1.a through III.F.1.d — at least two objectives must be tested no less than annually", [tested])
+}
+
+violations contains msg if {
+	irp_flag(["exercises", "responsible_personnel_participated"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.F.1.e.ii: The employees identified by position in Section III.F.2 did not participate in the exercises as active participants"
+}
+
+# ── III.F.2 — Assigned responsibility and resources ──────────────────────────
+
+violations contains msg if {
+	irp_flag(["responsibilities", "assigned_by_position"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.F.2: The Cybersecurity Incident Response Plan does not identify who, by position, is responsible for implementing its specific measures"
+}
+
+violations contains msg if {
+	irp_flag(["responsibilities", "resources_identified"]) == false
+	msg := "TSA SD Pipeline-2021-02G III.F.2: The Cybersecurity Incident Response Plan does not identify the resources necessary to implement its measures"
+}
+
+# ── Compliance report ────────────────────────────────────────────────────────
+
+compliance_report := {
+	"directive": "TSA SD Pipeline-2021-02G",
+	"section": "III.F",
+	"name": "Cybersecurity Incident Response Plan",
+	"exercise_frequency": "no less than annually",
+	"minimum_objectives_per_exercise": 2,
+	"requirements_evaluated": 13,
+	"compliant": compliant,
+	"violations": violations,
+	"violation_count": count(violations),
+}

--- a/frameworks/critical_infrastructure/tsa_pipeline/sd02_network_segmentation.rego
+++ b/frameworks/critical_infrastructure/tsa_pipeline/sd02_network_segmentation.rego
@@ -1,0 +1,157 @@
+package tsa_pipeline.sd02_network_segmentation
+
+import rego.v1
+
+# =============================================================================
+# TSA Security Directive Pipeline-2021-02G
+# Section III.B — Network Segmentation Policies and Controls
+#
+# Directive:  SD Pipeline-2021-02G
+# Effective:  May 3, 2026 through May 2, 2027
+#
+# Requirements evaluated: III.B.1.a–c, III.B.2.a–b (5 subparagraphs)
+#
+# III.B requires network segmentation policies and controls "designed to prevent
+# operational disruption to the Operational Technology system if the Information
+# Technology system is compromised or vice versa."
+#
+# Note the direction of III.B.2.b: OT system services must be prohibited from
+# traversing the IT system UNLESS the content of the OT system is encrypted
+# while in transit.
+#
+# --- INPUT CONTRACT ----------------------------------------------------------
+# input.network_segmentation: {
+#   "policy_documented":              boolean,
+#   "it_ot_interdependencies_documented": boolean,   # III.B.1.a
+#   "external_connections": {                        # III.B.1.b
+#       "documented":  boolean,
+#       "connections": [ { "name": string, "described": boolean } ]
+#   },
+#   "zones": {                                       # III.B.1.c
+#       "documented":            boolean,
+#       "boundaries":            [ { "name": string,
+#                                    "unauthorized_comms_prevented": boolean,
+#                                    "controls_described":           boolean } ],
+#       "classification_basis":  [string]  # "criticality" | "consequence"
+#                                          # | "operational_necessity"
+#   },
+#   "ot_services_traversing_it": {                    # III.B.2.b
+#       "occurs":              boolean,
+#       "encrypted_in_transit": boolean
+#   }
+# }
+#
+# NO FACT SOURCE EXISTS YET — see sd01_cybersecurity_coordinator.rego.
+#
+# OPA endpoint: POST <opa_ot_url>/v1/data/tsa_pipeline/sd02_network_segmentation
+# =============================================================================
+
+# `input` is UNDEFINED (not {}) when OPA receives an empty request body. Routing
+# every lookup through this defaulted alias makes an absent fact evaluate to the
+# fail-closed default instead of silently skipping the violation rule entirely.
+default facts := {}
+
+facts := input
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+required_zone_classification_basis := {"criticality", "consequence", "operational_necessity"}
+
+declared_classification_basis := {b |
+	some b in object.get(facts, ["network_segmentation", "zones", "classification_basis"], [])
+}
+
+zone_boundaries := [z |
+	some z in object.get(facts, ["network_segmentation", "zones", "boundaries"], [])
+	is_object(z)
+]
+
+external_connections := [c |
+	some c in object.get(facts, ["network_segmentation", "external_connections", "connections"], [])
+	is_object(c)
+]
+
+# ── III.B — Policy exists ────────────────────────────────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["network_segmentation", "policy_documented"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.B: No documented network segmentation policies and controls designed to prevent operational disruption to the Operational Technology system if the Information Technology system is compromised, or vice versa"
+}
+
+# ── III.B.1.a — IT/OT interdependencies ──────────────────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["network_segmentation", "it_ot_interdependencies_documented"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.B.1.a: No list and description of Information Technology and Operational Technology system interdependencies"
+}
+
+# ── III.B.1.b — External connections to the OT system ────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["network_segmentation", "external_connections", "documented"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.B.1.b: No list and description of all external connections to the Operational Technology system"
+}
+
+violations contains msg if {
+	some c in external_connections
+	object.get(c, "described", false) == false
+	msg := sprintf("TSA SD Pipeline-2021-02G III.B.1.b: External connection to the Operational Technology system '%s' is listed but not described", [object.get(c, "name", "unnamed")])
+}
+
+# ── III.B.1.c — Zone boundaries ──────────────────────────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["network_segmentation", "zones", "documented"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.B.1.c: No list and description of zone boundaries, including how Information Technology and Operational Technology systems are defined and organized into logical zones"
+}
+
+violations contains msg if {
+	some basis in required_zone_classification_basis
+	not basis in declared_classification_basis
+	msg := sprintf("TSA SD Pipeline-2021-02G III.B.1.c: Logical zones are not organized on the basis of '%s' — zones must be based on criticality, consequence, and operational necessity", [basis])
+}
+
+# ── III.B.2 — Securing and defending zone boundaries ─────────────────────────
+
+violations contains msg if {
+	count(zone_boundaries) == 0
+	msg := "TSA SD Pipeline-2021-02G III.B.2: No identification or description of measures for securing and defending zone boundaries"
+}
+
+violations contains msg if {
+	some z in zone_boundaries
+	object.get(z, "controls_described", false) == false
+	msg := sprintf("TSA SD Pipeline-2021-02G III.B.2: Zone boundary '%s' has no described security controls for securing and defending the boundary", [object.get(z, "name", "unnamed")])
+}
+
+violations contains msg if {
+	some z in zone_boundaries
+	object.get(z, "unauthorized_comms_prevented", false) == false
+	msg := sprintf("TSA SD Pipeline-2021-02G III.B.2.a: Zone boundary '%s' has no security control to prevent unauthorized communications between zones", [object.get(z, "name", "unnamed")])
+}
+
+# ── III.B.2.b — OT services traversing the IT system ─────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["network_segmentation", "ot_services_traversing_it", "occurs"], false) == true
+	object.get(facts, ["network_segmentation", "ot_services_traversing_it", "encrypted_in_transit"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.B.2.b: Operational Technology system services traverse the Information Technology system without the Operational Technology system content being encrypted while in transit"
+}
+
+# ── Compliance report ────────────────────────────────────────────────────────
+
+compliance_report := {
+	"directive": "TSA SD Pipeline-2021-02G",
+	"section": "III.B",
+	"name": "Network Segmentation Policies and Controls",
+	"requirements_evaluated": 5,
+	"zone_boundaries_assessed": count(zone_boundaries),
+	"external_connections_assessed": count(external_connections),
+	"compliant": compliant,
+	"violations": violations,
+	"violation_count": count(violations),
+}

--- a/frameworks/critical_infrastructure/tsa_pipeline/sd02_patch_management.rego
+++ b/frameworks/critical_infrastructure/tsa_pipeline/sd02_patch_management.rego
@@ -1,0 +1,149 @@
+package tsa_pipeline.sd02_patch_management
+
+import rego.v1
+
+# =============================================================================
+# TSA Security Directive Pipeline-2021-02G
+# Section III.E — Application of Security Patches and Updates
+#
+# Directive:  SD Pipeline-2021-02G
+# Effective:  May 3, 2026 through May 2, 2027
+#
+# Requirements evaluated: III.E.1, III.E.2.a–b, III.E.3 (4 subparagraphs)
+#
+# III.E requires the Owner/Operator to "reduce the risk of exploitation of
+# unpatched systems through the application of security patches and updates for
+# operating systems, applications, drivers, and firmware on Critical Cyber
+# Systems consistent with the Owner/Operator's risk-based methodology."
+#
+# III.E.3 is the OT carve-out: where patches cannot be applied without causing
+# a severe degradation of operational capability to meet business critical
+# functions, the strategy must include a description AND timeline of additional
+# mitigations addressing the risk created by not installing the patch.
+#
+# --- INPUT CONTRACT ----------------------------------------------------------
+# input.patch_management: {
+#   "strategy_documented":       boolean,
+#   "critical_patches_current":  boolean,
+#   "scope": [string],   # "operating_systems" | "applications" | "drivers"
+#                        # | "firmware"
+#   "risk_methodology": {                             # III.E.2.a
+#       "categorization_defined":   boolean,
+#       "criticality_determined":   boolean,
+#       "implementation_timeline_defined": boolean
+#   },
+#   "cisa_kev_prioritized":      boolean,             # III.E.2.b
+#   "unpatchable_systems": [ {                        # III.E.3
+#       "name":                    string,
+#       "severe_degradation_justified": boolean,
+#       "mitigations_described":   boolean,
+#       "mitigation_timeline_defined": boolean
+#   } ]
+# }
+#
+# NO FACT SOURCE EXISTS YET — see sd01_cybersecurity_coordinator.rego.
+#
+# OPA endpoint: POST <opa_ot_url>/v1/data/tsa_pipeline/sd02_patch_management
+# =============================================================================
+
+# `input` is UNDEFINED (not {}) when OPA receives an empty request body. Routing
+# every lookup through this defaulted alias makes an absent fact evaluate to the
+# fail-closed default instead of silently skipping the violation rule entirely.
+default facts := {}
+
+facts := input
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+required_scope := {
+	"operating_systems": "operating systems",
+	"applications": "applications",
+	"drivers": "drivers",
+	"firmware": "firmware",
+}
+
+declared_scope := {s | some s in object.get(facts, ["patch_management", "scope"], [])}
+
+unpatchable_systems := [u |
+	some u in object.get(facts, ["patch_management", "unpatchable_systems"], [])
+	is_object(u)
+]
+
+# ── III.E.1 — Patch management strategy ──────────────────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["patch_management", "strategy_documented"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.E.1: No patch management strategy ensuring all critical security patches and updates on Critical Cyber Systems are current"
+}
+
+violations contains msg if {
+	object.get(facts, ["patch_management", "critical_patches_current"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.E.1: Critical security patches and updates on Critical Cyber Systems are not current"
+}
+
+violations contains msg if {
+	some scope, label in required_scope
+	not scope in declared_scope
+	msg := sprintf("TSA SD Pipeline-2021-02G III.E: The patch management strategy does not cover %s on Critical Cyber Systems", [label])
+}
+
+# ── III.E.2.a — Risk methodology ─────────────────────────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["patch_management", "risk_methodology", "categorization_defined"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.E.2.a: The patch management strategy defines no risk methodology for categorizing patches and updates"
+}
+
+violations contains msg if {
+	object.get(facts, ["patch_management", "risk_methodology", "criticality_determined"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.E.2.a: The patch management strategy defines no risk methodology for determining the criticality of patches and updates"
+}
+
+violations contains msg if {
+	object.get(facts, ["patch_management", "risk_methodology", "implementation_timeline_defined"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.E.2.a: The patch management strategy defines no implementation timeline based on patch categorization and criticality"
+}
+
+# ── III.E.2.b — CISA Known Exploited Vulnerabilities Catalog ─────────────────
+
+violations contains msg if {
+	object.get(facts, ["patch_management", "cisa_kev_prioritized"], false) == false
+	msg := "TSA SD Pipeline-2021-02G III.E.2.b: The patch management strategy does not prioritize all security patches and updates on CISA's Known Exploited Vulnerabilities Catalog"
+}
+
+# ── III.E.3 — Systems that cannot be patched ─────────────────────────────────
+
+violations contains msg if {
+	some u in unpatchable_systems
+	object.get(u, "severe_degradation_justified", false) == false
+	msg := sprintf("TSA SD Pipeline-2021-02G III.E.3: Operational Technology system '%s' is exempted from patching without a documented justification that patching would cause a severe degradation of operational capability to meet business critical functions", [object.get(u, "name", "unnamed")])
+}
+
+violations contains msg if {
+	some u in unpatchable_systems
+	object.get(u, "mitigations_described", false) == false
+	msg := sprintf("TSA SD Pipeline-2021-02G III.E.3: Operational Technology system '%s' cannot be patched, but the strategy includes no description of additional mitigations addressing the risk created by not installing the patch or update", [object.get(u, "name", "unnamed")])
+}
+
+violations contains msg if {
+	some u in unpatchable_systems
+	object.get(u, "mitigation_timeline_defined", false) == false
+	msg := sprintf("TSA SD Pipeline-2021-02G III.E.3: Operational Technology system '%s' cannot be patched, but the strategy includes no timeline for the additional mitigations", [object.get(u, "name", "unnamed")])
+}
+
+# ── Compliance report ────────────────────────────────────────────────────────
+
+compliance_report := {
+	"directive": "TSA SD Pipeline-2021-02G",
+	"section": "III.E",
+	"name": "Application of Security Patches and Updates",
+	"requirements_evaluated": 4,
+	"unpatchable_systems_assessed": count(unpatchable_systems),
+	"compliant": compliant,
+	"violations": violations,
+	"violation_count": count(violations),
+}

--- a/frameworks/critical_infrastructure/tsa_pipeline/sd02_records.rego
+++ b/frameworks/critical_infrastructure/tsa_pipeline/sd02_records.rego
@@ -1,0 +1,179 @@
+package tsa_pipeline.sd02_records
+
+import rego.v1
+
+# =============================================================================
+# TSA Security Directive Pipeline-2021-02G
+# Section IV — Records
+# Section V  — Procedures for Security Directives
+#
+# Directive:  SD Pipeline-2021-02G
+# Effective:  May 3, 2026 through May 2, 2027
+#
+# Requirements evaluated: IV.A, IV.B.1–2, IV.C.1, IV.C.2.a–f, V.A.1–2
+#                         (11 subparagraphs)
+#
+# Section IV governs what TSA can demand and how it must be protected. All
+# information required to be reported or submitted under this Security Directive
+# is Sensitive Security Information subject to 49 CFR part 1520.
+#
+# Note IV.C.2.e.ii: packet captures are bounded — "not to exceed a period of
+# twenty-four hours, as identified and directed by TSA."
+#
+# --- INPUT CONTRACT ----------------------------------------------------------
+# input.records: {
+#   "previous_materials_relied_upon": boolean,   # IV.A
+#   "index_maintained":               boolean,
+#   "index_ordered_by_requirement":   boolean,
+#   "incorporated_by_reference":      boolean,
+#   "ssi_protection": {                          # IV.B
+#       "plans_and_reports":     boolean,
+#       "assessment_results":    boolean
+#   },
+#   "available_to_tsa_on_request":    boolean,   # IV.C.1
+#   "retrievable_document_types":     [string],  # IV.C.2 — see required_types
+#   "activity_snapshot": {                       # IV.C.2.e
+#       "log_files":              boolean,
+#       "packet_capture_capable": boolean,
+#       "packet_capture_max_hours": number,      # must be <= 24
+#       "east_west_traffic":      boolean,
+#       "north_south_traffic":    boolean
+#   },
+#   "directive_procedures": {                    # V.A
+#       "receipt_confirmed":      boolean,
+#       "disseminated_to_senior_management": boolean,
+#       "disseminated_to_implementers":     boolean
+#   }
+# }
+#
+# NO FACT SOURCE EXISTS YET — see sd01_cybersecurity_coordinator.rego.
+#
+# OPA endpoint: POST <opa_ot_url>/v1/data/tsa_pipeline/sd02_records
+# =============================================================================
+
+# `input` is UNDEFINED (not {}) when OPA receives an empty request body. Routing
+# every lookup through this defaulted alias makes an absent fact evaluate to the
+# fail-closed default instead of silently skipping the violation rule entirely.
+default facts := {}
+
+facts := input
+
+default compliant := false
+
+compliant if {
+	count(violations) == 0
+}
+
+required_document_types := {
+	"asset_inventory": "IV.C.2.a: Hardware/software asset inventory, including supervisory control and data acquisition systems",
+	"firewall_rules": "IV.C.2.b: Firewall rules",
+	"network_diagrams": "IV.C.2.c: Network diagrams, switch and router configurations, architecture diagrams, publicly routable internet protocol addresses, and Virtual Local Area Networks",
+	"policy_documents": "IV.C.2.d: Policy, procedural, and other documents that informed the development and documented implementation of the Cybersecurity Implementation Plan, Cybersecurity Incident Response Plan, Cybersecurity Assessment Plan, and assessment or audit results",
+	"activity_snapshot": "IV.C.2.e: Data providing a 'snapshot' of activity on and between Information and Operational Technology systems",
+}
+
+declared_document_types := {t | some t in object.get(facts, ["records", "retrievable_document_types"], [])}
+
+# ── IV.A — Use of previous plans, assessments, tests, and evaluations ────────
+
+violations contains msg if {
+	object.get(facts, ["records", "previous_materials_relied_upon"], false) == true
+	object.get(facts, ["records", "index_maintained"], false) == false
+	msg := "TSA SD Pipeline-2021-02G IV.A: Previously developed plans, assessments, tests, or evaluations are relied upon to meet this Security Directive's requirements, but no index of the records and their location is maintained"
+}
+
+violations contains msg if {
+	object.get(facts, ["records", "previous_materials_relied_upon"], false) == true
+	object.get(facts, ["records", "index_ordered_by_requirement"], false) == false
+	msg := "TSA SD Pipeline-2021-02G IV.A: The index of previously developed materials is not organized in the same sequence as the requirements in this Security Directive"
+}
+
+violations contains msg if {
+	object.get(facts, ["records", "previous_materials_relied_upon"], false) == true
+	object.get(facts, ["records", "incorporated_by_reference"], false) == false
+	msg := "TSA SD Pipeline-2021-02G IV.A: Previously developed materials are not explicitly incorporated by reference into the Cybersecurity Implementation Plan"
+}
+
+# ── IV.B — Protection of Sensitive Security Information ──────────────────────
+
+violations contains msg if {
+	object.get(facts, ["records", "ssi_protection", "plans_and_reports"], false) == false
+	msg := "TSA SD Pipeline-2021-02G IV.B.1: Plans and reports required by this Security Directive are not stored and transmitted consistent with the Sensitive Security Information requirements in 49 CFR part 1520"
+}
+
+violations contains msg if {
+	object.get(facts, ["records", "ssi_protection", "assessment_results"], false) == false
+	msg := "TSA SD Pipeline-2021-02G IV.B.2: Audit, testing, or assessment results are not stored and transmitted consistent with the Sensitive Security Information requirements in 49 CFR part 1520"
+}
+
+# ── IV.C — Documentation to establish compliance ─────────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["records", "available_to_tsa_on_request"], false) == false
+	msg := "TSA SD Pipeline-2021-02G IV.C.1: Records necessary to establish compliance are not made available to TSA upon request for inspection and/or copying"
+}
+
+violations contains msg if {
+	some doc_type, description in required_document_types
+	not doc_type in declared_document_types
+	msg := sprintf("TSA SD Pipeline-2021-02G %s — this record type cannot be produced for TSA inspection", [description])
+}
+
+# ── IV.C.2.e — Activity snapshot data ────────────────────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["records", "activity_snapshot", "log_files"], false) == false
+	msg := "TSA SD Pipeline-2021-02G IV.C.2.e.i: Log files providing a snapshot of activity on and between Information and Operational Technology systems cannot be produced"
+}
+
+violations contains msg if {
+	object.get(facts, ["records", "activity_snapshot", "packet_capture_capable"], false) == false
+	msg := "TSA SD Pipeline-2021-02G IV.C.2.e.ii: No capability to produce a capture of network traffic (packet capture) as identified and directed by TSA"
+}
+
+violations contains msg if {
+	hours := object.get(facts, ["records", "activity_snapshot", "packet_capture_max_hours"], 0)
+	is_number(hours)
+	hours > 24
+	msg := sprintf("TSA SD Pipeline-2021-02G IV.C.2.e.ii: Packet capture is configured for a %v-hour period — captures produced for TSA must not exceed a period of twenty-four hours", [hours])
+}
+
+violations contains msg if {
+	object.get(facts, ["records", "activity_snapshot", "east_west_traffic"], false) == false
+	msg := "TSA SD Pipeline-2021-02G IV.C.2.e.iii: 'East-West Traffic' of Operational Technology systems, sites, and environments within the scope of this Security Directive cannot be produced"
+}
+
+violations contains msg if {
+	object.get(facts, ["records", "activity_snapshot", "north_south_traffic"], false) == false
+	msg := "TSA SD Pipeline-2021-02G IV.C.2.e.iv: 'North-South Traffic' between Information and Operational Technology systems, and the perimeter boundaries between them, cannot be produced"
+}
+
+# ── V.A — General procedures ─────────────────────────────────────────────────
+
+violations contains msg if {
+	object.get(facts, ["records", "directive_procedures", "receipt_confirmed"], false) == false
+	msg := "TSA SD Pipeline-2021-02G V.A.1: Written confirmation of receipt of this Security Directive was not immediately provided to TSA (SurfOps-SD@tsa.dhs.gov)"
+}
+
+violations contains msg if {
+	object.get(facts, ["records", "directive_procedures", "disseminated_to_senior_management"], false) == false
+	msg := "TSA SD Pipeline-2021-02G V.A.2: The information and measures in this Security Directive were not immediately disseminated to corporate senior management and security management representatives"
+}
+
+violations contains msg if {
+	object.get(facts, ["records", "directive_procedures", "disseminated_to_implementers"], false) == false
+	msg := "TSA SD Pipeline-2021-02G V.A.2: The applicable security measures were not provided to the direct employees and authorized representatives responsible for implementing them"
+}
+
+# ── Compliance report ────────────────────────────────────────────────────────
+
+compliance_report := {
+	"directive": "TSA SD Pipeline-2021-02G",
+	"section": "IV / V",
+	"name": "Records, SSI Protection, and Directive Procedures",
+	"packet_capture_max_hours": 24,
+	"requirements_evaluated": 11,
+	"compliant": compliant,
+	"violations": violations,
+	"violation_count": count(violations),
+}

--- a/frameworks/critical_infrastructure/tsa_pipeline/tests/test_tsa_pipeline_deadlines.rego
+++ b/frameworks/critical_infrastructure/tsa_pipeline/tests/test_tsa_pipeline_deadlines.rego
@@ -1,0 +1,280 @@
+package tsa_pipeline.deadlines_test
+
+import rego.v1
+
+# The deadlines ARE the assessable content of these directives. Each test pins
+# one clock to the directive text so a future edit can't silently loosen it.
+#
+#   72 hours  SD-01G II.C.3    incident report to CISA
+#   24 hours  SD-01G II.C.5.f  supplemental information
+#    7 days   SD-01G II.B.1.e  Cybersecurity Coordinator info change
+#   60 days   SD-02G II.A.5    "no Critical Cyber Systems" notice
+#   45 days   SD-02G VI.C      threshold that makes a change "permanent"
+#   50 days   SD-02G VI.D      amendment request filing
+#   30 days   SD-02G VI.F      petition for reconsideration
+#   12 months SD-02G III.F.1.e incident response plan exercise
+#    2 objs   SD-02G III.F.1.e.i  minimum objectives per exercise
+#   24 months SD-02G III.G.2.b architecture design review
+#   33% / 100% SD-02G III.G.2.d annual / three-year assessment coverage
+#   12 months SD-02G III.G.3-4 assessment plan and report submission
+#   24 hours  SD-02G IV.C.2.e.ii  maximum packet capture period
+
+violation_matching(violations, needle) if {
+	some v in violations
+	contains(v, needle)
+}
+
+# ── SD-01G II.C.3 — 72-hour CISA reporting ───────────────────────────────────
+
+test_incident_reported_at_72_hours_is_compliant if {
+	violations := data.tsa_pipeline.sd01_reporting.violations with input as {"incident_reporting": {"incidents": [{
+		"id": "INC-1",
+		"reported_to_cisa": true,
+		"hours_to_report": 72,
+		"sd_reporting_stated": true,
+	}]}}
+	not violation_matching(violations, "II.C.3: Cybersecurity incident 'INC-1' was reported")
+}
+
+test_incident_reported_after_72_hours_violates if {
+	violations := data.tsa_pipeline.sd01_reporting.violations with input as {"incident_reporting": {"incidents": [{
+		"id": "INC-2",
+		"reported_to_cisa": true,
+		"hours_to_report": 73,
+		"sd_reporting_stated": true,
+	}]}}
+	violation_matching(violations, "II.C.3: Cybersecurity incident 'INC-2' was reported to CISA 73 hours")
+}
+
+test_unreported_incident_violates if {
+	violations := data.tsa_pipeline.sd01_reporting.violations with input as {"incident_reporting": {"incidents": [{
+		"id": "INC-3",
+		"reported_to_cisa": false,
+	}]}}
+	violation_matching(violations, "II.C.3: Cybersecurity incident 'INC-3' was never reported to CISA")
+}
+
+# ── SD-01G II.C.5.f — 24-hour supplemental information ───────────────────────
+
+test_supplemental_after_24_hours_violates if {
+	violations := data.tsa_pipeline.sd01_reporting.violations with input as {"incident_reporting": {"incidents": [{
+		"id": "INC-4",
+		"reported_to_cisa": true,
+		"hours_to_report": 10,
+		"sd_reporting_stated": true,
+		"initial_report_incomplete": true,
+		"supplemental_hours_after_available": 25,
+	}]}}
+	violation_matching(violations, "II.C.5.f: Supplemental information for incident 'INC-4' was provided 25 hours")
+}
+
+# ── SD-01G II.B.1.e — 7-day coordinator information update ───────────────────
+
+test_coordinator_info_change_within_7_days_is_compliant if {
+	violations := data.tsa_pipeline.sd01_coordinator.violations with input as {"cybersecurity_coordinator": {"days_since_information_change": 7}}
+	not violation_matching(violations, "II.B.1.e: Cybersecurity Coordinator information change is")
+}
+
+test_coordinator_info_change_after_7_days_violates if {
+	violations := data.tsa_pipeline.sd01_coordinator.violations with input as {"cybersecurity_coordinator": {"days_since_information_change": 8}}
+	violation_matching(violations, "II.B.1.e: Cybersecurity Coordinator information change is 8 days old")
+}
+
+# ── SD-01G II.B.1.c.ii — non-U.S. citizen trusted traveler membership ────────
+
+test_non_us_citizen_without_trusted_traveler_violates if {
+	violations := data.tsa_pipeline.sd01_coordinator.violations with input as {"cybersecurity_coordinator": {"primary": {
+		"name": "A. Example",
+		"us_citizen": false,
+	}}}
+	violation_matching(violations, "II.B.1.c.ii: Cybersecurity Coordinator 'A. Example' is a non-U.S. citizen")
+}
+
+test_non_us_citizen_with_nexus_membership_satisfies_c_ii if {
+	violations := data.tsa_pipeline.sd01_coordinator.violations with input as {"cybersecurity_coordinator": {"primary": {
+		"name": "A. Example",
+		"us_citizen": false,
+		"trusted_traveler_program": "NEXUS",
+		"known_traveler_number": "123456789",
+	}}}
+
+	# Needle must include the colon: "II.B.1.c.ii" is a substring of "II.B.1.c.iii".
+	not violation_matching(violations, "II.B.1.c.ii: Cybersecurity Coordinator")
+}
+
+# A program name with no identifier proves nothing — must still violate.
+test_trusted_traveler_program_without_number_violates if {
+	violations := data.tsa_pipeline.sd01_coordinator.violations with input as {"cybersecurity_coordinator": {"primary": {
+		"name": "A. Example",
+		"us_citizen": false,
+		"trusted_traveler_program": "NEXUS",
+	}}}
+	violation_matching(violations, "II.B.1.c.ii: Cybersecurity Coordinator")
+}
+
+# ── SD-02G II.A.5 — 60-day "no Critical Cyber Systems" notice ────────────────
+
+test_no_ccs_notice_after_60_days_violates if {
+	violations := data.tsa_pipeline.sd02_critical_cyber_systems.violations with input as {"critical_cyber_systems": {"none_determination": {
+		"declared": true,
+		"tsa_notified_in_writing": true,
+		"days_since_effective_date": 61,
+	}}}
+	violation_matching(violations, "II.A.5: A 'no Critical Cyber Systems' determination must be notified to TSA in writing within 60 days")
+}
+
+test_no_ccs_notice_within_60_days_is_compliant if {
+	violations := data.tsa_pipeline.sd02_critical_cyber_systems.violations with input as {"critical_cyber_systems": {"none_determination": {
+		"declared": true,
+		"tsa_notified_in_writing": true,
+		"days_since_effective_date": 60,
+	}}}
+	not violation_matching(violations, "II.A.5: A 'no Critical Cyber Systems' determination")
+}
+
+# ── SD-02G VI.C / VI.D — 45-day permanent change, 50-day filing ──────────────
+
+test_change_of_44_days_is_not_permanent if {
+	violations := data.tsa_pipeline.sd02_implementation_plan.violations with input as {"implementation_plan": {"amendments": {"pending_permanent_changes": [{
+		"description": "temp firewall exception",
+		"duration_days": 44,
+		"days_since_effective": 60,
+		"amendment_filed": false,
+	}]}}}
+	not violation_matching(violations, "VI.C: Change 'temp firewall exception'")
+	not violation_matching(violations, "VI.D: The amendment request for permanent change 'temp firewall exception'")
+}
+
+test_change_of_45_days_is_permanent_and_requires_amendment if {
+	violations := data.tsa_pipeline.sd02_implementation_plan.violations with input as {"implementation_plan": {"amendments": {"pending_permanent_changes": [{
+		"description": "new SIEM",
+		"duration_days": 45,
+		"days_since_effective": 10,
+		"amendment_filed": false,
+	}]}}}
+	violation_matching(violations, "VI.C: Change 'new SIEM' is intended to be in effect for 45 days")
+}
+
+test_amendment_filed_after_50_days_violates if {
+	violations := data.tsa_pipeline.sd02_implementation_plan.violations with input as {"implementation_plan": {"amendments": {"pending_permanent_changes": [{
+		"description": "new SIEM",
+		"duration_days": 90,
+		"days_since_effective": 51,
+		"amendment_filed": true,
+	}]}}}
+	violation_matching(violations, "VI.D: The amendment request for permanent change 'new SIEM' is 51 days past")
+}
+
+# ── SD-02G VI.F — 30-day petition for reconsideration ────────────────────────
+
+test_petition_after_30_days_violates if {
+	violations := data.tsa_pipeline.sd02_implementation_plan.violations with input as {"implementation_plan": {"amendments": {"denials": [{
+		"description": "zone redesign",
+		"days_since_denial": 31,
+		"petition_filed": false,
+		"reconsideration_intended": true,
+	}]}}}
+	violation_matching(violations, "VI.F: A petition for reconsideration of the denied amendment 'zone redesign'")
+}
+
+# ── SD-02G III.F.1.e — annual exercise, minimum two objectives ───────────────
+
+test_exercise_testing_one_objective_violates if {
+	violations := data.tsa_pipeline.sd02_incident_response_plan.violations with input as {"incident_response_plan": {"exercises": {"objectives_tested": 1}}}
+	violation_matching(violations, "III.F.1.e.i: Annual exercises tested 1 of the objectives")
+}
+
+test_exercise_testing_two_objectives_satisfies_minimum if {
+	violations := data.tsa_pipeline.sd02_incident_response_plan.violations with input as {"incident_response_plan": {"exercises": {"objectives_tested": 2}}}
+	not violation_matching(violations, "III.F.1.e.i: Annual exercises tested")
+}
+
+test_exercise_older_than_12_months_violates if {
+	violations := data.tsa_pipeline.sd02_incident_response_plan.violations with input as {"incident_response_plan": {"exercises": {
+		"conducted_within_last_12_months": true,
+		"objectives_tested": 3,
+		"months_since_last_exercise": 13,
+	}}}
+	violation_matching(violations, "III.F.1.e: The last Cybersecurity Incident Response Plan exercise was 13 months ago")
+}
+
+# ── SD-02G III.G.2.b — architecture design review every 24 months ────────────
+
+test_architecture_review_at_24_months_is_compliant if {
+	violations := data.tsa_pipeline.sd02_assessment_plan.violations with input as {"assessment_plan": {"architecture_design_review": {"months_since_last_review": 24}}}
+	not violation_matching(violations, "III.G.2.b: The last cybersecurity architecture design review")
+}
+
+test_architecture_review_after_24_months_violates if {
+	violations := data.tsa_pipeline.sd02_assessment_plan.violations with input as {"assessment_plan": {"architecture_design_review": {"months_since_last_review": 25}}}
+	violation_matching(violations, "III.G.2.b: The last cybersecurity architecture design review was 25 months ago")
+}
+
+# ── SD-02G III.G.2.d — one-third annual / 100 percent three-year coverage ────
+
+test_annual_coverage_below_one_third_violates if {
+	violations := data.tsa_pipeline.sd02_assessment_plan.violations with input as {"assessment_plan": {"schedule": {"annual_coverage_percent": 32, "three_year_coverage_percent": 100}}}
+	violation_matching(violations, "III.G.2.d: The assessment schedule covers 32 percent")
+}
+
+test_annual_coverage_of_one_third_is_compliant if {
+	violations := data.tsa_pipeline.sd02_assessment_plan.violations with input as {"assessment_plan": {"schedule": {"annual_coverage_percent": 33, "three_year_coverage_percent": 100}}}
+	not violation_matching(violations, "III.G.2.d: The assessment schedule covers")
+	not violation_matching(violations, "III.G.2.d: The assessment schedule reaches")
+}
+
+test_three_year_coverage_below_100_violates if {
+	violations := data.tsa_pipeline.sd02_assessment_plan.violations with input as {"assessment_plan": {"schedule": {"annual_coverage_percent": 40, "three_year_coverage_percent": 99}}}
+	violation_matching(violations, "III.G.2.d: The assessment schedule reaches 99 percent coverage")
+}
+
+# ── SD-02G III.G.3 — annual plan submission within 12 months ─────────────────
+
+test_plan_submitted_after_12_months_violates if {
+	violations := data.tsa_pipeline.sd02_assessment_plan.violations with input as {"assessment_plan": {"submission": {"submitted_to_tsa": true, "months_since_previous_approval": 13}}}
+	violation_matching(violations, "III.G.3: The Cybersecurity Assessment Plan was submitted 13 months")
+}
+
+# ── SD-02G IV.C.2.e.ii — packet capture must not exceed 24 hours ─────────────
+
+test_packet_capture_over_24_hours_violates if {
+	violations := data.tsa_pipeline.sd02_records.violations with input as {"records": {"activity_snapshot": {"packet_capture_max_hours": 25}}}
+	violation_matching(violations, "IV.C.2.e.ii: Packet capture is configured for a 25-hour period")
+}
+
+test_packet_capture_at_24_hours_is_compliant if {
+	violations := data.tsa_pipeline.sd02_records.violations with input as {"records": {"activity_snapshot": {"packet_capture_max_hours": 24}}}
+	not violation_matching(violations, "IV.C.2.e.ii: Packet capture is configured")
+}
+
+# ── SD-02G III.B.2.b — OT traffic over IT must be encrypted ──────────────────
+
+test_ot_traversing_it_unencrypted_violates if {
+	violations := data.tsa_pipeline.sd02_network_segmentation.violations with input as {"network_segmentation": {"ot_services_traversing_it": {"occurs": true, "encrypted_in_transit": false}}}
+	violation_matching(violations, "III.B.2.b: Operational Technology system services traverse")
+}
+
+test_ot_traversing_it_encrypted_is_compliant if {
+	violations := data.tsa_pipeline.sd02_network_segmentation.violations with input as {"network_segmentation": {"ot_services_traversing_it": {"occurs": true, "encrypted_in_transit": true}}}
+	not violation_matching(violations, "III.B.2.b")
+}
+
+# ── SD-02G III.C.2 — MFA control-room carve-out needs compensating controls ──
+
+test_control_room_mfa_exemption_without_compensating_controls_violates if {
+	violations := data.tsa_pipeline.sd02_access_control.violations with input as {"access_control": {"multi_factor_authentication": {
+		"implemented": false,
+		"control_room_workstations_exempt": true,
+		"compensating_controls_specified": false,
+	}}}
+	violation_matching(violations, "III.C.2: Multi-factor authentication is not applied to industrial control workstations")
+}
+
+test_control_room_mfa_exemption_with_compensating_controls_is_compliant if {
+	violations := data.tsa_pipeline.sd02_access_control.violations with input as {"access_control": {"multi_factor_authentication": {
+		"implemented": false,
+		"control_room_workstations_exempt": true,
+		"compensating_controls_specified": true,
+	}}}
+	not violation_matching(violations, "III.C.2")
+}

--- a/frameworks/critical_infrastructure/tsa_pipeline/tests/test_tsa_pipeline_main_smoke.rego
+++ b/frameworks/critical_infrastructure/tsa_pipeline/tests/test_tsa_pipeline_main_smoke.rego
@@ -1,0 +1,101 @@
+package tsa_pipeline.main_test
+
+import rego.v1
+
+# Contract smoke tests for the tsa_pipeline framework key.
+#
+# The trap these guard against: an undefined field inside an object literal
+# collapses the ENTIRE object to {} at the OPA endpoint, and the calling
+# playbook stores an empty result instead of failing. That silently affected
+# every cis_* key until rego PR #52. These tests encode the check permanently.
+
+# ── The framework key resolves ───────────────────────────────────────────────
+
+test_main_report_wellformed_on_empty_input if {
+	report := data.tsa_pipeline.main.compliance_report with input as {}
+	is_object(report)
+	count(report) > 0
+	is_boolean(report.compliant)
+	is_number(report.violation_count)
+	is_array(report.violations)
+}
+
+test_main_report_fails_closed_on_empty_input if {
+	report := data.tsa_pipeline.main.compliance_report with input as {}
+	report.compliant == false
+	report.sd_2021_01_compliant == false
+	report.sd_2021_02_compliant == false
+	report.violation_count > 0
+	report.passing_sections == 0
+}
+
+# ── Every section module resolves independently ──────────────────────────────
+#
+# Deliberately evaluated with input UNDEFINED (no `with input as {}`). A real
+# OPA POST with an empty body leaves input undefined, which is stricter than
+# input == {} — object.get(input, ...) is itself undefined in that case. Any
+# report field not sourced through a defaulted rule collapses here.
+
+test_every_section_report_wellformed_on_undefined_input if {
+	every section_report in [
+		data.tsa_pipeline.sd01_coordinator.compliance_report,
+		data.tsa_pipeline.sd01_reporting.compliance_report,
+		data.tsa_pipeline.sd01_vulnerability_assessment.compliance_report,
+		data.tsa_pipeline.sd02_critical_cyber_systems.compliance_report,
+		data.tsa_pipeline.sd02_implementation_plan.compliance_report,
+		data.tsa_pipeline.sd02_network_segmentation.compliance_report,
+		data.tsa_pipeline.sd02_access_control.compliance_report,
+		data.tsa_pipeline.sd02_continuous_monitoring.compliance_report,
+		data.tsa_pipeline.sd02_patch_management.compliance_report,
+		data.tsa_pipeline.sd02_incident_response_plan.compliance_report,
+		data.tsa_pipeline.sd02_assessment_plan.compliance_report,
+		data.tsa_pipeline.sd02_records.compliance_report,
+	] {
+		is_object(section_report)
+		count(section_report) > 0
+		is_boolean(section_report.compliant)
+		is_number(section_report.violation_count)
+	}
+}
+
+test_all_twelve_sections_present_in_report if {
+	report := data.tsa_pipeline.main.compliance_report with input as {}
+	count(report.sections) == 12
+	report.total_sections == 12
+}
+
+# ── Aggregation counts every section exactly once ────────────────────────────
+
+test_aggregate_count_equals_sum_of_sections if {
+	report := data.tsa_pipeline.main.compliance_report with input as {}
+	section_sum := sum([n |
+		some section in report.sections
+		n := count(section.violations)
+	])
+	report.violation_count == section_sum
+}
+
+test_directive_counts_sum_to_total if {
+	report := data.tsa_pipeline.main.compliance_report with input as {}
+	report.violation_count == report.sd_2021_01_violation_count + report.sd_2021_02_violation_count
+}
+
+# ── Metadata passthrough is defaulted, not undefined ─────────────────────────
+
+test_metadata_defaults_when_absent if {
+	report := data.tsa_pipeline.main.compliance_report with input as {}
+	report.entity_name == "unknown"
+	report.pipeline_type == "unknown"
+	report.assessed_at == "unknown"
+}
+
+test_metadata_passthrough_when_supplied if {
+	report := data.tsa_pipeline.main.compliance_report with input as {
+		"entity_name": "Example Pipeline Operator",
+		"pipeline_type": "natural_gas_transmission",
+		"assessment_date": "2026-08-11T00:00:00Z",
+	}
+	report.entity_name == "Example Pipeline Operator"
+	report.pipeline_type == "natural_gas_transmission"
+	report.assessed_at == "2026-08-11T00:00:00Z"
+}

--- a/frameworks/critical_infrastructure/tsa_pipeline/tsa_pipeline_main.rego
+++ b/frameworks/critical_infrastructure/tsa_pipeline/tsa_pipeline_main.rego
@@ -1,0 +1,305 @@
+package tsa_pipeline.main
+
+import rego.v1
+
+# =============================================================================
+# TSA Pipeline Security Directives — Main Orchestrator
+#
+# Aggregates both currently-effective TSA pipeline cybersecurity directives:
+#
+#   SD Pipeline-2021-01G — "Enhancing Pipeline Cybersecurity"
+#     Effective January 16, 2026 through January 15, 2027
+#     Supersedes SD Pipeline-2021-01F
+#       II.B  Cybersecurity Coordinator          [sd01_cybersecurity_coordinator.rego]
+#       II.C  Reporting Cybersecurity Incidents  [sd01_incident_reporting.rego]
+#       II.D  Cybersecurity Vulnerability Assmt  [sd01_vulnerability_assessment.rego]
+#
+#   SD Pipeline-2021-02G — "Pipeline Cybersecurity Mitigation Actions,
+#                           Contingency Planning, and Testing"
+#     Effective May 3, 2026 through May 2, 2027
+#     Supersedes SD Pipeline-2021-02F
+#       II.A/III.A  Scope + Critical Cyber Systems [sd02_critical_cyber_systems.rego]
+#       II.B/VI     Implementation Plan + Amends   [sd02_implementation_plan.rego]
+#       III.B       Network Segmentation           [sd02_network_segmentation.rego]
+#       III.C       Access Control                 [sd02_access_control.rego]
+#       III.D       Continuous Monitoring          [sd02_continuous_monitoring.rego]
+#       III.E       Security Patches and Updates   [sd02_patch_management.rego]
+#       III.F       Incident Response Plan         [sd02_incident_response_plan.rego]
+#       III.G       Cybersecurity Assessment Plan  [sd02_assessment_plan.rego]
+#       IV / V      Records and SSI Protection     [sd02_records.rego]
+#
+# Authority:  49 U.S.C. 114(d), (f), (l), and (m)
+# Applies to: Owner/Operators of a hazardous liquid and natural gas pipeline or
+#             a liquefied natural gas facility notified by TSA that their
+#             pipeline system or facility is critical
+# OPA bucket: ot  (opa_framework_map key: tsa_pipeline)
+#
+# --- FACT SOURCE STATUS ------------------------------------------------------
+# NOTHING IN THE COMPLIANCE REPO EMITS THIS INPUT TODAY. Both directives are
+# overwhelmingly plan-, attestation-, and recordkeeping-driven: "is there a
+# TSA-approved Cybersecurity Implementation Plan", "was the Assessment Plan
+# submitted within 12 months", "were at least one-third of measures assessed
+# this year". None of that comes from Ansible host fact-gathering.
+#
+# On empty input this framework reports fully non-compliant across all 12
+# sections. That is correct fail-closed behavior for an audit framework, but it
+# is NOT a working assessment — do not demo it as one until a fact source
+# (survey, attestation intake, or GRC export) is wired up on the Ansible side.
+#
+# OPA endpoint: POST <opa_ot_url>/v1/data/tsa_pipeline/main/compliance_report
+# =============================================================================
+
+import data.tsa_pipeline.sd01_coordinator
+import data.tsa_pipeline.sd01_reporting
+import data.tsa_pipeline.sd01_vulnerability_assessment
+import data.tsa_pipeline.sd02_access_control
+import data.tsa_pipeline.sd02_assessment_plan
+import data.tsa_pipeline.sd02_continuous_monitoring
+import data.tsa_pipeline.sd02_critical_cyber_systems
+import data.tsa_pipeline.sd02_implementation_plan
+import data.tsa_pipeline.sd02_incident_response_plan
+import data.tsa_pipeline.sd02_network_segmentation
+import data.tsa_pipeline.sd02_patch_management
+import data.tsa_pipeline.sd02_records
+
+# ── Violation aggregation ────────────────────────────────────────────────────
+# array.concat() takes exactly 2 arrays — build the tree in pairs.
+
+# --- SD Pipeline-2021-01G (3 sections) ---
+
+sd01_pair_1 := array.concat(
+	[v | some v in sd01_coordinator.violations],
+	[v | some v in sd01_reporting.violations],
+)
+
+sd01_violations := array.concat(
+	sd01_pair_1,
+	[v | some v in sd01_vulnerability_assessment.violations],
+)
+
+# --- SD Pipeline-2021-02G (9 sections) ---
+
+sd02_pair_1 := array.concat(
+	[v | some v in sd02_critical_cyber_systems.violations],
+	[v | some v in sd02_implementation_plan.violations],
+)
+
+sd02_pair_2 := array.concat(
+	[v | some v in sd02_network_segmentation.violations],
+	[v | some v in sd02_access_control.violations],
+)
+
+sd02_pair_3 := array.concat(
+	[v | some v in sd02_continuous_monitoring.violations],
+	[v | some v in sd02_patch_management.violations],
+)
+
+sd02_pair_4 := array.concat(
+	[v | some v in sd02_incident_response_plan.violations],
+	[v | some v in sd02_assessment_plan.violations],
+)
+
+sd02_quad_1 := array.concat(sd02_pair_1, sd02_pair_2)
+
+sd02_quad_2 := array.concat(sd02_pair_3, sd02_pair_4)
+
+sd02_violations := array.concat(
+	array.concat(sd02_quad_1, sd02_quad_2),
+	[v | some v in sd02_records.violations],
+)
+
+# --- Both directives ---
+
+all_violations := array.concat(sd01_violations, sd02_violations)
+
+# ── Top-level compliance ─────────────────────────────────────────────────────
+
+default compliant := false
+
+compliant if {
+	count(all_violations) == 0
+}
+
+# ── Per-section compliance flags ─────────────────────────────────────────────
+
+default sd01_coordinator_compliant := false
+
+default sd01_reporting_compliant := false
+
+default sd01_vulnerability_assessment_compliant := false
+
+default sd02_critical_cyber_systems_compliant := false
+
+default sd02_implementation_plan_compliant := false
+
+default sd02_network_segmentation_compliant := false
+
+default sd02_access_control_compliant := false
+
+default sd02_continuous_monitoring_compliant := false
+
+default sd02_patch_management_compliant := false
+
+default sd02_incident_response_plan_compliant := false
+
+default sd02_assessment_plan_compliant := false
+
+default sd02_records_compliant := false
+
+sd01_coordinator_compliant if sd01_coordinator.compliant
+
+sd01_reporting_compliant if sd01_reporting.compliant
+
+sd01_vulnerability_assessment_compliant if sd01_vulnerability_assessment.compliant
+
+sd02_critical_cyber_systems_compliant if sd02_critical_cyber_systems.compliant
+
+sd02_implementation_plan_compliant if sd02_implementation_plan.compliant
+
+sd02_network_segmentation_compliant if sd02_network_segmentation.compliant
+
+sd02_access_control_compliant if sd02_access_control.compliant
+
+sd02_continuous_monitoring_compliant if sd02_continuous_monitoring.compliant
+
+sd02_patch_management_compliant if sd02_patch_management.compliant
+
+sd02_incident_response_plan_compliant if sd02_incident_response_plan.compliant
+
+sd02_assessment_plan_compliant if sd02_assessment_plan.compliant
+
+sd02_records_compliant if sd02_records.compliant
+
+section_flags := [
+	sd01_coordinator_compliant,
+	sd01_reporting_compliant,
+	sd01_vulnerability_assessment_compliant,
+	sd02_critical_cyber_systems_compliant,
+	sd02_implementation_plan_compliant,
+	sd02_network_segmentation_compliant,
+	sd02_access_control_compliant,
+	sd02_continuous_monitoring_compliant,
+	sd02_patch_management_compliant,
+	sd02_incident_response_plan_compliant,
+	sd02_assessment_plan_compliant,
+	sd02_records_compliant,
+]
+
+total_sections := 12
+
+passing_sections := count([f | some f in section_flags; f == true])
+
+section_compliance_score := round((passing_sections / total_sections) * 100)
+
+# ── Directive-level rollups ──────────────────────────────────────────────────
+
+default sd01_compliant := false
+
+sd01_compliant if {
+	sd01_coordinator_compliant
+	sd01_reporting_compliant
+	sd01_vulnerability_assessment_compliant
+}
+
+default sd02_compliant := false
+
+sd02_compliant if {
+	sd02_critical_cyber_systems_compliant
+	sd02_implementation_plan_compliant
+	sd02_network_segmentation_compliant
+	sd02_access_control_compliant
+	sd02_continuous_monitoring_compliant
+	sd02_patch_management_compliant
+	sd02_incident_response_plan_compliant
+	sd02_assessment_plan_compliant
+	sd02_records_compliant
+}
+
+# ── Report metadata (defaulted — an undefined field collapses the object) ────
+
+default entity_name := "unknown"
+
+entity_name := input.entity_name
+
+default assessment_date := "unknown"
+
+assessment_date := input.assessment_date
+
+default pipeline_type := "unknown"
+
+pipeline_type := input.pipeline_type
+
+# ── Complete compliance report ───────────────────────────────────────────────
+
+compliance_report := {
+	"framework": "TSA Pipeline Security Directives",
+	"directives": [
+		"SD Pipeline-2021-01G — Enhancing Pipeline Cybersecurity (effective 2026-01-16)",
+		"SD Pipeline-2021-02G — Pipeline Cybersecurity Mitigation Actions, Contingency Planning, and Testing (effective 2026-05-03)",
+	],
+	"authority": "49 U.S.C. 114(d), (f), (l), and (m)",
+	"entity_name": entity_name,
+	"pipeline_type": pipeline_type,
+	"assessed_at": assessment_date,
+	"compliant": compliant,
+	"sd_2021_01_compliant": sd01_compliant,
+	"sd_2021_01_violation_count": count(sd01_violations),
+	"sd_2021_02_compliant": sd02_compliant,
+	"sd_2021_02_violation_count": count(sd02_violations),
+	"total_sections": total_sections,
+	"passing_sections": passing_sections,
+	"section_compliance_score": section_compliance_score,
+	"total_requirements_evaluated": 112,
+	"violation_count": count(all_violations),
+	"violations": all_violations,
+	"sections": {
+		"SD01_II_B_cybersecurity_coordinator": {
+			"compliant": sd01_coordinator_compliant,
+			"violations": sd01_coordinator.violations,
+		},
+		"SD01_II_C_incident_reporting": {
+			"compliant": sd01_reporting_compliant,
+			"violations": sd01_reporting.violations,
+		},
+		"SD01_II_D_vulnerability_assessment": {
+			"compliant": sd01_vulnerability_assessment_compliant,
+			"violations": sd01_vulnerability_assessment.violations,
+		},
+		"SD02_III_A_critical_cyber_systems": {
+			"compliant": sd02_critical_cyber_systems_compliant,
+			"violations": sd02_critical_cyber_systems.violations,
+		},
+		"SD02_II_B_implementation_plan": {
+			"compliant": sd02_implementation_plan_compliant,
+			"violations": sd02_implementation_plan.violations,
+		},
+		"SD02_III_B_network_segmentation": {
+			"compliant": sd02_network_segmentation_compliant,
+			"violations": sd02_network_segmentation.violations,
+		},
+		"SD02_III_C_access_control": {
+			"compliant": sd02_access_control_compliant,
+			"violations": sd02_access_control.violations,
+		},
+		"SD02_III_D_continuous_monitoring": {
+			"compliant": sd02_continuous_monitoring_compliant,
+			"violations": sd02_continuous_monitoring.violations,
+		},
+		"SD02_III_E_patch_management": {
+			"compliant": sd02_patch_management_compliant,
+			"violations": sd02_patch_management.violations,
+		},
+		"SD02_III_F_incident_response_plan": {
+			"compliant": sd02_incident_response_plan_compliant,
+			"violations": sd02_incident_response_plan.violations,
+		},
+		"SD02_III_G_assessment_plan": {
+			"compliant": sd02_assessment_plan_compliant,
+			"violations": sd02_assessment_plan.violations,
+		},
+		"SD02_IV_V_records": {
+			"compliant": sd02_records_compliant,
+			"violations": sd02_records.violations,
+		},
+	},
+}


### PR DESCRIPTION
Adds `frameworks/critical_infrastructure/tsa_pipeline/` — both currently-effective TSA pipeline cybersecurity directives as 12 section modules plus a `tsa_pipeline.main` orchestrator. **112 directive subparagraphs** assessed.

Written from the signed TSA PDFs, not secondary summaries. That mattered: search results claimed a *12-hour* CISA reporting deadline; §II.C.3 of the actual directive says **72 hours**.

| Directive | Effective | Sections |
|---|---|---|
| **SD Pipeline-2021-01G** — *Enhancing Pipeline Cybersecurity* | 2026-01-16 → 2027-01-15 (supersedes 01F) | II.B Coordinator · II.C CISA reporting · II.D Vulnerability assessment |
| **SD Pipeline-2021-02G** — *Mitigation Actions, Contingency Planning, and Testing* | 2026-05-03 → 2027-05-02 (supersedes 02F) | II.A/III.A Critical Cyber Systems · II.B/VI Implementation Plan + amendments · III.B Segmentation · III.C Access control · III.D Monitoring · III.E Patching · III.F Incident response · III.G Assessment plan · IV/V Records + SSI |

## The deadlines are the content

These directives are largely clock-driven, so every deadline gets its own test in `tests/test_tsa_pipeline_deadlines.rego` — boundary values on both sides:

| Clock | Cite |
|---|---|
| 72h CISA incident report | SD-01G II.C.3 |
| 24h supplemental information | SD-01G II.C.5.f |
| 7d Coordinator info change | SD-01G II.B.1.e |
| 60d "no Critical Cyber Systems" notice | SD-02G II.A.5 |
| 45d permanent change / 50d amendment / 30d reconsideration | SD-02G VI.C / VI.D / VI.F |
| Annual IRP exercise, ≥ 2 objectives | SD-02G III.F.1.e |
| 24-month architecture design review | SD-02G III.G.2.b |
| ⅓ per year, 100% over 3 years | SD-02G III.G.2.d |
| 12-month plan + report submission | SD-02G III.G.3–4 |
| 24h maximum packet capture | SD-02G IV.C.2.e.ii |

## Fail-closed by construction

Every lookup routes through a defaulted `facts` alias instead of `input` directly.

This is not cosmetic. OPA leaves `input` **undefined** (not `{}`) on an empty request body, so `object.get(input, ...)` was itself undefined — the violation rule body simply failed, no violation fired, and **five of twelve sections reported compliant with zero facts supplied**. Caught by evaluating the real empty-body case rather than `with input as {}`.

Contract tests now permanently encode both halves:
- no section report collapses to `{}` on undefined input — the failure mode that silently affected every `cis_*` key until #52
- `passing_sections == 0` on undefined input, so a future refactor can't quietly reintroduce fail-open

Writing those tests also caught a missing `default none_declared := false` before it shipped.

## Verification

```
opa test frameworks/critical_infrastructure/tsa_pipeline/   → 38/38
opa test . --ignore .github                                 → 342/342  (was 304)
opa fmt --list frameworks/critical_infrastructure/tsa_pipeline/  → clean
opa eval -d .../tsa_pipeline 'data.tsa_pipeline.main.compliance_report'
    → populated object, compliant:false, passing_sections:0, 129 violations
```

Policy count 532 → 545; README and CLAUDE.md counts updated to match.

## ⚠️ No fact source exists yet

Both directives are overwhelmingly **plan, attestation, and recordkeeping** requirements — "is there a TSA-approved Cybersecurity Implementation Plan", "was the Assessment Plan submitted within 12 months", "were ⅓ of measures assessed this year". None of that comes from Ansible host fact-gathering, and nothing in the compliance repo emits the `input` documented in each module header.

Absent input the framework reports **fully non-compliant across all 12 sections**. That is correct fail-closed behavior for an audit framework, but it is **not a working assessment** — it should not be demoed as one until an attestation intake or GRC export is wired up. Called out in the README and in every module header specifically so `tsa_pipeline` does not become a second `framework=hipaa` trap.

## Consumer follow-up (compliance repo)

Add `tsa_pipeline` to `opa_framework_map` in `ansible/vars/site_config.yml` under the **`ot`** bucket, then bump the submodule pointer. Endpoint: `POST <opa_ot_url>/v1/data/tsa_pipeline/main/compliance_report`.

## Separate finding — not fixed here

CI's "Run policy tests" step globs `*_test.rego`, which matches **1** of the repo's 83 test files. The other 82 — including the existing NIST 800-82, NERC-CIP, and IEC 62443 smoke tests, and the two added here — follow the documented `tests/test_*.rego` convention and **never run in CI**. The step's `opa test "$dir"` would also load only the `tests/` directory, without the policies under test.

Left out of this PR because `.github/workflows/` is a protected path needing the `Approved-By` trailer. Happy to fix it as a follow-up on your go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)