### PR TITLE
chore: remove lab IPs and consumer-specific language from the library

### DIFF
--- a/benchmarks/cis/_framework_key_tests/test_framework_key_bridges.rego
+++ b/benchmarks/cis/_framework_key_tests/test_framework_key_bridges.rego
@@ -1,10 +1,10 @@
 package cis_framework_key_bridges_test
 
-# Regression guard for the Generic Framework Assessment contract.
+# Regression guard for the framework-key entrypoint contract.
 #
-# Every key registered in opa_framework_map (compliance repo,
-# ansible/vars/site_config.yml) is queried by the playbook as
+# Each framework exposes a stable, key-addressable entrypoint at
 #   /v1/data/<key>/main/compliance_report
+# so a caller can evaluate any framework without knowing its package layout.
 #
 # If that path is undefined, or if any field inside the report object is
 # undefined, OPA returns {} — the playbook stores a silently empty result

--- a/benchmarks/cis/amazon_linux_2023/cis_amazon_linux_2023_main.rego
+++ b/benchmarks/cis/amazon_linux_2023/cis_amazon_linux_2023_main.rego
@@ -1,8 +1,8 @@
 package cis_amazon_linux_2023.main
 
 # Bridge: expose cis_amazon_linux_2023 under the /v1/data/<framework>/main/compliance_report
-# convention consumed by the Generic Framework Assessment playbook
-# (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
+# entrypoint convention, so a caller can evaluate this framework by key
+# without knowing its internal package layout.
 #
 # Two deliberate choices here:
 #

--- a/benchmarks/cis/debian_11/cis_debian_11_main.rego
+++ b/benchmarks/cis/debian_11/cis_debian_11_main.rego
@@ -1,8 +1,8 @@
 package cis_debian_11.main
 
 # Bridge: expose cis_debian_11 under the /v1/data/<framework>/main/compliance_report
-# convention consumed by the Generic Framework Assessment playbook
-# (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
+# entrypoint convention, so a caller can evaluate this framework by key
+# without knowing its internal package layout.
 #
 # Two deliberate choices here:
 #

--- a/benchmarks/cis/network_devices/pfsense/cis_pfsense.rego
+++ b/benchmarks/cis/network_devices/pfsense/cis_pfsense.rego
@@ -13,7 +13,7 @@ package cis_pfsense
 #   input.version             — pfSense/OPNsense version string
 #   input.platform            — "pfsense" or "opnsense"
 #
-# OPA endpoint: POST http://192.168.4.62:8181/v1/data/cis_pfsense/compliance_assessment
+# OPA endpoint: POST http://localhost:8181/v1/data/cis_pfsense/compliance_assessment
 
 import rego.v1
 

--- a/benchmarks/cis/network_devices/pfsense/cis_pfsense_main.rego
+++ b/benchmarks/cis/network_devices/pfsense/cis_pfsense_main.rego
@@ -1,8 +1,8 @@
 package cis_pfsense.main
 
 # Bridge: expose cis_pfsense under the /v1/data/<framework>/main/compliance_report
-# convention consumed by the Generic Framework Assessment playbook
-# (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
+# entrypoint convention, so a caller can evaluate this framework by key
+# without knowing its internal package layout.
 #
 # Two deliberate choices here:
 #

--- a/benchmarks/cis/network_devices/vyos/cis_vyos.rego
+++ b/benchmarks/cis/network_devices/vyos/cis_vyos.rego
@@ -13,7 +13,7 @@ package cis_vyos
 #   input.version     — VyOS version string  e.g. "VyOS 1.4.0"
 #   input.platform    — "vyos"
 #
-# OPA endpoint: POST http://192.168.4.62:8181/v1/data/cis_vyos/compliance_assessment
+# OPA endpoint: POST http://localhost:8181/v1/data/cis_vyos/compliance_assessment
 
 import rego.v1
 

--- a/benchmarks/cis/network_devices/vyos/cis_vyos_main.rego
+++ b/benchmarks/cis/network_devices/vyos/cis_vyos_main.rego
@@ -1,8 +1,8 @@
 package cis_vyos.main
 
 # Bridge: expose cis_vyos under the /v1/data/<framework>/main/compliance_report
-# convention consumed by the Generic Framework Assessment playbook
-# (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
+# entrypoint convention, so a caller can evaluate this framework by key
+# without knowing its internal package layout.
 #
 # Two deliberate choices here:
 #

--- a/benchmarks/cis/rhel_8/cis_rhel8_main.rego
+++ b/benchmarks/cis/rhel_8/cis_rhel8_main.rego
@@ -1,8 +1,8 @@
 package cis_rhel8.main
 
 # Bridge: expose cis_rhel8 under the /v1/data/<framework>/main/compliance_report
-# convention consumed by the Generic Framework Assessment playbook
-# (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
+# entrypoint convention, so a caller can evaluate this framework by key
+# without knowing its internal package layout.
 #
 # Two deliberate choices here:
 #

--- a/benchmarks/cis/rhel_9/cis_rhel9_main.rego
+++ b/benchmarks/cis/rhel_9/cis_rhel9_main.rego
@@ -1,8 +1,8 @@
 package cis_rhel9.main
 
 # Bridge: expose cis_rhel9 under the /v1/data/<framework>/main/compliance_report
-# convention consumed by the Generic Framework Assessment playbook
-# (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
+# entrypoint convention, so a caller can evaluate this framework by key
+# without knowing its internal package layout.
 #
 # Two deliberate choices here:
 #

--- a/benchmarks/cis/rocky_linux_8/cis_rocky_linux_8_main.rego
+++ b/benchmarks/cis/rocky_linux_8/cis_rocky_linux_8_main.rego
@@ -1,8 +1,8 @@
 package cis_rocky_linux_8.main
 
 # Bridge: expose cis_rocky_linux_8 under the /v1/data/<framework>/main/compliance_report
-# convention consumed by the Generic Framework Assessment playbook
-# (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
+# entrypoint convention, so a caller can evaluate this framework by key
+# without knowing its internal package layout.
 #
 # Two deliberate choices here:
 #

--- a/benchmarks/cis/rocky_linux_9/cis_rocky_linux_9_main.rego
+++ b/benchmarks/cis/rocky_linux_9/cis_rocky_linux_9_main.rego
@@ -1,8 +1,8 @@
 package cis_rocky_linux_9.main
 
 # Bridge: expose cis_rocky_linux_9 under the /v1/data/<framework>/main/compliance_report
-# convention consumed by the Generic Framework Assessment playbook
-# (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
+# entrypoint convention, so a caller can evaluate this framework by key
+# without knowing its internal package layout.
 #
 # Two deliberate choices here:
 #

--- a/benchmarks/cis/ubuntu_20_04/cis_ubuntu_2004_main.rego
+++ b/benchmarks/cis/ubuntu_20_04/cis_ubuntu_2004_main.rego
@@ -1,8 +1,8 @@
 package cis_ubuntu_2004.main
 
 # Bridge: expose cis_ubuntu_20_04 under the /v1/data/<framework>/main/compliance_report
-# convention consumed by the Generic Framework Assessment playbook
-# (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
+# entrypoint convention, so a caller can evaluate this framework by key
+# without knowing its internal package layout.
 #
 # Two deliberate choices here:
 #

--- a/benchmarks/cis/ubuntu_22_04/cis_ubuntu_2204_main.rego
+++ b/benchmarks/cis/ubuntu_22_04/cis_ubuntu_2204_main.rego
@@ -1,8 +1,8 @@
 package cis_ubuntu_2204.main
 
 # Bridge: expose cis_ubuntu_22_04 under the /v1/data/<framework>/main/compliance_report
-# convention consumed by the Generic Framework Assessment playbook
-# (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
+# entrypoint convention, so a caller can evaluate this framework by key
+# without knowing its internal package layout.
 #
 # Two deliberate choices here:
 #

--- a/benchmarks/cis/ubuntu_24_04/cis_ubuntu_2404_main.rego
+++ b/benchmarks/cis/ubuntu_24_04/cis_ubuntu_2404_main.rego
@@ -1,8 +1,8 @@
 package cis_ubuntu_2404.main
 
 # Bridge: expose cis_ubuntu_24_04 under the /v1/data/<framework>/main/compliance_report
-# convention consumed by the Generic Framework Assessment playbook
-# (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
+# entrypoint convention, so a caller can evaluate this framework by key
+# without knowing its internal package layout.
 #
 # Two deliberate choices here:
 #

--- a/benchmarks/cis/windows_server_2019_modular/cis_windows_2019_main.rego
+++ b/benchmarks/cis/windows_server_2019_modular/cis_windows_2019_main.rego
@@ -1,8 +1,8 @@
 package cis_windows_2019.main
 
 # Bridge: expose cis_windows_server_2019 under the /v1/data/<framework>/main/compliance_report
-# convention consumed by the Generic Framework Assessment playbook
-# (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
+# entrypoint convention, so a caller can evaluate this framework by key
+# without knowing its internal package layout.
 #
 # Two deliberate choices here:
 #

--- a/benchmarks/cis/windows_server_2022_modular/cis_windows_2022_main.rego
+++ b/benchmarks/cis/windows_server_2022_modular/cis_windows_2022_main.rego
@@ -1,8 +1,8 @@
 package cis_windows_2022.main
 
 # Bridge: expose cis_windows_server_2022 under the /v1/data/<framework>/main/compliance_report
-# convention consumed by the Generic Framework Assessment playbook
-# (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
+# entrypoint convention, so a caller can evaluate this framework by key
+# without knowing its internal package layout.
 #
 # Two deliberate choices here:
 #

--- a/benchmarks/stig/kubernetes/stig_kubernetes_main.rego
+++ b/benchmarks/stig/kubernetes/stig_kubernetes_main.rego
@@ -1,5 +1,5 @@
 # Wrapper exposing the Kubernetes STIG compliance report at the package path
-# expected by AAC's generic_framework_assessment.yml convention:
+# of the conventional framework-key entrypoint:
 #
 #   /v1/data/stig_kubernetes/main/compliance_report
 #

--- a/benchmarks/stig/openshift_4/stig_openshift_4_main.rego
+++ b/benchmarks/stig/openshift_4/stig_openshift_4_main.rego
@@ -1,5 +1,5 @@
 # Wrapper exposing the OpenShift 4 STIG compliance report at the package path
-# expected by AAC's generic_framework_assessment.yml convention:
+# of the conventional framework-key entrypoint:
 #
 #   /v1/data/stig_openshift_4/main/compliance_report
 #

--- a/benchmarks/stig/rhel_8/stig_rhel8_complete.rego
+++ b/benchmarks/stig/rhel_8/stig_rhel8_complete.rego
@@ -2,7 +2,7 @@ package stig.rhel_8
 
 # DISA STIG for RHEL 8 - Master Aggregator
 # STIG Version: V1R13 | Released: July 2024
-# Endpoint: POST http://192.168.4.62:8181/v1/data/stig/rhel_8/stig_assessment
+# Endpoint: POST http://localhost:8181/v1/data/stig/rhel_8/stig_assessment
 
 import rego.v1
 

--- a/benchmarks/stig/rhel_9/stig_rhel9_complete.rego
+++ b/benchmarks/stig/rhel_9/stig_rhel9_complete.rego
@@ -5,7 +5,7 @@ package stig.rhel_9
 # Aggregates all modules: configuration_management, services, software_integrity,
 #   file_permissions, audit_logging, ssh_config, account_auth, network, pki_crypto
 #
-# Endpoint: POST http://192.168.4.62:8181/v1/data/stig/rhel_9/stig_assessment
+# Endpoint: POST http://localhost:8181/v1/data/stig/rhel_9/stig_assessment
 
 import rego.v1
 

--- a/enforcement/README.md
+++ b/enforcement/README.md
@@ -62,7 +62,7 @@ POST http://<host>:8182/v1/data/sentinel/ansible/result
 ```bash
 # Convert playbook to JSON, then evaluate
 python3 -c "import sys,yaml,json; print(json.dumps({'input': {'environment':'production','plays': yaml.safe_load(open('site.yml'))}}))" \
-  | curl -s -X POST http://192.168.4.62:8182/v1/data/sentinel/ansible/result \
+  | curl -s -X POST http://localhost:8181/v1/data/sentinel/ansible/result \
          -H 'Content-Type: application/json' -d @- | jq '.result'
 ```
 
@@ -124,7 +124,7 @@ Evaluates a Terraform plan JSON for policy violations before `apply`.
 ```bash
 terraform plan -out=tfplan.bin && terraform show -json tfplan.bin \
   | jq '{input: {environment: "production", plan: .}}' \
-  | curl -s -X POST http://192.168.4.62:8182/v1/data/sentinel/terraform/result \
+  | curl -s -X POST http://localhost:8181/v1/data/sentinel/terraform/result \
          -H 'Content-Type: application/json' -d @- | jq '.result'
 ```
 

--- a/enforcement/ansible/sentinel_ansible.rego
+++ b/enforcement/ansible/sentinel_ansible.rego
@@ -4,7 +4,7 @@ import rego.v1
 
 # Sentinel-equivalent policy for Ansible playbooks
 # Playbook YAML is converted to JSON before evaluation (via `from_yaml | to_json`)
-# OPA endpoint: POST http://192.168.4.62:8182/v1/data/sentinel/ansible/result
+# OPA endpoint: POST http://localhost:8181/v1/data/sentinel/ansible/result
 #
 # Input shape:
 #   input.plays[].name          — play name (required)

--- a/enforcement/cicd/cicd_pipeline.rego
+++ b/enforcement/cicd/cicd_pipeline.rego
@@ -15,7 +15,7 @@ package cicd.pipeline
 #   - Container images pinned to digest in prod
 #   - Self-hosted runner governance
 #
-# OPA endpoint: POST http://192.168.4.62:8182/v1/data/cicd/pipeline
+# OPA endpoint: POST http://localhost:8181/v1/data/cicd/pipeline
 # Input: parsed pipeline configuration (GitHub Actions workflow JSON or equivalent)
 
 import rego.v1

--- a/enforcement/kubernetes/kubernetes_admission.rego
+++ b/enforcement/kubernetes/kubernetes_admission.rego
@@ -21,7 +21,7 @@ package kubernetes.admission
 #   - No NodePort services in production
 #   - Egress NetworkPolicy required per namespace
 #
-# OPA endpoint: POST http://192.168.4.62:8182/v1/data/kubernetes/admission
+# OPA endpoint: POST http://localhost:8181/v1/data/kubernetes/admission
 # Input: Kubernetes admission review request (AdmissionReview v1)
 
 import rego.v1

--- a/enforcement/supply_chain/slsa_governance.rego
+++ b/enforcement/supply_chain/slsa_governance.rego
@@ -13,7 +13,7 @@ package supply_chain.slsa
 # Also covers: SBOM completeness, dependency hygiene, license compliance,
 # artifact signing (Sigstore/Cosign), and CVE policy enforcement.
 #
-# OPA endpoint: POST http://192.168.4.62:8182/v1/data/supply_chain/slsa
+# OPA endpoint: POST http://localhost:8181/v1/data/supply_chain/slsa
 # Input: artifact metadata, provenance attestation, SBOM, build environment facts
 
 import rego.v1

--- a/enforcement/terraform/sentinel_terraform.rego
+++ b/enforcement/terraform/sentinel_terraform.rego
@@ -4,7 +4,7 @@ import rego.v1
 
 # Sentinel-equivalent policy for Terraform plans
 # Evaluated against `terraform show -json tfplan.bin` output
-# OPA endpoint: POST http://192.168.4.62:8182/v1/data/sentinel/terraform/result
+# OPA endpoint: POST http://localhost:8181/v1/data/sentinel/terraform/result
 #
 # Input shape (subset of Terraform plan JSON):
 #   input.resource_changes[].address        — "aws_instance.web"

--- a/frameworks/compliance/ncsc_caf/caf_main.rego
+++ b/frameworks/compliance/ncsc_caf/caf_main.rego
@@ -26,7 +26,7 @@ import data.ncsc_caf.d1_response_recovery
 #   C1 (Monitoring):        C1.d, C1.f
 #   D1 (Response):          D1.a, D1.b, D1.c
 #
-# OPA endpoint: POST http://192.168.4.62:8182/v1/data/ncsc_caf/main/compliance_report
+# OPA endpoint: POST http://localhost:8181/v1/data/ncsc_caf/main/compliance_report
 #
 # Three-tier scoring per CO: "achieved" | "partially_achieved" | "not_achieved"
 # Overall compliant: all assessed COs must be "achieved"

--- a/frameworks/critical_infrastructure/iec_62443/iec_62443_main.rego
+++ b/frameworks/critical_infrastructure/iec_62443/iec_62443_main.rego
@@ -30,7 +30,7 @@ import rego.v1
 #   SL 3 — Protection against sophisticated attacks (nation-state capable actors)
 #   SL 4 — Protection against state-sponsored, highly motivated, well-resourced attacks
 #
-# OPA Endpoint: POST http://192.168.4.62:8183/v1/data/iec_62443_main
+# OPA Endpoint: POST http://localhost:8181/v1/data/iec_62443_main
 # =============================================================================
 
 import data.iec_62443.fr1

--- a/frameworks/critical_infrastructure/tsa_pipeline/sd01_cybersecurity_coordinator.rego
+++ b/frameworks/critical_infrastructure/tsa_pipeline/sd01_cybersecurity_coordinator.rego
@@ -47,7 +47,7 @@ import rego.v1
 #   "law_enforcement_liaison_established":     boolean
 # }
 #
-# NO FACT SOURCE EXISTS YET. Nothing in the compliance repo emits
+# NO PUBLISHED FACT SOURCE EXISTS YET. Nothing in this library emits
 # input.cybersecurity_coordinator — these are attestation/document facts, not
 # host facts. Absent input this module reports fully non-compliant, which is
 # the correct fail-closed behavior for an audit framework. Do not present it as

--- a/frameworks/critical_infrastructure/tsa_pipeline/tsa_pipeline_main.rego
+++ b/frameworks/critical_infrastructure/tsa_pipeline/tsa_pipeline_main.rego
@@ -35,7 +35,7 @@ import rego.v1
 # OPA bucket: ot  (opa_framework_map key: tsa_pipeline)
 #
 # --- FACT SOURCE STATUS ------------------------------------------------------
-# NOTHING IN THE COMPLIANCE REPO EMITS THIS INPUT TODAY. Both directives are
+# NO FACT COLLECTOR SHIPS WITH THIS LIBRARY FOR THIS FRAMEWORK. Both directives are
 # overwhelmingly plan-, attestation-, and recordkeeping-driven: "is there a
 # TSA-approved Cybersecurity Implementation Plan", "was the Assessment Plan
 # submitted within 12 months", "were at least one-third of measures assessed

--- a/governance/finops/finops_tagging.rego
+++ b/governance/finops/finops_tagging.rego
@@ -13,7 +13,7 @@ package finops.tagging
 #   - Budget threshold tags
 #   - Orphaned/untagged resource detection
 #
-# OPA endpoint: POST http://192.168.4.62:8182/v1/data/finops/tagging
+# OPA endpoint: POST http://localhost:8181/v1/data/finops/tagging
 # Input: cloud resource inventory (from Ansible facts, AWS Config, Azure Policy, GCP Asset API)
 
 import rego.v1

--- a/governance/oidc/oidc_token_validation.rego
+++ b/governance/oidc/oidc_token_validation.rego
@@ -15,7 +15,7 @@ import rego.v1
 #   input.resource.hostname  — target host
 #
 # OPA evaluation:
-#   POST http://192.168.4.62:8182/v1/data/governance/oidc
+#   POST http://localhost:8181/v1/data/governance/oidc
 #   { "input": { "token": { "claims": {...} }, "resource": {...} } }
 
 # ── Role definitions ──────────────────────────────────────────────────────────


### PR DESCRIPTION
This library ships Apache-2.0 with a public OCI bundle and should be consumable by anyone running **OPA or EOPA**, with no knowledge of any particular consumer. Two things broke that.

## 1. A private lab IP was published in 14 shipped files

`192.168.4.62` appeared in **15 places** across policy headers and `enforcement/README.md`:

```
# OPA endpoint: POST http://192.168.4.62:8182/v1/data/sentinel/ansible/result
```

That's a private RFC1918 address for one specific lab host — meaningless to every other consumer, and forbidden by this repo's own `CLAUDE.md:208`:

> **No lab IPs in policies or tests** — they must never appear in Rego sample inputs, test fixtures, README examples.

All now use `http://localhost:8181`, matching the README quick start so the examples actually run from a clone. This also retires the `8181/8182/8183` split baked into those URLs — that was one deployment's three-container topology, not a property of the policies.

## 2. Comments pointed at another repo's internals

```
# convention consumed by the Generic Framework Assessment playbook
# (compliance repo, ansible/playbooks/generic_framework_assessment.yml).
# Every key registered in opa_framework_map (compliance repo,
# ansible/vars/site_config.yml) is queried by the playbook as ...
```

Rewritten to describe the convention on its own terms: a stable, key-addressable entrypoint at `/v1/data/<key>/main/compliance_report` letting a caller evaluate a framework without knowing its package layout. The convention is worth keeping — naming someone else's playbook is not.

**No rule logic changed.** 32 files, 48 lines, comments and URLs only. `opa test . --ignore .github` → **348/348**.

## Deliberately not in this PR

- **The `<key>.main` bridge modules themselves.** These are consumer glue and belong in the consuming repo. That's a two-repo move being scoped separately — and the boundary is subtler than it looks: `cis_rhel9.main` and `stig_kubernetes.main` are pure routing aliases over a canonical package, but `nist_800_82.main` and `tsa_pipeline.main` *are* the policy. Moving the wrong ones would gut the library.
- **Behavioural coupling in `governance/mcp/mcp_governance.rego`**, which hardcodes `startswith(name, "AAC")` in rule logic rather than taking the prefix as data. That one changes policy behaviour, so it needs its own change and its own tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)