### PR TITLE
fix(stig): stig_openshift_4 and stig_kubernetes reported a PASS on empty input

### DIFF
--- a/benchmarks/stig/kubernetes/stig_kubernetes_main.rego
+++ b/benchmarks/stig/kubernetes/stig_kubernetes_main.rego
@@ -10,17 +10,92 @@
 
 package stig_kubernetes.main
 
-import rego.v1
 import data.stig.kubernetes
+import rego.v1
+
+# ---------------------------------------------------------------------------
+# FAIL-CLOSED GATE
+#
+# The STIG rules are written as "finding is open if the fact says X". With NO
+# facts, nothing iterates, no finding opens, and the benchmark reports a near
+# pass for an assessment that evaluated nothing. Measured on empty input before
+# this gate: stig_kubernetes reported 86% with 25 of 29 controls "passed" — the
+# 4 open findings come from rules that fire on absent keys, so the boolean
+# `compliant` was false while the score was still meaningless.
+#
+# A false 86% is written to compliance_results as a real row and reads as a
+# nearly-clean cluster. See the companion gate in stig_openshift_4_main.rego,
+# which reported a full 100% pass on the same empty input.
+#
+# A missing-facts assessment is now reported as fully non-compliant with an
+# explicit finding, never as a partial pass.
+#
+# LIMITATION: this gate detects a completely EMPTY input, not a partial one.
+# An input carrying one irrelevant key still evaluates normally, so sparse or
+# wrong-shaped facts can still under-report findings.
+# ---------------------------------------------------------------------------
+
+default _facts_supplied := false
+
+_facts_supplied if count(object.keys(input)) > 0
+
+_no_facts_finding := {
+	"rule_title": "FAIL-CLOSED: no facts supplied for stig_kubernetes — the assessment could not be evaluated. This is NOT a passing result; check that fact collection ran and produced input.",
+	"severity": "CAT I",
+	"status": "open",
+}
+
+default _upstream := {}
+
+_upstream := kubernetes.compliance_report
+
+default _total_controls := 0
+
+_total_controls := _upstream.total_controls
+
+default _upstream_open := []
+
+_upstream_open := [f | some f in _upstream.open_findings]
+
+_open_findings := array.concat(_upstream_open, [_no_facts_finding]) if not _facts_supplied
+
+_open_findings := _upstream_open if _facts_supplied
+
+# No facts => every control is unverified, which counts as failed, not passed.
+_failed := _total_controls if not _facts_supplied
+
+_failed := count(_upstream_open) if _facts_supplied
+
+_passed := 0 if not _facts_supplied
+
+_passed := max([0, _total_controls - _failed]) if _facts_supplied
+
+default _percentage := 0
+
+_percentage := round((_passed * 100) / _total_controls) if _total_controls > 0
+
+default _compliant := false
+
+_compliant if {
+	_facts_supplied
+	count(_open_findings) == 0
+}
 
 # Upstream report uses "open_findings"; the generic playbook contract expects
 # "violations". Merge a violations alias into the report so callers can use
-# either name. Use object.union so existing keys (open_findings, etc.) survive.
-compliance_report := object.union(kubernetes.compliance_report, {
-    "violations":      kubernetes.compliance_report.open_findings,
-    "violation_count": count(kubernetes.compliance_report.open_findings),
+# either name. Use object.union so existing keys (all_findings, category
+# breakdown, version) survive; the gated values override the upstream ones.
+compliance_report := object.union(_upstream, {
+	"compliant": _compliant,
+	"passed_controls": _passed,
+	"failed_controls": _failed,
+	"compliance_percentage": _percentage,
+	"open_findings": _open_findings,
+	"violations": _open_findings,
+	"violation_count": count(_open_findings),
+	"facts_supplied": _facts_supplied,
 })
 
-compliant := kubernetes.compliance_report.compliant
+compliant := _compliant
 
-violations := kubernetes.compliance_report.open_findings
+violations := _open_findings

--- a/benchmarks/stig/kubernetes/tests/test_stig_kubernetes_smoke.rego
+++ b/benchmarks/stig/kubernetes/tests/test_stig_kubernetes_smoke.rego
@@ -1,7 +1,7 @@
 package stig_kubernetes.main_test
 
-import rego.v1
 import data.stig_kubernetes.main
+import rego.v1
 
 # Phase 1 contract smoke test: the live orchestrator endpoint
 # (data.stig_kubernetes.main.compliance_report) must return a well-formed
@@ -11,4 +11,34 @@ test_report_wellformed_on_empty_input if {
 	is_object(report)
 	count(report) > 0
 	is_boolean(report.compliant)
+}
+
+# Well-formedness alone is not enough. Before the fail-closed gate this report
+# was well-formed and `compliant` was already false — but the score was 86%
+# with 25 of 29 controls counted as PASSED on empty input. Asserting only the
+# boolean is what let that through, so assert the score too.
+test_fails_closed_on_empty_input if {
+	report := main.compliance_report with input as {}
+	report.compliant == false
+	report.facts_supplied == false
+	report.compliance_percentage == 0
+	report.passed_controls == 0
+	report.failed_controls == report.total_controls
+	report.violation_count > 0
+}
+
+test_no_facts_finding_is_explicit if {
+	report := main.compliance_report with input as {}
+	some f in report.violations
+	contains(f.rule_title, "FAIL-CLOSED: no facts supplied for stig_kubernetes")
+}
+
+# The gate must be transparent once real facts arrive — a genuine assessment
+# must still score normally, not stay pinned at zero.
+test_gate_transparent_when_facts_supplied if {
+	report := main.compliance_report with input as {"kube_apiserver": {"anonymous_auth": false}}
+	report.facts_supplied == true
+	report.compliance_percentage > 0
+	report.passed_controls > 0
+	not contains(concat(" ", [f.rule_title | some f in report.violations]), "FAIL-CLOSED")
 }

--- a/benchmarks/stig/openshift_4/stig_openshift_4_main.rego
+++ b/benchmarks/stig/openshift_4/stig_openshift_4_main.rego
@@ -10,17 +10,91 @@
 
 package stig_openshift_4.main
 
-import rego.v1
 import data.stig.openshift_4
+import rego.v1
+
+# ---------------------------------------------------------------------------
+# FAIL-CLOSED GATE
+#
+# The STIG rules are written as "finding is open if the fact says X". With NO
+# facts, nothing iterates, no finding opens, and the benchmark reports a clean
+# pass for an assessment that evaluated nothing. Measured on empty input before
+# this gate: stig_openshift_4 reported compliant=true at 100% (24/24 passed),
+# and stig_kubernetes 86% (25/29 passed).
+#
+# That is the same empty-input signature the CIS bridges were gated against in
+# #52 — and unlike a report that collapses to {} (which the playbook now fails
+# on), a bogus PASS is written to compliance_results as a green row. It is the
+# more dangerous of the two failure modes, which is why it is fixed first.
+#
+# A missing-facts assessment is now reported as fully non-compliant with an
+# explicit finding, never as a pass.
+#
+# LIMITATION: this gate detects a completely EMPTY input, not a partial one.
+# An input carrying one irrelevant key still evaluates normally, so sparse or
+# wrong-shaped facts can still under-report findings.
+# ---------------------------------------------------------------------------
+
+default _facts_supplied := false
+
+_facts_supplied if count(object.keys(input)) > 0
+
+_no_facts_finding := {
+	"rule_title": "FAIL-CLOSED: no facts supplied for stig_openshift_4 — the assessment could not be evaluated. This is NOT a passing result; check that fact collection ran and produced input.",
+	"severity": "CAT I",
+	"status": "open",
+}
+
+default _upstream := {}
+
+_upstream := openshift_4.compliance_report
+
+default _total_controls := 0
+
+_total_controls := _upstream.total_controls
+
+default _upstream_open := []
+
+_upstream_open := [f | some f in _upstream.open_findings]
+
+_open_findings := array.concat(_upstream_open, [_no_facts_finding]) if not _facts_supplied
+
+_open_findings := _upstream_open if _facts_supplied
+
+# No facts => every control is unverified, which counts as failed, not passed.
+_failed := _total_controls if not _facts_supplied
+
+_failed := count(_upstream_open) if _facts_supplied
+
+_passed := 0 if not _facts_supplied
+
+_passed := max([0, _total_controls - _failed]) if _facts_supplied
+
+default _percentage := 0
+
+_percentage := round((_passed * 100) / _total_controls) if _total_controls > 0
+
+default _compliant := false
+
+_compliant if {
+	_facts_supplied
+	count(_open_findings) == 0
+}
 
 # Upstream report uses "open_findings"; the generic playbook contract expects
 # "violations". Merge a violations alias into the report so callers can use
-# either name.
-compliance_report := object.union(openshift_4.compliance_report, {
-    "violations":      openshift_4.compliance_report.open_findings,
-    "violation_count": count(openshift_4.compliance_report.open_findings),
+# either name. The gated values override the upstream ones.
+compliance_report := object.union(_upstream, {
+	"compliant": _compliant,
+	"passed_controls": _passed,
+	"failed_controls": _failed,
+	"compliance_percentage": _percentage,
+	"open_findings": _open_findings,
+	"violations": _open_findings,
+	"violation_count": count(_open_findings),
+	"facts_supplied": _facts_supplied,
 })
 
-compliant := openshift_4.compliance_report.compliant
+compliant := _compliant
 
-violations := openshift_4.compliance_report.open_findings
+violations := _open_findings

--- a/benchmarks/stig/openshift_4/tests/test_stig_openshift_4_smoke.rego
+++ b/benchmarks/stig/openshift_4/tests/test_stig_openshift_4_smoke.rego
@@ -1,7 +1,7 @@
 package stig_openshift_4.main_test
 
-import rego.v1
 import data.stig_openshift_4.main
+import rego.v1
 
 # Phase 1 contract smoke test: the live orchestrator endpoint
 # (data.stig_openshift_4.main.compliance_report) must return a well-formed
@@ -11,4 +11,32 @@ test_report_wellformed_on_empty_input if {
 	is_object(report)
 	count(report) > 0
 	is_boolean(report.compliant)
+}
+
+# Well-formedness alone is not enough: before the fail-closed gate this report
+# was well-formed AND claimed compliant=true at 100% (24/24 passed) on empty
+# input. A bogus PASS reaches compliance_results as a green row, which is worse
+# than a report that collapses to {} (the playbook fails on that one).
+test_fails_closed_on_empty_input if {
+	report := main.compliance_report with input as {}
+	report.compliant == false
+	report.facts_supplied == false
+	report.compliance_percentage == 0
+	report.passed_controls == 0
+	report.failed_controls == report.total_controls
+	report.violation_count > 0
+}
+
+test_no_facts_finding_is_explicit if {
+	report := main.compliance_report with input as {}
+	some f in report.violations
+	contains(f.rule_title, "FAIL-CLOSED: no facts supplied for stig_openshift_4")
+}
+
+# The gate must be transparent once real facts arrive — it must not permanently
+# pin the score to zero.
+test_gate_transparent_when_facts_supplied if {
+	report := main.compliance_report with input as {"openshift": {"fips_mode": true}}
+	report.facts_supplied == true
+	not contains(concat(" ", [f.rule_title | some f in report.violations]), "FAIL-CLOSED")
 }


### PR DESCRIPTION
Found by sweeping all **65** `opa_framework_map` keys for the defect class #52 fixed for CIS. This PR fixes the dangerous subset; the rest is follow-up (below).

## The bug

Both `<key>.main` bridges were added to satisfy the `generic_framework_assessment` routing convention but never received the fail-closed gate #52 added to the CIS bridges. Measured on **empty input**, before this change:

| key | compliant | score | controls "passed" | findings |
|---|---|---|---|---|
| `stig_openshift_4` | **true** | **100%** | 24 / 24 | 0 |
| `stig_kubernetes` | false | **86%** | 25 / 29 | 4 |

The STIG rules are written as *"finding is open if the fact says X"*. With no facts nothing iterates, no finding opens, and the benchmark reports a clean or near-clean pass for an assessment that **evaluated nothing**.

## Why this one first

There are two failure modes in this class, and they are not equally bad:

- A report that collapses to `{}` — the playbook now **fails the job** (`generic_framework_assessment.yml`). Loud, no bad data.
- A bogus **PASS** — written to `compliance_results` as a green row that reads as a healthy cluster. Silent.

This is the second kind. It's the same empty-input signature that, per #52, already reached the database for `cis_rhel10`.

## Why the existing tests missed it

`stig_kubernetes` is the instructive case: `compliant` was *already* `false` there (4 rules happen to fire on absent keys), while the score sat at 86% with 25 controls counted as passed. The smoke tests asserted only well-formedness and the boolean — so a meaningless 86% sailed through.

Both tests now assert the **score** as well as the boolean.

## The fix

Both bridges gate on `_facts_supplied`. No facts ⇒ 0%, 0 passed, every control counted failed, an explicit `FAIL-CLOSED` finding, `compliant: false`.

```
stig_openshift_4  empty → compliant=False  0%  passed=0  failed=24/24  violations=1
stig_kubernetes   empty → compliant=False  0%  passed=0  failed=29/29  violations=5
stig_kubernetes   facts → compliant=False 86%  passed=25 failed=4      facts_supplied=True
```

The gate is transparent once real facts arrive — the last line confirms a genuine assessment still scores normally rather than being pinned at zero. That's asserted by `test_gate_transparent_when_facts_supplied` in both suites.

Same `LIMITATION` as #52 applies and is documented in both files: this detects a completely empty input, not a partial one.

## Verification

```
opa test . --ignore .github  → 348/348  (was 342)
```
6 new tests. `opa fmt` clean on all 4 touched files (import ordering was already off in both bridges pre-change).

## Audit result — the other 24 keys

Of 65 registered keys: **40 clean**, **2 fixed here**, **23 remaining**.

The remaining 23 have no resolvable `<key>.main.compliance_report`, so the playbook fails the job loudly — a real gap, but not data corruption. Two sub-groups:

- **7 keys have a real `<key>.main` but no `compliance_report` rule** — `digital_sovereignty`, `fisma`, `gdpr`, `hipaa`, `pci_dss`, `soc2`, `sox`. They define `report` / `overall_compliant` instead.
- **16 keys have no `<key>.main` at all** — name mismatches (`nerc_cip` → `nerc_cip_main`, `iec_62443` → `iec_62443_main`, `stig_rhel8` → `stig.rhel_8`, `ami_device` → `ami.device.compliance`, `crypto_miner_detection` → `security.crypto_miner_detection`, …).

The four `sentinel_*` keys need a decision rather than a bridge: `sentinel.ansible` and friends are **enforcement decision sets** (allow/deny), not compliance reports. Manufacturing a `compliance_report` shape for them would be dishonest; the right fix is probably a distinct contract or removing them from `opa_framework_map`. Flagging rather than guessing.

Not folded in here — each bridge needs a real `total_controls` basis and violations source, and those differ per framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)