### PR TITLE
feat(cis/saas): CIS Microsoft 365 Foundations Benchmark v7.0.0

### DIFF
--- a/.github/workflows/opa-test.yml
+++ b/.github/workflows/opa-test.yml
@@ -6,10 +6,15 @@ on:
     paths:
       - '**/*.rego'
       - '.github/workflows/opa-test.yml'
+      - 'scripts/check_cis_ids.py'
+      - '**/data/cis_*_index.json'
   pull_request:
     branches: [main]
     paths:
       - '**/*.rego'
+      - '.github/workflows/opa-test.yml'
+      - 'scripts/check_cis_ids.py'
+      - '**/data/cis_*_index.json'
 
 permissions:
   contents: read
@@ -79,15 +84,64 @@ jobs:
 
       - name: Run policy tests
         run: |
+          # Load the WHOLE repo in one run, per CLAUDE.md. Two reasons this
+          # is not a per-directory loop:
+          #
+          #  1. The previous loop globbed only '*_test.rego', which matched
+          #     1 of 84 test files. The other 83 use the repo's documented
+          #     'test_*.rego' convention and never executed in CI at all.
+          #  2. Tests can span trees -- frameworks/compliance/cra imports
+          #     enforcement/supply_chain/slsa_governance.rego -- so testing a
+          #     directory in isolation reports false failures.
+          #
+          # --ignore .github because opa otherwise tries to parse the YAML
+          # in the .github directory that lives inside the benchmarks tree.
           echo "Running tests ..."
-          RC=0
-          for f in $(find . -name "*_test.rego" -not -path "./.git/*"); do
-            dir=$(dirname "$f")
-            echo "  Testing $dir ..."
-            opa test "$dir" -v || RC=1
-          done
-          echo "Tests complete"
-          exit $RC
+          opa test . --ignore .github
+
+      - name: Guard against silent test-discovery loss
+        run: |
+          # A drop in test count means tests stopped being discovered, which
+          # looks identical to "all tests pass". Fail loudly instead.
+          #
+          # This is a discovery-collapse tripwire, NOT an exact expected
+          # count. The floor is the pre-existing suite size (348) rather
+          # than the current total, so that a branch which does not carry
+          # this tree's tests still passes. Ratchet it upward deliberately.
+          MIN_TESTS=348
+          count=$(opa test . --ignore .github 2>&1 | grep -oE 'PASS: [0-9]+' | grep -oE '[0-9]+')
+          echo "tests run: ${count:-0} (floor: $MIN_TESTS)"
+          if [ "${count:-0}" -lt "$MIN_TESTS" ]; then
+            echo "ERROR: expected at least $MIN_TESTS tests, ran ${count:-0}."
+            echo "Either tests were deleted, or discovery regressed."
+            exit 1
+          fi
+
+      - name: Verify CIS control ids against the benchmark enumeration
+        run: |
+          # Unit tests cannot catch a violation message that cites the wrong
+          # CIS control number -- they assert against the same wrong number.
+          # This checks every cited id against the benchmark's own
+          # enumeration, and that the message corresponds to the control
+          # that id actually names.
+          python3 scripts/check_cis_ids.py \
+            --enumeration benchmarks/cis/saas/m365_v7/data/cis_m365_v7_index.json \
+            --policy-dir benchmarks/cis/saas/m365_v7
+
+      - name: Assert the guard still rejects the deprecated m365 tree
+        run: |
+          # benchmarks/cis/saas/m365/ is deprecated precisely because its
+          # control ids do not match the benchmark. If this ever starts
+          # passing, either the tree was fixed (and should be un-deprecated)
+          # or the guard stopped working. Both need a human.
+          if python3 scripts/check_cis_ids.py \
+               --enumeration benchmarks/cis/saas/m365_v7/data/cis_m365_v7_index.json \
+               --policy-dir benchmarks/cis/saas/m365 > /dev/null 2>&1; then
+            echo "ERROR: the guard passed on the deprecated m365/ tree."
+            echo "Expected failure -- its ids do not match the benchmark."
+            exit 1
+          fi
+          echo "OK: guard correctly rejects the deprecated m365/ tree"
 
       - name: Count policies
         run: |

--- a/benchmarks/cis/saas/README.md
+++ b/benchmarks/cis/saas/README.md
@@ -8,7 +8,8 @@ than per-host facts.
 
 | Subdirectory | Benchmark | Vendor admin API |
 |---|---|---|
-| [`m365/`](m365/) | CIS Microsoft 365 Foundations Benchmark v3.1.0 | Microsoft Graph |
+| [`m365_v7/`](m365_v7/) | CIS Microsoft 365 Foundations Benchmark **v7.0.0** | Microsoft Graph |
+| [`m365/`](m365/) | v3.1.0 — **DEPRECATED**, control ids do not match the benchmark | Microsoft Graph |
 
 Companion fact-gathering Ansible modules live in the **AAC
 compliance repo** at `collections/ansible_collections/aac/<vendor>/`.

--- a/benchmarks/cis/saas/m365/README.md
+++ b/benchmarks/cis/saas/m365/README.md
@@ -1,3 +1,23 @@
+> ## ⚠️ DEPRECATED — DO NOT USE FOR NEW ASSESSMENTS
+>
+> **The control numbers in this directory do not correspond to any CIS
+> benchmark.** Measured 2026-08-14 against the CIS Microsoft 365
+> Foundations Benchmark v7.0.0: of 46 control-id citations, **20 name ids
+> that do not exist** and **22 name real ids whose requirement is unrelated
+> to the message**. Only 3 distinct ids of 40 are correct.
+>
+> The section topology assumed here (7 sections) is wrong; the benchmark
+> has **9**. Entra is section 5 (not 1), Exchange 6 (not 4), SharePoint 7
+> (not 6), Teams 8 (not 7), Fabric 9 (not 5). Sub-numbering is
+> independently wrong even where the section number happens to match.
+>
+> The 36/36 passing unit tests do not contradict this — they assert
+> against the same invented numbers.
+>
+> **Use [`../m365_v7/`](../m365_v7/) instead.** This directory is retained
+> only because repo convention treats a benchmark version as immutable.
+> `scripts/check_cis_ids.py` fails against this tree by design.
+
 # CIS Microsoft 365 Foundations Benchmark — Rego Library
 
 Policies evaluating a Microsoft 365 tenant's compliance against the

--- a/benchmarks/cis/saas/m365_v7/COVERAGE.md
+++ b/benchmarks/cis/saas/m365_v7/COVERAGE.md
@@ -1,0 +1,82 @@
+# CIS Microsoft 365 Foundations Benchmark v7.0.0 — coverage
+
+**Version:** v1.0
+**Benchmark:** CIS Microsoft 365 Foundations Benchmark **v7.0.0**, released 2026-05-20
+**Evaluated:** **14 of 160** recommendations (**9%**)
+
+This file exists because a partial assessment that does not say it is
+partial reads as a clean bill of health. Everything below is measured, not
+estimated: the control count comes from the benchmark's own enumeration
+(`data/cis_m365_v7_index.json`), and the evaluated ids come from the
+modules themselves.
+
+## Per-section coverage
+
+| § | Section | Controls | Evaluated | Module |
+|---|---|---|---|---|
+| 1 | Microsoft 365 admin center | 15 | 1 | `admin_center_validation.rego` |
+| 2 | Microsoft Defender | 21 | 3 | `defender_validation.rego` |
+| 3 | Microsoft Purview | 5 | 1 | `purview_validation.rego` |
+| 4 | Microsoft Intune admin center | 2 | **0** | — |
+| 5 | Microsoft Entra admin center | 63 | 4 | `entra_validation.rego` |
+| 6 | Exchange admin center | 13 | 1 | `exchange_validation.rego` |
+| 7 | SharePoint admin center | 12 | 4 | `sharepoint_validation.rego` |
+| 8 | Microsoft Teams admin center | 17 | **0** | — |
+| 9 | Microsoft Fabric | 12 | **0** | — |
+| | **Total** | **160** | **14** | |
+
+Evaluated ids: `1.1.3`, `2.1.8`, `2.1.9`, `2.1.10`, `3.1.1`, `5.2.2.1`,
+`5.2.2.2`, `5.2.2.3`, `5.3.1`, `6.1.1`, `7.2.1`, `7.2.6`, `7.2.7`, `7.2.11`.
+
+## Why coverage is 9%
+
+Coverage is bounded by **fact collection**, not by policy. The `aac.m365`
+collection currently issues ten Microsoft Graph calls. Four of its seven
+modules return only **Microsoft Secure Score**, which is Microsoft's own
+scoring model with its own control set — it is not the CIS benchmark, and
+a Secure Score `implementationStatus` does not establish a CIS
+recommendation. Those were not carried into v7.
+
+| Section | Blocker |
+|---|---|
+| 4 — Intune | No collector. Needs Graph `deviceManagement/*` and an additional application permission on the app registration. |
+| 8 — Teams | Collector returns a Teams app count and Secure Score. Real coverage needs Teams PowerShell or Graph beta. |
+| 9 — Fabric | Collector returns Secure Score. Fabric tenant settings are only exposed by the Fabric Admin REST API, not Graph. |
+| 2 — Defender (18 of 21) | Safe Links, Safe Attachments, anti-phishing, anti-spam and connection filtering need Exchange Online PowerShell. |
+| 5 — Entra (59 of 63) | Most section 5 controls need Graph endpoints the collector does not call yet; several are only on `/beta`, and `graph.py` pins `GRAPH_BASE` to `/v1.0`. |
+| 6 — Exchange (12 of 13) | Transport rules and mail-flow controls need Exchange Online PowerShell. |
+
+## Evidence-strength caveat
+
+**`6.1.1` is a proxy, not a direct measurement.** Graph v1.0 does not
+expose the tenant-wide `AuditDisabled` organization flag, so the collector
+samples per-user `mailboxSettings` instead. It can demonstrate that
+auditing is off for sampled mailboxes; it cannot prove the organization
+flag is `False`. The benchmark's own audit procedure uses Exchange Online
+PowerShell. This is surfaced at runtime in the section 6 report under
+`evidence_strength` so a reader cannot miss it.
+
+## What is deliberately absent
+
+- **No tenant-wide `compliant` boolean.** The orchestrator exposes
+  `assessed_controls_compliant`, which is scoped to `evaluated_control_ids`
+  only. A 14-of-160 assessment has no business emitting a benchmark verdict.
+- **Fail-closed everywhere.** Missing facts produce a violation stating the
+  control could not be evaluated. Absent facts never read as a pass.
+
+## Controls dropped from the pre-v7 library
+
+`Security Defaults` has **no counterpart in v7.0.0**. The nearest control,
+`5.1.2.1` (*Per-user MFA*), is a different requirement and is not
+established by the facts collected. The check was **removed rather than
+renumbered** — inventing a plausible id is the exact defect this rewrite
+exists to correct.
+
+## Relationship to `benchmarks/cis/saas/m365/`
+
+The older directory targets v3.1.0 and its control numbering does not
+correspond to any CIS benchmark: of 46 citations, 20 name ids that do not
+exist and 22 name real ids whose requirement is unrelated to the message.
+It is retained per repo convention (a new benchmark version is a new
+directory, never a mutation) but **must not be used for new assessments**.
+`scripts/check_cis_ids.py` fails against it by design.

--- a/benchmarks/cis/saas/m365_v7/README.md
+++ b/benchmarks/cis/saas/m365_v7/README.md
@@ -1,0 +1,102 @@
+# CIS Microsoft 365 Foundations Benchmark v7.0.0 — Rego Library
+
+**Version:** v1.0
+**Benchmark:** CIS Microsoft 365 Foundations Benchmark **v7.0.0** (released 2026-05-20)
+**Coverage:** 14 of 160 recommendations — see [COVERAGE.md](COVERAGE.md)
+
+## Sections
+
+The benchmark defines **nine** sections. Getting this topology right
+matters: the pre-v7 library assumed seven and renumbered them, which is
+why its control ids named different requirements than the checks they
+labelled.
+
+| § | Section | Package | Module |
+|---|---|---|---|
+| 1 | Microsoft 365 admin center | `cis_m365_v7.admin_center` | `admin_center_validation.rego` |
+| 2 | Microsoft Defender | `cis_m365_v7.defender` | `defender_validation.rego` |
+| 3 | Microsoft Purview | `cis_m365_v7.purview` | `purview_validation.rego` |
+| 4 | Microsoft Intune admin center | — | not evaluated |
+| 5 | Microsoft Entra admin center | `cis_m365_v7.entra` | `entra_validation.rego` |
+| 6 | Exchange admin center | `cis_m365_v7.exchange` | `exchange_validation.rego` |
+| 7 | SharePoint admin center | `cis_m365_v7.sharepoint` | `sharepoint_validation.rego` |
+| 8 | Microsoft Teams admin center | — | not evaluated |
+| 9 | Microsoft Fabric | — | not evaluated |
+
+Note that **SPF, DKIM and DMARC are section 2 (Defender)** controls in
+v7.0.0, not Exchange controls.
+
+## Query paths
+
+```
+/v1/data/cis_m365_v7/main/compliance_report        # orchestrator (start here)
+/v1/data/cis_m365_v7/<package>/compliance_report   # a single section
+```
+
+The orchestrator reports `assessed_controls_compliant`, **not** a bare
+`compliant`. That is deliberate — see COVERAGE.md.
+
+## The control-id guard
+
+Unit tests cannot catch a violation message that cites the wrong CIS
+control number, because the tests assert against the same wrong number.
+The guard checks citations against the benchmark's own enumeration:
+
+```bash
+python3 scripts/check_cis_ids.py \
+  --enumeration benchmarks/cis/saas/m365_v7/data/cis_m365_v7_index.json \
+  --policy-dir  benchmarks/cis/saas/m365_v7
+```
+
+It applies two checks:
+
+1. **Existence** — every cited id must appear in the benchmark.
+2. **Coherence** — the message must share a substantive word with the
+   benchmark's own title for that id. This is the check that catches
+   `"CIS 1.1.1: Security Defaults..."` when `1.1.1` is actually
+   *"Ensure Administrative accounts are cloud-only"*.
+
+It runs in CI on every PR touching this tree.
+
+### `data/cis_m365_v7_index.json`
+
+The enumeration ships as a **keyword digest**: control ids, section names,
+assessment status, profile levels, and a sorted set of substantive words
+from each title. It deliberately carries **no verbatim CIS recommendation
+titles** — CIS terms of use require contacting CIS Legal before
+reproducing portions of a benchmark, and this repository is public and
+Apache-2.0. The digest is derived data and is all the coherence check
+needs.
+
+Regenerate it from a local copy of the PDF (the PDF itself is not
+redistributable and is not vendored here):
+
+```bash
+pdftotext -layout CIS_Microsoft_365_Foundations_Benchmark_v7.0.0.pdf m365_v7.txt
+python3 parse_m365_v7.py m365_v7.txt
+```
+
+## Input contract
+
+Facts come from the `aac.m365` Ansible collection in the AAC compliance
+repo, which reads Microsoft Graph. Each module documents its expected
+input shape in its header comment. The Rego does not care how the state
+was obtained, only that the shape matches.
+
+Every module is **fail-closed**: absent facts produce a violation saying
+the control could not be evaluated. A missing fact never reads as a pass.
+
+## Tests
+
+```bash
+opa test benchmarks/cis/saas/m365_v7/ benchmarks/cis/saas/m365_v7/tests/ -v
+```
+
+31 tests covering each control's violation path, its passing path, the
+fail-closed path, and the orchestrator's coverage accounting.
+
+## Relationship to `../m365/`
+
+`../m365/` targets v3.1.0 and its numbering does not correspond to any CIS
+benchmark. It is retained because repo convention treats a new benchmark
+version as a new directory, but it must not be used for new assessments.

--- a/benchmarks/cis/saas/m365_v7/admin_center_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/admin_center_validation.rego
@@ -1,0 +1,67 @@
+# CIS Microsoft 365 Foundations Benchmark v7.0.0
+# Section 1 -- Microsoft 365 admin center
+#
+# Every control id cited below is verified against the benchmark by
+# scripts/check_cis_ids.py, which fails CI if an id does not exist or if
+# the message does not correspond to the control that id names.
+#
+# Input contract (from the aac.m365 collection):
+#   input.identity.global_admins[]  - {id, display_name, user_principal_name,
+#                                      mfa_methods[], has_strong_mfa}
+#   input.identity.collected        - bool; false/absent means the collector
+#                                     did not run, which must NOT read as pass
+
+package cis_m365_v7.admin_center
+
+import rego.v1
+
+default compliant := false
+
+default facts_present := false
+
+facts_present if {
+	is_array(input.identity.global_admins)
+}
+
+global_admin_count := count(input.identity.global_admins) if {
+	facts_present
+} else := -1
+
+# CIS 1.1.3 -- the benchmark requires the number of global admins to sit
+# between two and four inclusive.
+violation contains msg if {
+	facts_present
+	global_admin_count < 2
+	msg := sprintf("CIS 1.1.3: only %d global admin(s) designated; fewer than two risks lockout with no second administrator", [global_admin_count])
+}
+
+violation contains msg if {
+	facts_present
+	global_admin_count > 4
+	msg := sprintf("CIS 1.1.3: %d global admins designated; more than four widens standing privilege beyond what the benchmark permits", [global_admin_count])
+}
+
+# Fail closed: absent facts are reported, never silently treated as a pass.
+violation contains msg if {
+	not facts_present
+	msg := "CIS 1.1.3: global admin facts not collected -- control could not be evaluated (this is not a pass)"
+}
+
+compliant if {
+	facts_present
+	count(violation) == 0
+}
+
+compliance_report := {
+	"benchmark": "CIS Microsoft 365 Foundations Benchmark",
+	"benchmark_version": "7.0.0",
+	"section": "1",
+	"name": "Microsoft 365 admin center",
+	"section_total_controls": 15,
+	"controls_evaluated": 1,
+	"controls": ["1.1.3"],
+	"facts_present": facts_present,
+	"violations": violation,
+	"violation_count": count(violation),
+	"compliant": compliant,
+}

--- a/benchmarks/cis/saas/m365_v7/cis_m365_v7_complete.rego
+++ b/benchmarks/cis/saas/m365_v7/cis_m365_v7_complete.rego
@@ -1,0 +1,96 @@
+# CIS Microsoft 365 Foundations Benchmark v7.0.0 -- master orchestrator
+#
+# Aggregates the per-section reports and, just as importantly, states what
+# is NOT evaluated. The benchmark defines 160 recommendations across nine
+# sections; this library evaluates 14 of them. A caller that reads only
+# `compliant` from a partial assessment would draw a false conclusion, so
+# this report deliberately does not expose a bare tenant-wide `compliant`
+# boolean. It exposes `assessed_controls_compliant` -- true only of the
+# controls actually evaluated -- alongside the coverage that qualifies it.
+#
+# OPA query path: /v1/data/cis_m365_v7/main/compliance_report
+
+package cis_m365_v7.main
+
+import data.cis_m365_v7.admin_center
+import data.cis_m365_v7.defender
+import data.cis_m365_v7.entra
+import data.cis_m365_v7.exchange
+import data.cis_m365_v7.purview
+import data.cis_m365_v7.sharepoint
+import rego.v1
+
+BENCHMARK_TOTAL_CONTROLS := 160
+
+# Sections with no fact collector at all. Declared explicitly so that a
+# reader (or an auditor) sees the gap rather than inferring coverage from
+# the absence of violations.
+not_evaluated := [
+	{
+		"section": "4",
+		"name": "Microsoft Intune admin center",
+		"section_total_controls": 2,
+		"reason": "no collector; Intune controls require Graph deviceManagement/* and an additional application permission scope",
+	},
+	{
+		"section": "8",
+		"name": "Microsoft Teams admin center",
+		"section_total_controls": 17,
+		"reason": "collector returns only a Teams app count and Microsoft Secure Score; neither establishes a CIS control",
+	},
+	{
+		"section": "9",
+		"name": "Microsoft Fabric",
+		"section_total_controls": 12,
+		"reason": "collector returns only Microsoft Secure Score; Fabric tenant settings require the Fabric Admin REST API, not Graph",
+	},
+]
+
+section_reports := [
+	admin_center.compliance_report,
+	defender.compliance_report,
+	purview.compliance_report,
+	entra.compliance_report,
+	exchange.compliance_report,
+	sharepoint.compliance_report,
+]
+
+# array.concat takes exactly two arrays -- fold rather than vararg.
+all_violations := [v |
+	some r in section_reports
+	some v in r.violations
+]
+
+evaluated_controls := [c |
+	some r in section_reports
+	some c in r.controls
+]
+
+controls_evaluated := count(evaluated_controls)
+
+controls_not_evaluated := BENCHMARK_TOTAL_CONTROLS - controls_evaluated
+
+default assessed_controls_compliant := false
+
+assessed_controls_compliant if {
+	count(all_violations) == 0
+}
+
+compliance_report := {
+	"benchmark": "CIS Microsoft 365 Foundations Benchmark",
+	"benchmark_version": "7.0.0",
+	"benchmark_released": "2026-05-20",
+	"benchmark_total_controls": BENCHMARK_TOTAL_CONTROLS,
+	"controls_evaluated": controls_evaluated,
+	"controls_not_evaluated": controls_not_evaluated,
+	"coverage_percentage": round(controls_evaluated * 100 / BENCHMARK_TOTAL_CONTROLS),
+	"evaluated_control_ids": evaluated_controls,
+	"sections_evaluated": section_reports,
+	"sections_not_evaluated": not_evaluated,
+	"violations": all_violations,
+	"violation_count": count(all_violations),
+	# Scoped deliberately: true means "no violation among the controls that
+	# were evaluated", NOT "the tenant meets the benchmark".
+	"assessed_controls_compliant": assessed_controls_compliant,
+	"interpretation": "This is a partial assessment. assessed_controls_compliant covers only evaluated_control_ids and must not be read as benchmark compliance.",
+}

--- a/benchmarks/cis/saas/m365_v7/data/cis_m365_v7_index.json
+++ b/benchmarks/cis/saas/m365_v7/data/cis_m365_v7_index.json
@@ -1,0 +1,2681 @@
+{
+  "benchmark": "CIS Microsoft 365 Foundations Benchmark",
+  "version": "7.0.0",
+  "released": "2026-05-20",
+  "source": "official CIS PDF (Appendix summary table + Recommendations body)",
+  "sections": {
+    "1": "Microsoft 365 admin center",
+    "2": "Microsoft Defender",
+    "3": "Microsoft Purview",
+    "4": "Microsoft Intune admin center",
+    "5": "Microsoft Entra admin center",
+    "6": "Exchange admin center",
+    "7": "SharePoint admin center",
+    "8": "Microsoft Teams admin center",
+    "9": "Microsoft Fabric"
+  },
+  "total_recommendations": 160,
+  "form": "keyword-digest (no verbatim CIS titles)",
+  "recommendations": [
+    {
+      "control_id": "1.1.1",
+      "section": 1,
+      "section_name": "Microsoft 365 admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "accounts",
+        "administrative",
+        "cloud"
+      ]
+    },
+    {
+      "control_id": "1.1.2",
+      "section": 1,
+      "section_name": "Microsoft 365 admin center",
+      "assessment": "Manual",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "access",
+        "accounts",
+        "defined",
+        "emergency",
+        "two"
+      ]
+    },
+    {
+      "control_id": "1.1.3",
+      "section": 1,
+      "section_name": "Microsoft 365 admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "admins",
+        "between",
+        "designated",
+        "four",
+        "global",
+        "two"
+      ]
+    },
+    {
+      "control_id": "1.1.4",
+      "section": 1,
+      "section_name": "Microsoft 365 admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "accounts",
+        "administrative",
+        "application",
+        "footprint",
+        "licenses",
+        "reduced"
+      ]
+    },
+    {
+      "control_id": "1.2.1",
+      "section": 1,
+      "section_name": "Microsoft 365 admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "approved",
+        "exist",
+        "groups",
+        "managed",
+        "organizationally",
+        "public"
+      ]
+    },
+    {
+      "control_id": "1.2.2",
+      "section": 1,
+      "section_name": "Microsoft 365 admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "blocked",
+        "mailboxes",
+        "shared",
+        "sign"
+      ]
+    },
+    {
+      "control_id": "1.3.1",
+      "section": 1,
+      "section_name": "Microsoft 365 admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "'password",
+        "'set",
+        "expiration",
+        "expire",
+        "never",
+        "passwords",
+        "policy'",
+        "recommended"
+      ]
+    },
+    {
+      "control_id": "1.3.2",
+      "section": 1,
+      "section_name": "Microsoft 365 admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "'idle",
+        "devices",
+        "hours",
+        "less",
+        "session",
+        "timeout'",
+        "unmanaged"
+      ]
+    },
+    {
+      "control_id": "1.3.3",
+      "section": 1,
+      "section_name": "Microsoft 365 admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "'external",
+        "available",
+        "calendars",
+        "sharing'"
+      ]
+    },
+    {
+      "control_id": "1.3.4",
+      "section": 1,
+      "section_name": "Microsoft 365 admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "'user",
+        "apps",
+        "owned",
+        "services'"
+      ]
+    },
+    {
+      "control_id": "1.3.5",
+      "section": 1,
+      "section_name": "Microsoft 365 admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "forms",
+        "internal",
+        "phishing",
+        "protection"
+      ]
+    },
+    {
+      "control_id": "1.3.6",
+      "section": 1,
+      "section_name": "Microsoft 365 admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "customer",
+        "feature",
+        "lockbox"
+      ]
+    },
+    {
+      "control_id": "1.3.7",
+      "section": 1,
+      "section_name": "Microsoft 365 admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "'microsoft",
+        "'third",
+        "365",
+        "party",
+        "services'",
+        "storage",
+        "web'"
+      ]
+    },
+    {
+      "control_id": "1.3.8",
+      "section": 1,
+      "section_name": "Microsoft 365 admin center",
+      "assessment": "Manual",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "cannot",
+        "organization",
+        "outside",
+        "people",
+        "shared",
+        "sways",
+        "your"
+      ]
+    },
+    {
+      "control_id": "1.3.9",
+      "section": 1,
+      "section_name": "Microsoft 365 admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "bookings",
+        "pages",
+        "select",
+        "shared",
+        "users"
+      ]
+    },
+    {
+      "control_id": "2.1.1",
+      "section": 2,
+      "section_name": "Microsoft Defender",
+      "assessment": "Automated",
+      "levels": [
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "applications",
+        "links",
+        "office",
+        "safe"
+      ]
+    },
+    {
+      "control_id": "2.1.2",
+      "section": 2,
+      "section_name": "Microsoft Defender",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "attachment",
+        "common",
+        "filter",
+        "types"
+      ]
+    },
+    {
+      "control_id": "2.1.3",
+      "section": 2,
+      "section_name": "Microsoft Defender",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "internal",
+        "malware",
+        "notifications",
+        "sending",
+        "users"
+      ]
+    },
+    {
+      "control_id": "2.1.4",
+      "section": 2,
+      "section_name": "Microsoft Defender",
+      "assessment": "Automated",
+      "levels": [
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "attachments",
+        "safe"
+      ]
+    },
+    {
+      "control_id": "2.1.5",
+      "section": 2,
+      "section_name": "Microsoft Defender",
+      "assessment": "Automated",
+      "levels": [
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "attachments",
+        "microsoft",
+        "onedrive",
+        "safe",
+        "sharepoint",
+        "teams"
+      ]
+    },
+    {
+      "control_id": "2.1.6",
+      "section": 2,
+      "section_name": "Microsoft Defender",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "administrators",
+        "exchange",
+        "notify",
+        "online",
+        "spam"
+      ]
+    },
+    {
+      "control_id": "2.1.7",
+      "section": 2,
+      "section_name": "Microsoft Defender",
+      "assessment": "Automated",
+      "levels": [
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "anti",
+        "created",
+        "phishing"
+      ]
+    },
+    {
+      "control_id": "2.1.8",
+      "section": 2,
+      "section_name": "Microsoft Defender",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "domains",
+        "exchange",
+        "published",
+        "records",
+        "spf"
+      ]
+    },
+    {
+      "control_id": "2.1.9",
+      "section": 2,
+      "section_name": "Microsoft Defender",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "dkim",
+        "domains",
+        "exchange",
+        "online"
+      ]
+    },
+    {
+      "control_id": "2.1.10",
+      "section": 2,
+      "section_name": "Microsoft Defender",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "dmarc",
+        "domains",
+        "exchange",
+        "online",
+        "published",
+        "records"
+      ]
+    },
+    {
+      "control_id": "2.1.11",
+      "section": 2,
+      "section_name": "Microsoft Defender",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "applied",
+        "attachment",
+        "comprehensive",
+        "filtering"
+      ]
+    },
+    {
+      "control_id": "2.1.12",
+      "section": 2,
+      "section_name": "Microsoft Defender",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "connection",
+        "filter",
+        "list"
+      ]
+    },
+    {
+      "control_id": "2.1.13",
+      "section": 2,
+      "section_name": "Microsoft Defender",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "connection",
+        "filter",
+        "list",
+        "safe"
+      ]
+    },
+    {
+      "control_id": "2.1.14",
+      "section": 2,
+      "section_name": "Microsoft Defender",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "anti",
+        "contain",
+        "domains",
+        "inbound",
+        "spam"
+      ]
+    },
+    {
+      "control_id": "2.1.15",
+      "section": 2,
+      "section_name": "Microsoft Defender",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "anti",
+        "limits",
+        "message",
+        "outbound",
+        "place",
+        "spam"
+      ]
+    },
+    {
+      "control_id": "2.2.1",
+      "section": 2,
+      "section_name": "Microsoft Defender",
+      "assessment": "Manual",
+      "levels": [
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "access",
+        "account",
+        "activity",
+        "emergency",
+        "monitored"
+      ]
+    },
+    {
+      "control_id": "2.4.1",
+      "section": 2,
+      "section_name": "Microsoft Defender",
+      "assessment": "Automated",
+      "levels": [
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "account",
+        "priority",
+        "protection"
+      ]
+    },
+    {
+      "control_id": "2.4.2",
+      "section": 2,
+      "section_name": "Microsoft Defender",
+      "assessment": "Automated",
+      "levels": [
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "'strict",
+        "accounts",
+        "applied",
+        "presets",
+        "priority",
+        "protection'"
+      ]
+    },
+    {
+      "control_id": "2.4.3",
+      "section": 2,
+      "section_name": "Microsoft Defender",
+      "assessment": "Manual",
+      "levels": [
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "apps",
+        "cloud",
+        "defender",
+        "microsoft"
+      ]
+    },
+    {
+      "control_id": "2.4.4",
+      "section": 2,
+      "section_name": "Microsoft Defender",
+      "assessment": "Automated",
+      "levels": [
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "auto",
+        "hour",
+        "microsoft",
+        "purge",
+        "teams",
+        "zero"
+      ]
+    },
+    {
+      "control_id": "2.4.5",
+      "section": 2,
+      "section_name": "Microsoft Defender",
+      "assessment": "Manual",
+      "levels": [
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "'air'",
+        "remediation"
+      ]
+    },
+    {
+      "control_id": "3.1.1",
+      "section": 3,
+      "section_name": "Microsoft Purview",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "365",
+        "audit",
+        "log",
+        "microsoft",
+        "search"
+      ]
+    },
+    {
+      "control_id": "3.2.1",
+      "section": 3,
+      "section_name": "Microsoft Purview",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "dlp"
+      ]
+    },
+    {
+      "control_id": "3.2.2",
+      "section": 3,
+      "section_name": "Microsoft Purview",
+      "assessment": "Automated",
+      "levels": [
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "dlp",
+        "microsoft",
+        "teams"
+      ]
+    },
+    {
+      "control_id": "3.2.3",
+      "section": 3,
+      "section_name": "Microsoft Purview",
+      "assessment": "Automated",
+      "levels": [
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "copilot",
+        "dlp",
+        "published",
+        "users"
+      ]
+    },
+    {
+      "control_id": "3.3.1",
+      "section": 3,
+      "section_name": "Microsoft Purview",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "information",
+        "label",
+        "protection",
+        "published",
+        "sensitivity"
+      ]
+    },
+    {
+      "control_id": "4.1",
+      "section": 4,
+      "section_name": "Microsoft Intune admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "'not",
+        "compliance",
+        "compliant'",
+        "devices",
+        "marked",
+        "without"
+      ]
+    },
+    {
+      "control_id": "4.2",
+      "section": 4,
+      "section_name": "Microsoft Intune admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "blocked",
+        "device",
+        "devices",
+        "enrollment",
+        "owned",
+        "personally"
+      ]
+    },
+    {
+      "control_id": "5.1.2.1",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Manual",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "'per",
+        "mfa'",
+        "user"
+      ]
+    },
+    {
+      "control_id": "5.1.2.2",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "applications",
+        "cannot",
+        "register",
+        "users"
+      ]
+    },
+    {
+      "control_id": "5.1.2.3",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "'restrict",
+        "'yes'",
+        "admin",
+        "creating",
+        "non",
+        "tenants'",
+        "users"
+      ]
+    },
+    {
+      "control_id": "5.1.2.4",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Manual",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "access",
+        "admin",
+        "center",
+        "entra"
+      ]
+    },
+    {
+      "control_id": "5.1.2.5",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Manual",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "hidden",
+        "option",
+        "remain",
+        "signed"
+      ]
+    },
+    {
+      "control_id": "5.1.2.6",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Manual",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "'linkedin",
+        "account",
+        "connections'"
+      ]
+    },
+    {
+      "control_id": "5.1.3.1",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "cannot",
+        "create",
+        "groups",
+        "security",
+        "users"
+      ]
+    },
+    {
+      "control_id": "5.1.3.2",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Manual",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "'restrict",
+        "'yes'",
+        "ability",
+        "access",
+        "features",
+        "groups",
+        "groups'",
+        "user"
+      ]
+    },
+    {
+      "control_id": "5.1.3.3",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Manual",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "'no'",
+        "'owners",
+        "can",
+        "group",
+        "groups'",
+        "manage",
+        "membership",
+        "requests"
+      ]
+    },
+    {
+      "control_id": "5.1.3.4",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "'no'",
+        "'users",
+        "365",
+        "api",
+        "azure",
+        "can",
+        "create",
+        "groups",
+        "microsoft",
+        "portals",
+        "powershell'"
+      ]
+    },
+    {
+      "control_id": "5.1.4.1",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "ability",
+        "devices",
+        "entra",
+        "join"
+      ]
+    },
+    {
+      "control_id": "5.1.4.2",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "devices",
+        "limited",
+        "maximum",
+        "number",
+        "per",
+        "user"
+      ]
+    },
+    {
+      "control_id": "5.1.4.3",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "added",
+        "administrator",
+        "during",
+        "entra",
+        "join",
+        "local",
+        "role"
+      ]
+    },
+    {
+      "control_id": "5.1.4.4",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "administrator",
+        "assignment",
+        "during",
+        "entra",
+        "join",
+        "limited",
+        "local"
+      ]
+    },
+    {
+      "control_id": "5.1.4.5",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "administrator",
+        "local",
+        "password",
+        "solution"
+      ]
+    },
+    {
+      "control_id": "5.1.4.6",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "bitlocker",
+        "keys",
+        "recovering",
+        "users"
+      ]
+    },
+    {
+      "control_id": "5.1.5.1",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "accessing",
+        "apps",
+        "behalf",
+        "company",
+        "consent",
+        "data",
+        "their",
+        "user"
+      ]
+    },
+    {
+      "control_id": "5.1.5.2",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "admin",
+        "consent",
+        "workflow"
+      ]
+    },
+    {
+      "control_id": "5.1.5.3",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "addition",
+        "applications",
+        "blocked",
+        "password"
+      ]
+    },
+    {
+      "control_id": "5.1.5.4",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "180",
+        "applications",
+        "days",
+        "does",
+        "exceed",
+        "lifetime",
+        "password"
+      ]
+    },
+    {
+      "control_id": "5.1.5.5",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "application",
+        "generated",
+        "new",
+        "passwords",
+        "system"
+      ]
+    },
+    {
+      "control_id": "5.1.5.6",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "180",
+        "applications",
+        "certificate",
+        "days",
+        "does",
+        "exceed",
+        "lifetime",
+        "maximum"
+      ]
+    },
+    {
+      "control_id": "5.1.6.1",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "collaboration",
+        "domains",
+        "invitations",
+        "sent"
+      ]
+    },
+    {
+      "control_id": "5.1.6.2",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "access",
+        "guest",
+        "user"
+      ]
+    },
+    {
+      "control_id": "5.1.6.3",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "guest",
+        "invitations",
+        "limited",
+        "user"
+      ]
+    },
+    {
+      "control_id": "5.1.8.1",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "deployments",
+        "hash",
+        "hybrid",
+        "password",
+        "sync"
+      ]
+    },
+    {
+      "control_id": "5.2.2.1",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "administrative",
+        "authentication",
+        "multifactor",
+        "roles",
+        "users"
+      ]
+    },
+    {
+      "control_id": "5.2.2.2",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "authentication",
+        "multifactor",
+        "users"
+      ]
+    },
+    {
+      "control_id": "5.2.2.3",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "access",
+        "authentication",
+        "block",
+        "conditional",
+        "legacy"
+      ]
+    },
+    {
+      "control_id": "5.2.2.4",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "administrative",
+        "browser",
+        "frequency",
+        "persistent",
+        "sessions",
+        "sign",
+        "users"
+      ]
+    },
+    {
+      "control_id": "5.2.2.5",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "'phishing",
+        "administrators",
+        "mfa",
+        "required",
+        "resistant",
+        "strength'"
+      ]
+    },
+    {
+      "control_id": "5.2.2.6",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "identity",
+        "protection",
+        "risk",
+        "user"
+      ]
+    },
+    {
+      "control_id": "5.2.2.7",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "identity",
+        "protection",
+        "risk",
+        "sign"
+      ]
+    },
+    {
+      "control_id": "5.2.2.8",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "'sign",
+        "blocked",
+        "high",
+        "medium",
+        "risk",
+        "risk'"
+      ]
+    },
+    {
+      "control_id": "5.2.2.9",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "authentication",
+        "device",
+        "managed",
+        "required"
+      ]
+    },
+    {
+      "control_id": "5.2.2.10",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "device",
+        "information",
+        "managed",
+        "register",
+        "required",
+        "security"
+      ]
+    },
+    {
+      "control_id": "5.2.2.11",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "'every",
+        "enrollment",
+        "frequency",
+        "intune",
+        "sign",
+        "time'"
+      ]
+    },
+    {
+      "control_id": "5.2.2.12",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "blocked",
+        "code",
+        "device",
+        "flow",
+        "sign"
+      ]
+    },
+    {
+      "control_id": "5.2.2.13",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "periodic",
+        "reauthentication",
+        "required",
+        "users"
+      ]
+    },
+    {
+      "control_id": "5.2.2.14",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "'named",
+        "defined",
+        "locations'",
+        "trusted"
+      ]
+    },
+    {
+      "control_id": "5.2.2.15",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "access",
+        "controls",
+        "exclusionary",
+        "geographic",
+        "utilized"
+      ]
+    },
+    {
+      "control_id": "5.2.2.16",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "enforced",
+        "protection",
+        "session",
+        "token",
+        "tokens"
+      ]
+    },
+    {
+      "control_id": "5.2.2.17",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "authentication",
+        "blocked",
+        "transfer"
+      ]
+    },
+    {
+      "control_id": "5.2.3.1",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "against",
+        "authenticator",
+        "fatigue",
+        "mfa",
+        "microsoft",
+        "protect"
+      ]
+    },
+    {
+      "control_id": "5.2.3.2",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "banned",
+        "custom",
+        "lists",
+        "passwords"
+      ]
+    },
+    {
+      "control_id": "5.2.3.3",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "active",
+        "directory",
+        "password",
+        "prem",
+        "protection"
+      ]
+    },
+    {
+      "control_id": "5.2.3.4",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "'mfa",
+        "capable'",
+        "member",
+        "users"
+      ]
+    },
+    {
+      "control_id": "5.2.3.5",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "authentication",
+        "methods",
+        "weak"
+      ]
+    },
+    {
+      "control_id": "5.2.3.6",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "authentication",
+        "multifactor",
+        "preferred",
+        "system"
+      ]
+    },
+    {
+      "control_id": "5.2.3.7",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "authentication",
+        "email",
+        "method",
+        "otp"
+      ]
+    },
+    {
+      "control_id": "5.2.3.8",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "'10'",
+        "'lockout",
+        "account",
+        "less",
+        "threshold'"
+      ]
+    },
+    {
+      "control_id": "5.2.3.9",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "'lockout",
+        "account",
+        "duration",
+        "least",
+        "seconds",
+        "seconds'"
+      ]
+    },
+    {
+      "control_id": "5.2.3.10",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "applications",
+        "authenticator",
+        "companion",
+        "microsoft"
+      ]
+    },
+    {
+      "control_id": "5.2.4.1",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Manual",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "'all'",
+        "'self",
+        "enabled'",
+        "password",
+        "reset",
+        "service"
+      ]
+    },
+    {
+      "control_id": "5.2.4.2",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Manual",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "methods",
+        "password",
+        "required",
+        "reset"
+      ]
+    },
+    {
+      "control_id": "5.2.4.3",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Manual",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "authentication",
+        "confirmation",
+        "registration",
+        "required",
+        "sspr"
+      ]
+    },
+    {
+      "control_id": "5.2.4.4",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Manual",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "notified",
+        "password",
+        "resets",
+        "users"
+      ]
+    },
+    {
+      "control_id": "5.2.4.5",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Manual",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "admins",
+        "notified",
+        "other",
+        "password",
+        "reset",
+        "their",
+        "when"
+      ]
+    },
+    {
+      "control_id": "5.3.1",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "activated",
+        "assigned",
+        "assignments",
+        "privileged",
+        "role"
+      ]
+    },
+    {
+      "control_id": "5.3.2",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "'access",
+        "guest",
+        "reviews'",
+        "users"
+      ]
+    },
+    {
+      "control_id": "5.3.3",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "'access",
+        "privileged",
+        "reviews'",
+        "roles"
+      ]
+    },
+    {
+      "control_id": "5.3.4",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "activation",
+        "administrator",
+        "approval",
+        "global",
+        "required",
+        "role"
+      ]
+    },
+    {
+      "control_id": "5.3.5",
+      "section": 5,
+      "section_name": "Microsoft Entra admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "activation",
+        "administrator",
+        "approval",
+        "privileged",
+        "required",
+        "role"
+      ]
+    },
+    {
+      "control_id": "6.1.1",
+      "section": 6,
+      "section_name": "Exchange admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "'auditdisabled'",
+        "'false'",
+        "organizationally"
+      ]
+    },
+    {
+      "control_id": "6.1.2",
+      "section": 6,
+      "section_name": "Exchange admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "actions",
+        "audit",
+        "mailbox"
+      ]
+    },
+    {
+      "control_id": "6.1.3",
+      "section": 6,
+      "section_name": "Exchange admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "'auditbypassenabled'",
+        "mailboxes"
+      ]
+    },
+    {
+      "control_id": "6.2.1",
+      "section": 6,
+      "section_name": "Exchange admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "blocked",
+        "forms",
+        "forwarding",
+        "mail"
+      ]
+    },
+    {
+      "control_id": "6.2.2",
+      "section": 6,
+      "section_name": "Exchange admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "domains",
+        "mail",
+        "rules",
+        "specific",
+        "transport",
+        "whitelist"
+      ]
+    },
+    {
+      "control_id": "6.2.3",
+      "section": 6,
+      "section_name": "Exchange admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "email",
+        "external",
+        "identified",
+        "senders"
+      ]
+    },
+    {
+      "control_id": "6.3.1",
+      "section": 6,
+      "section_name": "Exchange admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "add",
+        "ins",
+        "installing",
+        "outlook",
+        "users"
+      ]
+    },
+    {
+      "control_id": "6.3.2",
+      "section": 6,
+      "section_name": "Exchange admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "ability",
+        "accounts",
+        "add",
+        "calendars",
+        "email",
+        "personal"
+      ]
+    },
+    {
+      "control_id": "6.5.1",
+      "section": 6,
+      "section_name": "Exchange admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "authentication",
+        "exchange",
+        "modern",
+        "online"
+      ]
+    },
+    {
+      "control_id": "6.5.2",
+      "section": 6,
+      "section_name": "Exchange admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "end",
+        "mailtips",
+        "users"
+      ]
+    },
+    {
+      "control_id": "6.5.3",
+      "section": 6,
+      "section_name": "Exchange admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "additional",
+        "outlook",
+        "providers",
+        "storage",
+        "web"
+      ]
+    },
+    {
+      "control_id": "6.5.4",
+      "section": 6,
+      "section_name": "Exchange admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "auth",
+        "smtp"
+      ]
+    },
+    {
+      "control_id": "6.5.5",
+      "section": 6,
+      "section_name": "Exchange admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "direct",
+        "rejected",
+        "send",
+        "submissions"
+      ]
+    },
+    {
+      "control_id": "7.2.1",
+      "section": 7,
+      "section_name": "SharePoint admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "applications",
+        "authentication",
+        "modern",
+        "required",
+        "sharepoint"
+      ]
+    },
+    {
+      "control_id": "7.2.2",
+      "section": 7,
+      "section_name": "SharePoint admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "azure",
+        "b2b",
+        "integration",
+        "onedrive",
+        "sharepoint"
+      ]
+    },
+    {
+      "control_id": "7.2.3",
+      "section": 7,
+      "section_name": "SharePoint admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "content",
+        "external",
+        "sharing"
+      ]
+    },
+    {
+      "control_id": "7.2.4",
+      "section": 7,
+      "section_name": "SharePoint admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "content",
+        "onedrive",
+        "sharing"
+      ]
+    },
+    {
+      "control_id": "7.2.5",
+      "section": 7,
+      "section_name": "SharePoint admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "cannot",
+        "don't",
+        "guest",
+        "items",
+        "own",
+        "share",
+        "sharepoint",
+        "they",
+        "users"
+      ]
+    },
+    {
+      "control_id": "7.2.6",
+      "section": 7,
+      "section_name": "SharePoint admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "external",
+        "sharepoint",
+        "sharing"
+      ]
+    },
+    {
+      "control_id": "7.2.7",
+      "section": 7,
+      "section_name": "SharePoint admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "link",
+        "onedrive",
+        "sharepoint",
+        "sharing"
+      ]
+    },
+    {
+      "control_id": "7.2.8",
+      "section": 7,
+      "section_name": "SharePoint admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "external",
+        "group",
+        "security",
+        "sharing"
+      ]
+    },
+    {
+      "control_id": "7.2.9",
+      "section": 7,
+      "section_name": "SharePoint admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "access",
+        "automatically",
+        "expire",
+        "guest",
+        "onedrive",
+        "site",
+        "will"
+      ]
+    },
+    {
+      "control_id": "7.2.10",
+      "section": 7,
+      "section_name": "SharePoint admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "code",
+        "reauthentication",
+        "verification"
+      ]
+    },
+    {
+      "control_id": "7.2.11",
+      "section": 7,
+      "section_name": "SharePoint admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "link",
+        "permission",
+        "sharepoint",
+        "sharing"
+      ]
+    },
+    {
+      "control_id": "7.3.1",
+      "section": 7,
+      "section_name": "SharePoint admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "365",
+        "disallowed",
+        "download",
+        "files",
+        "infected",
+        "office",
+        "sharepoint"
+      ]
+    },
+    {
+      "control_id": "8.1.1",
+      "section": 8,
+      "section_name": "Microsoft Teams admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "approved",
+        "cloud",
+        "external",
+        "file",
+        "services",
+        "sharing",
+        "storage",
+        "teams"
+      ]
+    },
+    {
+      "control_id": "8.1.2",
+      "section": 8,
+      "section_name": "Microsoft Teams admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "address",
+        "can't",
+        "channel",
+        "email",
+        "emails",
+        "send",
+        "users"
+      ]
+    },
+    {
+      "control_id": "8.2.1",
+      "section": 8,
+      "section_name": "Microsoft Teams admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "admin",
+        "center",
+        "domains",
+        "external",
+        "teams"
+      ]
+    },
+    {
+      "control_id": "8.2.2",
+      "section": 8,
+      "section_name": "Microsoft Teams admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "communication",
+        "teams",
+        "unmanaged",
+        "users"
+      ]
+    },
+    {
+      "control_id": "8.2.3",
+      "section": 8,
+      "section_name": "Microsoft Teams admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "cannot",
+        "conversations",
+        "external",
+        "initiate",
+        "teams",
+        "users"
+      ]
+    },
+    {
+      "control_id": "8.2.4",
+      "section": 8,
+      "section_name": "Microsoft Teams admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "accounts",
+        "cannot",
+        "communicate",
+        "organization",
+        "teams",
+        "tenants",
+        "trial"
+      ]
+    },
+    {
+      "control_id": "8.4.1",
+      "section": 8,
+      "section_name": "Microsoft Teams admin center",
+      "assessment": "Manual",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "app",
+        "permission"
+      ]
+    },
+    {
+      "control_id": "8.5.1",
+      "section": 8,
+      "section_name": "Microsoft Teams admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "anonymous",
+        "can't",
+        "join",
+        "meeting",
+        "users"
+      ]
+    },
+    {
+      "control_id": "8.5.2",
+      "section": 8,
+      "section_name": "Microsoft Teams admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "anonymous",
+        "callers",
+        "can't",
+        "dial",
+        "meeting",
+        "start",
+        "users"
+      ]
+    },
+    {
+      "control_id": "8.5.3",
+      "section": 8,
+      "section_name": "Microsoft Teams admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "bypass",
+        "can",
+        "lobby",
+        "org",
+        "people"
+      ]
+    },
+    {
+      "control_id": "8.5.4",
+      "section": 8,
+      "section_name": "Microsoft Teams admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "bypass",
+        "can't",
+        "dialing",
+        "lobby",
+        "users"
+      ]
+    },
+    {
+      "control_id": "8.5.5",
+      "section": 8,
+      "section_name": "Microsoft Teams admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "anonymous",
+        "chat",
+        "does",
+        "meeting",
+        "users"
+      ]
+    },
+    {
+      "control_id": "8.5.6",
+      "section": 8,
+      "section_name": "Microsoft Teams admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "can",
+        "organizers",
+        "present"
+      ]
+    },
+    {
+      "control_id": "8.5.7",
+      "section": 8,
+      "section_name": "Microsoft Teams admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "can't",
+        "control",
+        "external",
+        "give",
+        "participants",
+        "request"
+      ]
+    },
+    {
+      "control_id": "8.5.8",
+      "section": 8,
+      "section_name": "Microsoft Teams admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "chat",
+        "external",
+        "meeting"
+      ]
+    },
+    {
+      "control_id": "8.5.9",
+      "section": 8,
+      "section_name": "Microsoft Teams admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "meeting",
+        "recording"
+      ]
+    },
+    {
+      "control_id": "8.6.1",
+      "section": 8,
+      "section_name": "Microsoft Teams admin center",
+      "assessment": "Automated",
+      "levels": [
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "can",
+        "concerns",
+        "report",
+        "security",
+        "teams",
+        "users"
+      ]
+    },
+    {
+      "control_id": "9.1.1",
+      "section": 9,
+      "section_name": "Microsoft Fabric",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "access",
+        "guest",
+        "user"
+      ]
+    },
+    {
+      "control_id": "9.1.2",
+      "section": 9,
+      "section_name": "Microsoft Fabric",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "external",
+        "invitations",
+        "user"
+      ]
+    },
+    {
+      "control_id": "9.1.3",
+      "section": 9,
+      "section_name": "Microsoft Fabric",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "access",
+        "content",
+        "guest"
+      ]
+    },
+    {
+      "control_id": "9.1.4",
+      "section": 9,
+      "section_name": "Microsoft Fabric",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "'publish",
+        "web'"
+      ]
+    },
+    {
+      "control_id": "9.1.5",
+      "section": 9,
+      "section_name": "Microsoft Fabric",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 2",
+        "E5 Level 2"
+      ],
+      "title_keywords": [
+        "'disabled'",
+        "'interact",
+        "python'",
+        "share",
+        "visuals"
+      ]
+    },
+    {
+      "control_id": "9.1.6",
+      "section": 9,
+      "section_name": "Microsoft Fabric",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "'allow",
+        "'enabled'",
+        "apply",
+        "content'",
+        "labels",
+        "sensitivity",
+        "users"
+      ]
+    },
+    {
+      "control_id": "9.1.7",
+      "section": 9,
+      "section_name": "Microsoft Fabric",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "links",
+        "shareable"
+      ]
+    },
+    {
+      "control_id": "9.1.8",
+      "section": 9,
+      "section_name": "Microsoft Fabric",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "data",
+        "enabling",
+        "external",
+        "sharing"
+      ]
+    },
+    {
+      "control_id": "9.1.9",
+      "section": 9,
+      "section_name": "Microsoft Fabric",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "'block",
+        "'enabled'",
+        "authentication'",
+        "resourcekey"
+      ]
+    },
+    {
+      "control_id": "9.1.10",
+      "section": 9,
+      "section_name": "Microsoft Fabric",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "access",
+        "apis",
+        "principals",
+        "service"
+      ]
+    },
+    {
+      "control_id": "9.1.11",
+      "section": 9,
+      "section_name": "Microsoft Fabric",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "cannot",
+        "create",
+        "principals",
+        "profiles",
+        "service"
+      ]
+    },
+    {
+      "control_id": "9.1.12",
+      "section": 9,
+      "section_name": "Microsoft Fabric",
+      "assessment": "Automated",
+      "levels": [
+        "E3 Level 1",
+        "E5 Level 1"
+      ],
+      "title_keywords": [
+        "ability",
+        "connections",
+        "create",
+        "deployment",
+        "pipelines",
+        "principals",
+        "service",
+        "workspaces"
+      ]
+    }
+  ]
+}

--- a/benchmarks/cis/saas/m365_v7/defender_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/defender_validation.rego
@@ -1,0 +1,75 @@
+# CIS Microsoft 365 Foundations Benchmark v7.0.0
+# Section 2 -- Microsoft Defender
+#
+# NOTE ON PLACEMENT: SPF / DKIM / DMARC are section 2 controls in v7.0.0,
+# not Exchange controls. The pre-v7 library evaluated them under its own
+# "Exchange" module, which was one of the reasons its control numbers did
+# not correspond to the benchmark.
+#
+# Input contract (from the aac.m365 collection):
+#   input.exchange.verified_domains[] - {id, is_default, is_initial,
+#                                        spf_present, dkim_present,
+#                                        dmarc_present}
+#
+# NOT EVALUATED in this module: every Defender policy control (Safe Links,
+# Safe Attachments, anti-phishing, anti-spam, connection filtering --
+# 2.1.1 through 2.1.7 and 2.1.11 onward). The current collector returns
+# only Microsoft Secure Score, which is a different control set from the
+# CIS benchmark and cannot establish these controls. See COVERAGE.md.
+
+package cis_m365_v7.defender
+
+import rego.v1
+
+default compliant := false
+
+default facts_present := false
+
+facts_present if {
+	is_array(input.exchange.verified_domains)
+}
+
+# CIS 2.1.8 -- SPF records published for all Exchange domains.
+violation contains msg if {
+	some d in input.exchange.verified_domains
+	not d.spf_present
+	msg := sprintf("CIS 2.1.8: no SPF record published for domain '%s' -- receivers cannot distinguish legitimate senders from spoofed mail", [d.id])
+}
+
+# CIS 2.1.9 -- DKIM enabled for all Exchange Online domains.
+violation contains msg if {
+	some d in input.exchange.verified_domains
+	not d.dkim_present
+	msg := sprintf("CIS 2.1.9: DKIM not enabled for domain '%s' -- outbound mail carries no cryptographic origin signature", [d.id])
+}
+
+# CIS 2.1.10 -- DMARC records published for all Exchange Online domains.
+violation contains msg if {
+	some d in input.exchange.verified_domains
+	not d.dmarc_present
+	msg := sprintf("CIS 2.1.10: no DMARC record published for domain '%s' -- SPF and DKIM failures have no enforcement disposition", [d.id])
+}
+
+violation contains msg if {
+	not facts_present
+	msg := "CIS 2.1.8: verified-domain facts not collected -- SPF, DKIM and DMARC controls could not be evaluated (this is not a pass)"
+}
+
+compliant if {
+	facts_present
+	count(violation) == 0
+}
+
+compliance_report := {
+	"benchmark": "CIS Microsoft 365 Foundations Benchmark",
+	"benchmark_version": "7.0.0",
+	"section": "2",
+	"name": "Microsoft Defender",
+	"section_total_controls": 21,
+	"controls_evaluated": 3,
+	"controls": ["2.1.8", "2.1.9", "2.1.10"],
+	"facts_present": facts_present,
+	"violations": violation,
+	"violation_count": count(violation),
+	"compliant": compliant,
+}

--- a/benchmarks/cis/saas/m365_v7/entra_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/entra_validation.rego
@@ -1,0 +1,130 @@
+# CIS Microsoft 365 Foundations Benchmark v7.0.0
+# Section 5 -- Microsoft Entra admin center
+#
+# Section 5 is the largest in the benchmark: 63 of its 160 recommendations.
+# This module evaluates the four that the current Graph collector can
+# actually establish.
+#
+# DROPPED FROM THE PRE-v7 LIBRARY: the "Security Defaults" check. v7.0.0
+# has no Security Defaults recommendation -- the nearest control is 5.1.2.1
+# ("Per-user MFA"), which is a different requirement and is not established
+# by the facts we collect. The check was removed rather than renumbered;
+# inventing an id is the defect this rewrite exists to fix.
+#
+# Input contract (from the aac.m365 collection):
+#   input.identity.conditional_access_policies[] - {id, display_name, state,
+#                                                   conditions, grant_controls}
+#   input.identity.pim_role_assignments[]        - {principal_id, role_definition_id, status}
+#   input.identity.pim_available                 - bool
+
+package cis_m365_v7.entra
+
+import rego.v1
+
+default compliant := false
+
+default facts_present := false
+
+facts_present if {
+	is_array(input.identity.conditional_access_policies)
+}
+
+enabled_policies contains p if {
+	some p in input.identity.conditional_access_policies
+	p.state == "enabled"
+}
+
+# A policy requires MFA when its grant controls include the mfa built-in.
+requires_mfa(p) if {
+	some c in p.grant_controls.builtInControls
+	c == "mfa"
+}
+
+# Scope helper: "All" in includeUsers means the policy covers every user.
+targets_all_users(p) if {
+	some u in p.conditions.users.includeUsers
+	u == "All"
+}
+
+targets_admin_roles(p) if {
+	count(p.conditions.users.includeRoles) > 0
+}
+
+# CIS 5.2.2.1 -- multifactor authentication for users in administrative roles.
+violation contains msg if {
+	facts_present
+	not admin_mfa_enforced
+	msg := "CIS 5.2.2.1: no enabled Conditional Access policy requires multifactor authentication for administrative roles"
+}
+
+default admin_mfa_enforced := false
+
+admin_mfa_enforced if {
+	some p in enabled_policies
+	requires_mfa(p)
+	targets_admin_roles(p)
+}
+
+# CIS 5.2.2.2 -- multifactor authentication for all users.
+violation contains msg if {
+	facts_present
+	not all_user_mfa_enforced
+	msg := "CIS 5.2.2.2: no enabled Conditional Access policy requires multifactor authentication for all users"
+}
+
+default all_user_mfa_enforced := false
+
+all_user_mfa_enforced if {
+	some p in enabled_policies
+	requires_mfa(p)
+	targets_all_users(p)
+}
+
+# CIS 5.2.2.3 -- Conditional Access must block legacy authentication.
+violation contains msg if {
+	facts_present
+	not legacy_auth_blocked
+	msg := "CIS 5.2.2.3: no enabled Conditional Access policy blocks legacy authentication; legacy protocols bypass multifactor authentication"
+}
+
+default legacy_auth_blocked := false
+
+legacy_auth_blocked if {
+	some p in enabled_policies
+	some c in p.conditions.clientAppTypes
+	c in {"exchangeActiveSync", "other"}
+	some g in p.grant_controls.builtInControls
+	g == "block"
+}
+
+# CIS 5.3.1 -- privileged roles should be activated through PIM, not
+# permanently assigned.
+violation contains msg if {
+	facts_present
+	not input.identity.pim_available
+	msg := "CIS 5.3.1: Privileged Identity Management not in use; privileged role assignments are standing rather than activated on demand"
+}
+
+violation contains msg if {
+	not facts_present
+	msg := "CIS 5.2.2.1: Conditional Access facts not collected -- multifactor and legacy-authentication controls could not be evaluated (this is not a pass)"
+}
+
+compliant if {
+	facts_present
+	count(violation) == 0
+}
+
+compliance_report := {
+	"benchmark": "CIS Microsoft 365 Foundations Benchmark",
+	"benchmark_version": "7.0.0",
+	"section": "5",
+	"name": "Microsoft Entra admin center",
+	"section_total_controls": 63,
+	"controls_evaluated": 4,
+	"controls": ["5.2.2.1", "5.2.2.2", "5.2.2.3", "5.3.1"],
+	"facts_present": facts_present,
+	"violations": violation,
+	"violation_count": count(violation),
+	"compliant": compliant,
+}

--- a/benchmarks/cis/saas/m365_v7/exchange_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/exchange_validation.rego
@@ -1,0 +1,61 @@
+# CIS Microsoft 365 Foundations Benchmark v7.0.0
+# Section 6 -- Exchange admin center
+#
+# Input contract (from the aac.m365 collection):
+#   input.exchange.mailbox_audit_summary - {sampled, audit_enabled,
+#                                           audit_disabled, evaluable}
+#
+# COLLECTION LIMIT -- read this before trusting 6.1.1. Graph v1.0 does not
+# expose the tenant-wide 'AuditDisabled' organization flag. The collector
+# samples per-user mailboxSettings instead, so this is a PROXY: it can show
+# that auditing is off for sampled mailboxes, but it cannot prove the
+# organization-level flag is False. A clean result here is weaker evidence
+# than a clean result from Exchange Online PowerShell, which is what the
+# benchmark's own audit procedure uses. Surfaced in compliance_report as
+# evidence_strength so a reader cannot miss it.
+
+package cis_m365_v7.exchange
+
+import rego.v1
+
+default compliant := false
+
+default facts_present := false
+
+facts_present if {
+	input.exchange.mailbox_audit_summary.evaluable == true
+}
+
+# CIS 6.1.1 -- mailbox auditing must not be disabled organizationally.
+violation contains msg if {
+	facts_present
+	input.exchange.mailbox_audit_summary.audit_disabled > 0
+	msg := sprintf("CIS 6.1.1: AuditDisabled is effectively true for %d of %d sampled mailboxes -- organizationally this flag must be False or mailbox actions are not recorded", [input.exchange.mailbox_audit_summary.audit_disabled, input.exchange.mailbox_audit_summary.sampled])
+}
+
+violation contains msg if {
+	not facts_present
+	msg := "CIS 6.1.1: mailbox facts not collected -- could not establish that AuditDisabled is organizationally False (this is not a pass)"
+}
+
+compliant if {
+	facts_present
+	count(violation) == 0
+}
+
+compliance_report := {
+	"benchmark": "CIS Microsoft 365 Foundations Benchmark",
+	"benchmark_version": "7.0.0",
+	"section": "6",
+	"name": "Exchange admin center",
+	"section_total_controls": 13,
+	"controls_evaluated": 1,
+	"controls": ["6.1.1"],
+	"facts_present": facts_present,
+	"evidence_strength": {
+		"6.1.1": "proxy -- per-user mailboxSettings sample; Graph v1.0 does not expose the tenant-wide AuditDisabled flag",
+	},
+	"violations": violation,
+	"violation_count": count(violation),
+	"compliant": compliant,
+}

--- a/benchmarks/cis/saas/m365_v7/purview_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/purview_validation.rego
@@ -1,0 +1,55 @@
+# CIS Microsoft 365 Foundations Benchmark v7.0.0
+# Section 3 -- Microsoft Purview
+#
+# Input contract (from the aac.m365 collection):
+#   input.purview.audit_log_accessible - bool; a directoryAudits probe
+#                                        returned at least one record
+#
+# NOT EVALUATED: 3.2.x (DLP), 3.3.x (labels), Insider Risk Management and
+# Communication Compliance. The Purview collector returns Secure Score plus
+# an audit-log reachability probe and an eDiscovery case count; none of
+# those establish the remaining section 3 controls. See COVERAGE.md.
+
+package cis_m365_v7.purview
+
+import rego.v1
+
+default compliant := false
+
+default facts_present := false
+
+facts_present if {
+	is_boolean(input.purview.audit_log_accessible)
+}
+
+# CIS 3.1.1 -- unified audit log search must be enabled. If the audit log
+# cannot be searched, there is no record for an investigator to read.
+violation contains msg if {
+	facts_present
+	not input.purview.audit_log_accessible
+	msg := "CIS 3.1.1: unified audit log search returned no records -- audit logging is not enabled, so tenant activity is not retained for investigation"
+}
+
+violation contains msg if {
+	not facts_present
+	msg := "CIS 3.1.1: audit log facts not collected -- control could not be evaluated (this is not a pass)"
+}
+
+compliant if {
+	facts_present
+	count(violation) == 0
+}
+
+compliance_report := {
+	"benchmark": "CIS Microsoft 365 Foundations Benchmark",
+	"benchmark_version": "7.0.0",
+	"section": "3",
+	"name": "Microsoft Purview",
+	"section_total_controls": 5,
+	"controls_evaluated": 1,
+	"controls": ["3.1.1"],
+	"facts_present": facts_present,
+	"violations": violation,
+	"violation_count": count(violation),
+	"compliant": compliant,
+}

--- a/benchmarks/cis/saas/m365_v7/sharepoint_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/sharepoint_validation.rego
@@ -1,0 +1,74 @@
+# CIS Microsoft 365 Foundations Benchmark v7.0.0
+# Section 7 -- SharePoint admin center
+#
+# Input contract (from the aac.m365 collection, /admin/sharepoint/settings):
+#   input.sharepoint.sharing_capability          - str
+#   input.sharepoint.default_sharing_link_type   - str
+#   input.sharepoint.default_link_permission     - str
+#   input.sharepoint.legacy_auth_protocols_enabled - bool
+#   input.sharepoint.settings_reachable          - bool
+
+package cis_m365_v7.sharepoint
+
+import rego.v1
+
+default compliant := false
+
+default facts_present := false
+
+facts_present if {
+	input.sharepoint.settings_reachable == true
+}
+
+# CIS 7.2.1 -- modern authentication required for SharePoint applications.
+violation contains msg if {
+	facts_present
+	input.sharepoint.legacy_auth_protocols_enabled == true
+	msg := "CIS 7.2.1: legacy authentication protocols are permitted for SharePoint applications; modern authentication is not required, so clients can bypass Conditional Access"
+}
+
+# CIS 7.2.6 -- SharePoint external sharing must be restricted. The most
+# permissive setting allows sharing with anonymous external users.
+violation contains msg if {
+	facts_present
+	input.sharepoint.sharing_capability == "ExternalUserAndGuestSharing"
+	msg := "CIS 7.2.6: SharePoint external sharing is set to the most permissive value (ExternalUserAndGuestSharing); restrict to ExistingExternalUserSharingOnly or Disabled"
+}
+
+# CIS 7.2.7 -- link sharing must be restricted in SharePoint and OneDrive.
+violation contains msg if {
+	facts_present
+	input.sharepoint.default_sharing_link_type == "AnonymousAccess"
+	msg := "CIS 7.2.7: the default sharing link is anonymous, so newly created links are world-readable; restrict link sharing to specific people or the organization"
+}
+
+# CIS 7.2.11 -- the default sharing link permission should be view, not edit.
+violation contains msg if {
+	facts_present
+	input.sharepoint.default_link_permission == "Edit"
+	msg := "CIS 7.2.11: the SharePoint default sharing link permission grants Edit; a default of View limits accidental modification by recipients"
+}
+
+violation contains msg if {
+	not facts_present
+	msg := "CIS 7.2.1: SharePoint tenant settings were not reachable -- external sharing and authentication controls could not be evaluated (this is not a pass)"
+}
+
+compliant if {
+	facts_present
+	count(violation) == 0
+}
+
+compliance_report := {
+	"benchmark": "CIS Microsoft 365 Foundations Benchmark",
+	"benchmark_version": "7.0.0",
+	"section": "7",
+	"name": "SharePoint admin center",
+	"section_total_controls": 12,
+	"controls_evaluated": 4,
+	"controls": ["7.2.1", "7.2.6", "7.2.7", "7.2.11"],
+	"facts_present": facts_present,
+	"violations": violation,
+	"violation_count": count(violation),
+	"compliant": compliant,
+}

--- a/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
+++ b/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
@@ -1,0 +1,272 @@
+package cis_m365_v7_test
+
+import data.cis_m365_v7.admin_center
+import data.cis_m365_v7.defender
+import data.cis_m365_v7.entra
+import data.cis_m365_v7.exchange
+import data.cis_m365_v7.main
+import data.cis_m365_v7.purview
+import data.cis_m365_v7.sharepoint
+import rego.v1
+
+# ── Fail-closed behaviour ─────────────────────────────────────────────
+# The defect class this library exists to avoid is a green result that was
+# never actually established. Absent facts must produce a violation and a
+# false `compliant`, never silence.
+
+test_admin_center_absent_facts_is_not_a_pass if {
+	r := admin_center.compliance_report with input as {}
+	r.compliant == false
+	r.facts_present == false
+	count(r.violations) == 1
+}
+
+test_defender_absent_facts_is_not_a_pass if {
+	r := defender.compliance_report with input as {}
+	r.compliant == false
+	count(r.violations) == 1
+}
+
+test_entra_absent_facts_is_not_a_pass if {
+	r := entra.compliance_report with input as {}
+	r.compliant == false
+}
+
+test_sharepoint_unreachable_settings_is_not_a_pass if {
+	r := sharepoint.compliance_report with input as {"sharepoint": {"settings_reachable": false}}
+	r.compliant == false
+}
+
+test_reports_never_collapse_to_empty_object if {
+	# A single undefined field turns the whole object into {} at the OPA
+	# endpoint. Assert every report is populated under empty input.
+	count(admin_center.compliance_report) > 0 with input as {}
+	count(defender.compliance_report) > 0 with input as {}
+	count(purview.compliance_report) > 0 with input as {}
+	count(entra.compliance_report) > 0 with input as {}
+	count(exchange.compliance_report) > 0 with input as {}
+	count(sharepoint.compliance_report) > 0 with input as {}
+	count(main.compliance_report) > 0 with input as {}
+}
+
+# ── CIS 1.1.3 -- between two and four global admins ───────────────────
+
+admins(n) := {"identity": {"global_admins": [{"id": sprintf("u%d", [i])} | some i in numbers.range(1, n)]}}
+
+test_1_1_3_too_few_global_admins if {
+	r := admin_center.compliance_report with input as admins(1)
+	r.compliant == false
+	some v in r.violations
+	contains(v, "CIS 1.1.3")
+}
+
+test_1_1_3_too_many_global_admins if {
+	r := admin_center.compliance_report with input as admins(6)
+	r.compliant == false
+}
+
+test_1_1_3_three_global_admins_passes if {
+	r := admin_center.compliance_report with input as admins(3)
+	r.compliant == true
+	count(r.violations) == 0
+}
+
+# ── CIS 2.1.8 / 2.1.9 / 2.1.10 -- SPF, DKIM, DMARC ────────────────────
+
+domains(spf, dkim, dmarc) := {"exchange": {"verified_domains": [{
+	"id": "example.com",
+	"spf_present": spf,
+	"dkim_present": dkim,
+	"dmarc_present": dmarc,
+}]}}
+
+test_2_1_8_missing_spf if {
+	r := defender.compliance_report with input as domains(false, true, true)
+	some v in r.violations
+	contains(v, "CIS 2.1.8")
+}
+
+test_2_1_9_missing_dkim if {
+	r := defender.compliance_report with input as domains(true, false, true)
+	some v in r.violations
+	contains(v, "CIS 2.1.9")
+}
+
+test_2_1_10_missing_dmarc if {
+	r := defender.compliance_report with input as domains(true, true, false)
+	some v in r.violations
+	contains(v, "CIS 2.1.10")
+}
+
+test_all_mail_auth_present_passes if {
+	r := defender.compliance_report with input as domains(true, true, true)
+	r.compliant == true
+}
+
+# ── CIS 3.1.1 -- unified audit log ────────────────────────────────────
+
+test_3_1_1_audit_log_unavailable if {
+	r := purview.compliance_report with input as {"purview": {"audit_log_accessible": false}}
+	r.compliant == false
+	some v in r.violations
+	contains(v, "CIS 3.1.1")
+}
+
+test_3_1_1_audit_log_available_passes if {
+	r := purview.compliance_report with input as {"purview": {"audit_log_accessible": true}}
+	r.compliant == true
+}
+
+# ── CIS 5.2.2.x / 5.3.1 -- Conditional Access and PIM ─────────────────
+
+ca_tenant(policies, pim) := {"identity": {
+	"conditional_access_policies": policies,
+	"pim_available": pim,
+}}
+
+mfa_all_users := {
+	"id": "p1",
+	"state": "enabled",
+	"conditions": {"users": {"includeUsers": ["All"], "includeRoles": []}, "clientAppTypes": ["all"]},
+	"grant_controls": {"builtInControls": ["mfa"]},
+}
+
+mfa_admins := {
+	"id": "p2",
+	"state": "enabled",
+	"conditions": {"users": {"includeUsers": [], "includeRoles": ["62e90394-role"]}, "clientAppTypes": ["all"]},
+	"grant_controls": {"builtInControls": ["mfa"]},
+}
+
+block_legacy := {
+	"id": "p3",
+	"state": "enabled",
+	"conditions": {"users": {"includeUsers": ["All"], "includeRoles": []}, "clientAppTypes": ["exchangeActiveSync", "other"]},
+	"grant_controls": {"builtInControls": ["block"]},
+}
+
+test_5_2_2_2_no_mfa_for_all_users if {
+	r := entra.compliance_report with input as ca_tenant([mfa_admins, block_legacy], true)
+	some v in r.violations
+	contains(v, "CIS 5.2.2.2")
+}
+
+test_5_2_2_3_legacy_auth_not_blocked if {
+	r := entra.compliance_report with input as ca_tenant([mfa_all_users, mfa_admins], true)
+	some v in r.violations
+	contains(v, "CIS 5.2.2.3")
+}
+
+test_5_3_1_pim_not_in_use if {
+	r := entra.compliance_report with input as ca_tenant([mfa_all_users, mfa_admins, block_legacy], false)
+	some v in r.violations
+	contains(v, "CIS 5.3.1")
+}
+
+test_entra_fully_configured_passes if {
+	r := entra.compliance_report with input as ca_tenant([mfa_all_users, mfa_admins, block_legacy], true)
+	r.compliant == true
+	count(r.violations) == 0
+}
+
+# A policy that is present but disabled must not satisfy the control.
+test_disabled_policy_does_not_satisfy_control if {
+	disabled := object.union(mfa_all_users, {"state": "disabled"})
+	r := entra.compliance_report with input as ca_tenant([disabled], true)
+	some v in r.violations
+	contains(v, "CIS 5.2.2.2")
+}
+
+# ── CIS 6.1.1 -- mailbox auditing ─────────────────────────────────────
+
+test_6_1_1_audit_disabled_on_sampled_mailboxes if {
+	r := exchange.compliance_report with input as {"exchange": {"mailbox_audit_summary": {
+		"sampled": 10, "audit_enabled": 7, "audit_disabled": 3, "evaluable": true,
+	}}}
+	r.compliant == false
+	some v in r.violations
+	contains(v, "CIS 6.1.1")
+}
+
+test_6_1_1_all_audited_passes if {
+	r := exchange.compliance_report with input as {"exchange": {"mailbox_audit_summary": {
+		"sampled": 10, "audit_enabled": 10, "audit_disabled": 0, "evaluable": true,
+	}}}
+	r.compliant == true
+}
+
+test_6_1_1_declares_proxy_evidence if {
+	# The collection limit must stay visible in the report -- a reader has
+	# to be able to see that this is weaker than a PowerShell-sourced result.
+	r := exchange.compliance_report with input as {}
+	contains(r.evidence_strength["6.1.1"], "proxy")
+}
+
+# ── CIS 7.2.x -- SharePoint sharing ───────────────────────────────────
+
+sp(cap, link, perm, legacy) := {"sharepoint": {
+	"settings_reachable": true,
+	"sharing_capability": cap,
+	"default_sharing_link_type": link,
+	"default_link_permission": perm,
+	"legacy_auth_protocols_enabled": legacy,
+}}
+
+test_7_2_1_legacy_auth_enabled if {
+	r := sharepoint.compliance_report with input as sp("Disabled", "Internal", "View", true)
+	some v in r.violations
+	contains(v, "CIS 7.2.1")
+}
+
+test_7_2_6_most_permissive_sharing if {
+	r := sharepoint.compliance_report with input as sp("ExternalUserAndGuestSharing", "Internal", "View", false)
+	some v in r.violations
+	contains(v, "CIS 7.2.6")
+}
+
+test_7_2_7_anonymous_default_link if {
+	r := sharepoint.compliance_report with input as sp("Disabled", "AnonymousAccess", "View", false)
+	some v in r.violations
+	contains(v, "CIS 7.2.7")
+}
+
+test_7_2_11_default_link_permission_edit if {
+	r := sharepoint.compliance_report with input as sp("Disabled", "Internal", "Edit", false)
+	some v in r.violations
+	contains(v, "CIS 7.2.11")
+}
+
+test_sharepoint_hardened_passes if {
+	r := sharepoint.compliance_report with input as sp("Disabled", "Internal", "View", false)
+	r.compliant == true
+}
+
+# ── Orchestrator accounting ───────────────────────────────────────────
+
+test_orchestrator_reports_partial_coverage_honestly if {
+	r := main.compliance_report with input as {}
+	r.benchmark_total_controls == 160
+	r.controls_evaluated == 14
+	r.controls_not_evaluated == 146
+	count(r.sections_not_evaluated) == 3
+}
+
+test_orchestrator_exposes_no_bare_compliant_field if {
+	# Reading `compliant` from a 14-of-160 assessment would be misleading,
+	# so the orchestrator must not offer one. Assert on the key set --
+	# referencing a statically-absent field is a compile error, not a test.
+	r := main.compliance_report with input as {}
+	not "compliant" in object.keys(r)
+	"assessed_controls_compliant" in object.keys(r)
+}
+
+test_orchestrator_scopes_its_verdict_to_evaluated_controls if {
+	r := main.compliance_report with input as {}
+	r.assessed_controls_compliant == false
+	contains(r.interpretation, "partial assessment")
+}
+
+test_every_evaluated_id_is_reported if {
+	r := main.compliance_report with input as {}
+	count(r.evaluated_control_ids) == r.controls_evaluated
+}

--- a/scripts/check_cis_ids.py
+++ b/scripts/check_cis_ids.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Assert that every CIS control id cited in a Rego violation message
+actually exists in the benchmark.
+
+This is the guard for the defect found on 2026-08-14: the original
+cis_m365 modules invented their own section topology, so five of seven
+modules cited control numbers that name a different requirement than the
+one being evaluated. Unit tests could not catch it -- they assert against
+the same invented numbers. Only a check against the benchmark's own
+enumeration can.
+
+Usage:
+    check_cis_ids.py --enumeration <enum.json> --policy-dir <dir> [--prefix CIS]
+
+Exit 0 if every cited id is in the enumeration, 1 otherwise.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+
+STOPWORDS = frozenset(
+    """ensure is are be set to the a an of on off and or not with for in that
+    only has have been configured enable enabled disable disabled restrict
+    restricted allow allowed default defaults policy policies use used using
+    all any from at by it its this these those than then which who whom""".split()
+)
+WORD = re.compile(r"[a-z0-9']+")
+
+
+def keywords(text: str) -> set[str]:
+    return {w for w in WORD.findall(text.lower()) if w not in STOPWORDS and len(w) > 2}
+
+
+def load_enumeration(path: pathlib.Path):
+    """Accept either enumeration form.
+
+    The public index carries `title_keywords` (a derived keyword digest)
+    instead of verbatim CIS titles, so that the library can ship the guard
+    without redistributing portions of the benchmark. The full form carries
+    `title` and is kept outside the public repo. Both support the coherence
+    check, which only ever compares keyword sets.
+    """
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    kw, display = {}, {}
+    for r in doc["recommendations"]:
+        cid = r["control_id"]
+        if "title" in r:
+            kw[cid] = keywords(r["title"])
+            display[cid] = r["title"]
+        else:
+            kw[cid] = set(r.get("title_keywords", []))
+            display[cid] = "keywords: " + ", ".join(sorted(kw[cid])[:6])
+    label = f"{doc['benchmark']} v{doc['version']}"
+    return kw, display, label
+
+
+def scan(policy_dir: pathlib.Path, prefix: str):
+    """Yield (file, line_no, control_id) for every cited id.
+
+    Matches the house convention for violation messages, e.g.
+        msg := "CIS 1.1.1: Ensure Administrative accounts are cloud-only"
+    """
+    pattern = re.compile(rf"\b{re.escape(prefix)}\s+(\d+(?:\.\d+)+)\s*:?\s*(.*)")
+    for rego in sorted(policy_dir.rglob("*.rego")):
+        if rego.name.startswith("test_") or rego.name.endswith("_test.rego"):
+            continue
+        for n, line in enumerate(rego.read_text(encoding="utf-8").splitlines(), 1):
+            for m in pattern.finditer(line):
+                yield rego, n, m.group(1), m.group(2).rstrip('"').strip()
+
+
+SECTION_DECL = re.compile(r'"section":\s*"(\d+)"')
+SECTION_TOTAL = re.compile(r'"section_total_controls":\s*(\d+)')
+
+
+def check_section_totals(policy_dir: pathlib.Path, enum_path: pathlib.Path):
+    """Each section module hardcodes `section_total_controls`. Nothing else
+    ties that number to the benchmark, so regenerating the enumeration could
+    silently leave the modules claiming stale denominators -- the same drift
+    class this guard exists to prevent. Cross-check them.
+
+    Returns a list of (file, section, declared, actual) mismatches.
+    """
+    doc = json.loads(enum_path.read_text(encoding="utf-8"))
+    actual: dict[str, int] = {}
+    for r in doc["recommendations"]:
+        key = str(r["section"])
+        actual[key] = actual.get(key, 0) + 1
+
+    problems = []
+    for rego in sorted(policy_dir.rglob("*.rego")):
+        if rego.name.startswith("test_") or rego.name.endswith("_test.rego"):
+            continue
+        text = rego.read_text(encoding="utf-8")
+        sec = SECTION_DECL.search(text)
+        tot = SECTION_TOTAL.search(text)
+        if not sec or not tot:
+            continue
+        declared, real = int(tot.group(1)), actual.get(sec.group(1))
+        if real is None or declared != real:
+            problems.append((rego, sec.group(1), declared, real))
+    return problems
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--enumeration", required=True, type=pathlib.Path)
+    ap.add_argument("--policy-dir", required=True, type=pathlib.Path)
+    ap.add_argument("--prefix", default="CIS")
+    args = ap.parse_args()
+
+    kw, display, label = load_enumeration(args.enumeration)
+    cited = list(scan(args.policy_dir, args.prefix))
+    if not cited:
+        print(f"no {args.prefix} ids cited under {args.policy_dir} -- nothing to check")
+        return 0
+
+    distinct = {c for _, _, c, _ in cited}
+    print(f"benchmark : {label} ({len(kw)} recommendations)")
+    print(f"policies  : {args.policy_dir}")
+    print(f"citations : {len(cited)} ({len(distinct)} distinct ids)\n")
+
+    # Check 1: the cited id must exist at all.
+    unknown = [(f, n, c) for f, n, c, _ in cited if c not in kw]
+
+    # Check 2 -- the one that actually catches the 2026-08-14 defect. An id
+    # can exist and still be the WRONG id: 'CIS 1.1.1: Security Defaults...'
+    # cites a real control that is named 'Ensure Administrative accounts are
+    # cloud-only'. Require the message to share at least one substantive word
+    # with the benchmark's own title for that id.
+    incoherent = []
+    for f, n, c, msg in cited:
+        if c not in kw or not msg:
+            continue
+        if not (keywords(msg) & kw[c]):
+            incoherent.append((f, n, c, msg, display[c]))
+
+    if unknown:
+        print(f"FAIL [1/2]: {len(unknown)} citation(s) reference ids absent from the benchmark")
+        by_file: dict[pathlib.Path, list[tuple[int, str]]] = {}
+        for f, n, c in unknown:
+            by_file.setdefault(f, []).append((n, c))
+        for f in sorted(by_file):
+            print(f"  {f.name}")
+            for n, c in by_file[f]:
+                print(f"    line {n}: {args.prefix} {c}  -- no such control")
+        print()
+
+    if incoherent:
+        print(f"FAIL [2/2]: {len(incoherent)} citation(s) cite a real id whose")
+        print("            benchmark title shares no keyword with the message")
+        for f, n, c, msg, title in incoherent:
+            print(f"  {f.name}:{n}")
+            print(f"    cites   : {args.prefix} {c} -- {title!r}")
+            print(f"    message : {msg[:88]!r}")
+        print()
+
+    # Check 3: declared per-section denominators must match the benchmark.
+    drift = check_section_totals(args.policy_dir, args.enumeration)
+    if drift:
+        print(f"FAIL [3/3]: {len(drift)} module(s) declare a stale section_total_controls")
+        for f, sec, declared, real in drift:
+            print(f"  {f.name}: section {sec} declares {declared}, benchmark has {real}")
+        print()
+
+    if unknown or incoherent or drift:
+        print(
+            "Auditors read violation messages, not the source. A message citing a\n"
+            "control number that names a different requirement is an evidence defect,\n"
+            "and unit tests cannot catch it -- they assert the same wrong numbers."
+        )
+        return 1
+
+    print(f"OK: all {len(distinct)} distinct ids exist in {label} and are coherent")
+    print(f"OK: per-section control totals match the benchmark")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/parse_m365_v7.py
+++ b/scripts/parse_m365_v7.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Extract the CIS Microsoft 365 Foundations Benchmark v7.0.0 control
+enumeration from the official PDF.
+
+Produces the authoritative (section, control_id, title, assessment,
+levels) set that every m365_v7 Rego violation message must cite.
+
+Two-source strategy, because neither source alone is trustworthy:
+
+  * The Appendix summary table is the COMPLETE list, but its rows wrap
+    across lines and carry \\uf06f checkbox glyphs.
+  * The Recommendations body carries Profile Applicability (E3/E5 Level
+    1/2), but its headings also wrap, so they cannot be matched as
+    single lines.
+
+So: take ids/titles/assessment from the summary table by accumulating
+wrapped rows, take levels from the body by anchoring on each known id,
+and assert the two agree on the id set.
+
+Usage:
+    pdftotext -layout CIS_Microsoft_365_Foundations_Benchmark_v7.0.0.pdf m365_v7.txt
+    python3 parse_m365_v7.py m365_v7.txt
+
+The PDF itself is NOT redistributable (CIS terms of use). This script
+reads a local copy; it does not vendor the benchmark.
+"""
+import json
+import re
+import sys
+
+FORM_FEED = "\x0c"      # prefixes the first line of every page
+CHECKBOX = ""     # summary table Yes/No boxes; private-use glyph
+
+# Mirrors check_cis_ids.py -- keep the two in sync.
+STOPWORDS = frozenset(
+    """ensure is are be set to the a an of on off and or not with for in that
+    only has have been configured enable enabled disable disabled restrict
+    restricted allow allowed default defaults policy policies use used using
+    all any from at by it its this these those than then which who whom""".split()
+)
+_WORD = re.compile(r"[a-z0-9']+")
+
+
+def keywords(text):
+    return {w for w in _WORD.findall(text.lower()) if w not in STOPWORDS and len(w) > 2}
+
+
+ROW = re.compile(r"^(\d+(?:\.\d+)+)\s+(\S.*?)\s*$")
+SECTION = re.compile(r"^(\d+)\s+([A-Z][A-Za-z0-9 &'/-]+?)\s*$")
+ASSESS = re.compile(r"\((Automated|Manual)\)")
+LEVEL = re.compile(r"^\s*[•·*-]\s*(E\d)\s+Level\s+(\d)\s*$")
+# With -layout, the repeating page header renders as ONE line carrying
+# several column captions ("CIS Benchmark Recommendation ... Set"), not as
+# separate lines -- so match on any line containing a caption, not on
+# whole-line equality. Getting this wrong silently appends page furniture
+# to a wrapped title and drops the recommendation.
+NOISE = re.compile(
+    r"^\s*(Page \d+\s*$|CIS Benchmark Recommendation|Correctly\s*$|Yes\s+No\s*$|Set\s*$)"
+)
+
+
+def load(path):
+    with open(path, encoding="utf-8") as fh:
+        text = fh.read()
+    return text.replace(FORM_FEED, "").replace(CHECKBOX, " ").split("\n")
+
+
+def marker_span(lines, start_marker, end_marker):
+    start = end = None
+    for i, ln in enumerate(lines):
+        s = ln.strip()
+        if start is None and s == start_marker:
+            start = i
+        elif start is not None and s == end_marker:
+            end = i
+            break
+    if start is None or end is None:
+        raise SystemExit(f"could not locate {start_marker!r}..{end_marker!r}")
+    return start, end
+
+
+def parse_summary(lines):
+    """Accumulate wrapped rows. A row is a recommendation iff its full
+    accumulated title ends with an (Automated)/(Manual) marker --
+    subsection headers such as '1.1 Users' never do. Depth is NOT a
+    usable discriminator: section 4 uses two-level ids (4.1, 4.2) while
+    every other section uses three."""
+    sections, pending, out = {}, None, []
+
+    def flush():
+        if pending is None:
+            return
+        cid, parts = pending
+        title = " ".join(p.strip() for p in parts if p.strip()).strip()
+        m = ASSESS.search(title)
+        if not m:
+            return  # a subsection header ('1.1 Users'), not a recommendation
+        # Truncate at the marker rather than anchoring to end-of-string:
+        # page furniture can survive the noise filter and trail the title.
+        out.append(
+            {
+                "control_id": cid,
+                "section": int(cid.split(".")[0]),
+                "title": title[: m.start()].strip(),
+                "assessment": m.group(1),
+                "levels": [],
+            }
+        )
+
+    for ln in lines:
+        if NOISE.match(ln) or not ln.strip():
+            continue
+        sec = SECTION.match(ln)
+        if sec and int(sec.group(1)) <= 20:
+            flush()
+            pending = None
+            sections[int(sec.group(1))] = sec.group(2).strip()
+            continue
+        row = ROW.match(ln)
+        if row:
+            flush()
+            pending = (row.group(1), [row.group(2)])
+            continue
+        if pending is not None:
+            pending[1].append(ln)
+    flush()
+    return sections, out
+
+
+def parse_levels(lines, ids):
+    """Anchor on each known id at the start of a body line, then take the
+    Profile Applicability bullets that follow before the next id."""
+    levels = {cid: [] for cid in ids}
+    current = None
+    for ln in lines:
+        row = ROW.match(ln)
+        if row and row.group(1) in levels:
+            current = row.group(1)
+            continue
+        lv = LEVEL.match(ln)
+        if lv and current:
+            label = f"{lv.group(1)} Level {lv.group(2)}"
+            if label not in levels[current]:
+                levels[current].append(label)
+    return levels
+
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else "m365_v7.txt"
+    lines = load(path)
+
+    s_start, s_end = marker_span(lines, "Appendix: Summary Table", "Appendix: Change History")
+    sections, recs = parse_summary(lines[s_start:s_end])
+
+    b_start, _ = marker_span(lines, "Recommendations", "Appendix: Summary Table")
+    levels = parse_levels(lines[b_start:s_start], {r["control_id"] for r in recs})
+    for r in recs:
+        r["levels"] = levels.get(r["control_id"], [])
+        r["section_name"] = sections.get(r["section"], "")
+
+    meta = {
+        "benchmark": "CIS Microsoft 365 Foundations Benchmark",
+        "version": "7.0.0",
+        "released": "2026-05-20",
+        "source": "official CIS PDF (Appendix summary table + Recommendations body)",
+        "sections": {str(k): v for k, v in sorted(sections.items())},
+        "total_recommendations": len(recs),
+    }
+
+    # Full form -- carries verbatim CIS recommendation titles. CIS terms of
+    # use require contacting CIS Legal before reproducing portions of a
+    # Benchmark in third-party documentation, so this form must NOT be
+    # committed to the public rego_policy_libraries repo.
+    with open("cis_m365_v7_enumeration.json", "w", encoding="utf-8") as fh:
+        json.dump({**meta, "recommendations": recs}, fh, indent=2)
+
+    # Public form -- control ids, section names, assessment status, profile
+    # levels, and a KEYWORD DIGEST of each title. The digest is derived data
+    # (a sorted set of substantive words), not the recommendation text, and
+    # it is all the coherence guard needs. Safe for the public library.
+    public = [
+        {
+            "control_id": r["control_id"],
+            "section": r["section"],
+            "section_name": r["section_name"],
+            "assessment": r["assessment"],
+            "levels": r["levels"],
+            "title_keywords": sorted(keywords(r["title"])),
+        }
+        for r in recs
+    ]
+    with open("cis_m365_v7_index.json", "w", encoding="utf-8") as fh:
+        json.dump({**meta, "form": "keyword-digest (no verbatim CIS titles)",
+                   "recommendations": public}, fh, indent=2)
+
+    counts = {}
+    for r in recs:
+        counts[r["section"]] = counts.get(r["section"], 0) + 1
+    print(f"sections: {len(sections)}")
+    for k in sorted(sections):
+        print(f"  {k}  {sections[k]:<34} {counts.get(k, 0):>3}")
+    print(f"TOTAL: {len(recs)}")
+    nolevel = [r["control_id"] for r in recs if not r["levels"]]
+    print(f"levels resolved: {len(recs) - len(nolevel)}/{len(recs)}")
+    if nolevel:
+        print(f"  no level: {nolevel[:10]}{'...' if len(nolevel) > 10 else ''}")
+    # contiguity check: within each section, ids should form a dense tree
+    ids = sorted(r["control_id"] for r in recs)
+    print(f"first: {ids[0]}  last: {ids[-1]}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

`benchmarks/cis/saas/m365/` invented its own section topology. Measured against the real benchmark, of its **46 control-id citations, 20 name ids that do not exist** and **22 name real ids whose requirement is unrelated to the message** — only **3 distinct ids of 40** are correct.

Its 36/36 passing tests do not contradict this: they assert against the same wrong numbers.

The benchmark has **9 sections, not 7**. Entra is 5 (not 1), Exchange 6 (not 4), SharePoint 7 (not 6), Teams 8 (not 7), Fabric 9 (not 5) — and sub-numbering is independently wrong even where a section number happens to match (our `2.1.2` is Safe Links; the real `2.1.2` is Common Attachment Types Filter).

Violation messages are what auditors read. A message citing a control number that names a different requirement is an evidence defect.

## What

`benchmarks/cis/saas/m365_v7/` — the existing tree is **deprecated, not mutated**, per repo convention.

- **6 section modules**, covering **14 of the benchmark's 160** recommendations; every id verified against the benchmark's own enumeration.
- **Orchestrator** reporting `assessed_controls_compliant` scoped to the evaluated ids — deliberately **no tenant-wide `compliant`**, because a 14-of-160 assessment has no business emitting a benchmark verdict.
- **Fail-closed throughout**: absent facts raise a violation stating the control could not be evaluated. A missing fact never reads as a pass.
- **COVERAGE.md** stating per-section coverage and why it is bounded by *fact collection*, not policy — four of seven collectors return only Microsoft Secure Score, which is Microsoft's own scoring model, not the CIS control set.
- **Security Defaults dropped, not renumbered**: v7.0.0 has no such control. Inventing a plausible id is the defect being fixed.

## Guard

`scripts/check_cis_ids.py` applies three checks:

1. **Existence** — every cited id appears in the benchmark.
2. **Coherence** — the message shares a substantive word with the benchmark's title for that id. This is what catches `"CIS 1.1.1: Security Defaults…"` when `1.1.1` is *"Ensure Administrative accounts are cloud-only"*.
3. **Denominators** — each module's `section_total_controls` matches the enumeration, so regenerating it can't silently leave stale totals.

| | old `m365/` | new `m365_v7/` |
|---|---|---|
| ids that don't exist | 20 | 0 |
| ids naming a different requirement | 22 | 0 |
| correct | **4 of 46** | **35 of 35** |

CI asserts **both** directions — green on v7, and a step that fails if the guard ever stops rejecting the deprecated tree.

`data/cis_m365_v7_index.json` ships as a **keyword digest with no verbatim CIS titles**: CIS terms of use require contacting CIS Legal before reproducing portions of a benchmark, and this repo is public and Apache-2.0. The digest is derived data and is all the coherence check needs. `scripts/parse_m365_v7.py` regenerates it from a local PDF; the PDF is not vendored.

## CI fix (incidental, and significant)

The test step globbed `*_test.rego`, which matched **1 of 84** test files. The other 83 use the repo's documented `test_*.rego` convention and **had never run in CI**.

Now runs `opa test . --ignore .github` — **379 tests, all passing** — with a floor check so a future discovery regression fails loudly instead of looking green. The floor is set to the pre-existing count (348) rather than the current total, so branches without this tree still pass.

Whole-repo invocation also avoids false failures from cross-tree imports (`frameworks/compliance/cra` imports `enforcement/supply_chain/slsa_governance.rego`).

## Verification

- `opa test . --ignore .github` → **379/379**
- guard on `m365_v7` → pass (ids, coherence, denominators)
- guard on `m365/` → fails, by design
- orchestrator on empty input → populated object, fail-closed, 14/160

🤖 Generated with [Claude Code](https://claude.com/claude-code)