### PR TITLE
feat(cis/m365_v7): section 7 SharePoint complete via PnP.PowerShell

### DIFF
--- a/benchmarks/cis/saas/m365_v7/COVERAGE.md
+++ b/benchmarks/cis/saas/m365_v7/COVERAGE.md
@@ -1,8 +1,8 @@
 # CIS Microsoft 365 Foundations Benchmark v7.0.0 — coverage
 
-**Version:** v1.5
+**Version:** v1.6
 **Benchmark:** CIS Microsoft 365 Foundations Benchmark **v7.0.0**, released 2026-05-20
-**Evaluated:** **76 of 160** recommendations (**48%**)
+**Evaluated:** **90 of 160** recommendations (**56%**)
 **Requires attestation:** 6 (verified to have no app-only read path)
 **Unresolved:** 10 (parked pending a live-tenant probe during the POC)
 
@@ -17,7 +17,7 @@ modules themselves.
 | § | Section | Controls | Evaluated | Module |
 |---|---|---|---|---|
 | 1 | Microsoft 365 admin center | 15 | 9 | `admin_center_validation.rego` |
-| 2 | Microsoft Defender | 21 | 3 | `defender_validation.rego` |
+| 2 | Microsoft Defender | 21 | **17** | `defender_validation.rego` |
 | 3 | Microsoft Purview | 5 | 1 | `purview_validation.rego` |
 | 4 | Microsoft Intune admin center | 2 | 2 | `intune_validation.rego` |
 | 5 | Microsoft Entra admin center | 63 | 20 | `entra_validation.rego` |
@@ -25,13 +25,13 @@ modules themselves.
 | 7 | SharePoint admin center | 12 | **12** | `sharepoint_validation.rego` |
 | 8 | Microsoft Teams admin center | 17 | **16** | `teams_validation.rego` |
 | 9 | Microsoft Fabric | 12 | **0** | — |
-| | **Total** | **160** | **76** | |
+| | **Total** | **160** | **90** | |
 
 Evaluated ids: `1.1.1`, `1.1.3`, `1.1.4`, `1.2.1`, `1.3.1`, `1.3.2`, `1.3.4`,
 `1.3.5`, `1.3.7`, `4.1`, `4.2`, `2.1.8`, `2.1.9`, `2.1.10`, `3.1.1`, `5.2.2.1`,
 `5.2.2.2`, `5.2.2.3`, `5.3.1`, `6.1.1`, `7.2.1`, `7.2.6`, `7.2.7`, `7.2.11`.
 
-## Why coverage is 48%
+## Why coverage is 56%
 
 Coverage is bounded by **fact collection**, not by policy. The `aac.m365`
 collection currently issues ten Microsoft Graph calls. Four of its seven
@@ -45,7 +45,7 @@ recommendation. Those were not carried into v7.
 | 4 — Intune | **Now collected.** Requires the `DeviceManagementConfiguration.Read.All` application permission — without it both controls report unavailable, never pass. |
 | 8 — Teams | Collector returns a Teams app count and Secure Score. Real coverage needs Teams PowerShell or Graph beta. |
 | 9 — Fabric | Collector returns Secure Score. Fabric tenant settings are only exposed by the Fabric Admin REST API, not Graph. |
-| 2 — Defender (18 of 21) | Safe Links, Safe Attachments, anti-phishing, anti-spam and connection filtering need Exchange Online PowerShell. |
+| 2 — Defender (4 of 21) | **Now collected** via Exchange Online PowerShell. Only 2.2.1, 2.4.3 and 2.4.5 outstanding — all Manual in CIS with no PowerShell audit procedure. |
 | 5 — Entra (59 of 63) | Most section 5 controls need Graph endpoints the collector does not call yet; several are only on `/beta`, and `graph.py` pins `GRAPH_BASE` to `/v1.0`. |
 | 6 — Exchange | **Complete.** All 13 controls via Exchange Online PowerShell in `aac-m365-ee`. |
 

--- a/benchmarks/cis/saas/m365_v7/COVERAGE.md
+++ b/benchmarks/cis/saas/m365_v7/COVERAGE.md
@@ -1,8 +1,8 @@
 # CIS Microsoft 365 Foundations Benchmark v7.0.0 — coverage
 
-**Version:** v1.6
+**Version:** v1.7
 **Benchmark:** CIS Microsoft 365 Foundations Benchmark **v7.0.0**, released 2026-05-20
-**Evaluated:** **90 of 160** recommendations (**56%**)
+**Evaluated:** **96 of 160** recommendations (**60%**)
 **Requires attestation:** 6 (verified to have no app-only read path)
 **Unresolved:** 10 (parked pending a live-tenant probe during the POC)
 
@@ -16,22 +16,22 @@ modules themselves.
 
 | § | Section | Controls | Evaluated | Module |
 |---|---|---|---|---|
-| 1 | Microsoft 365 admin center | 15 | 9 | `admin_center_validation.rego` |
+| 1 | Microsoft 365 admin center | 15 | **11** | `admin_center_validation.rego` |
 | 2 | Microsoft Defender | 21 | **17** | `defender_validation.rego` |
-| 3 | Microsoft Purview | 5 | 1 | `purview_validation.rego` |
+| 3 | Microsoft Purview | 5 | **5** | `purview_validation.rego` |
 | 4 | Microsoft Intune admin center | 2 | 2 | `intune_validation.rego` |
 | 5 | Microsoft Entra admin center | 63 | 20 | `entra_validation.rego` |
 | 6 | Exchange admin center | 13 | **13** | `exchange_validation.rego` |
 | 7 | SharePoint admin center | 12 | **12** | `sharepoint_validation.rego` |
 | 8 | Microsoft Teams admin center | 17 | **16** | `teams_validation.rego` |
 | 9 | Microsoft Fabric | 12 | **0** | — |
-| | **Total** | **160** | **90** | |
+| | **Total** | **160** | **96** | |
 
 Evaluated ids: `1.1.1`, `1.1.3`, `1.1.4`, `1.2.1`, `1.3.1`, `1.3.2`, `1.3.4`,
 `1.3.5`, `1.3.7`, `4.1`, `4.2`, `2.1.8`, `2.1.9`, `2.1.10`, `3.1.1`, `5.2.2.1`,
 `5.2.2.2`, `5.2.2.3`, `5.3.1`, `6.1.1`, `7.2.1`, `7.2.6`, `7.2.7`, `7.2.11`.
 
-## Why coverage is 56%
+## Why coverage is 60%
 
 Coverage is bounded by **fact collection**, not by policy. The `aac.m365`
 collection currently issues ten Microsoft Graph calls. Four of its seven

--- a/benchmarks/cis/saas/m365_v7/COVERAGE.md
+++ b/benchmarks/cis/saas/m365_v7/COVERAGE.md
@@ -1,8 +1,8 @@
 # CIS Microsoft 365 Foundations Benchmark v7.0.0 — coverage
 
-**Version:** v1.3
+**Version:** v1.4
 **Benchmark:** CIS Microsoft 365 Foundations Benchmark **v7.0.0**, released 2026-05-20
-**Evaluated:** **52 of 160** recommendations (**33%**)
+**Evaluated:** **60 of 160** recommendations (**38%**)
 **Requires attestation:** 6 (verified to have no app-only read path)
 **Unresolved:** 10 (parked pending a live-tenant probe during the POC)
 
@@ -22,16 +22,16 @@ modules themselves.
 | 4 | Microsoft Intune admin center | 2 | 2 | `intune_validation.rego` |
 | 5 | Microsoft Entra admin center | 63 | 20 | `entra_validation.rego` |
 | 6 | Exchange admin center | 13 | **13** | `exchange_validation.rego` |
-| 7 | SharePoint admin center | 12 | 4 | `sharepoint_validation.rego` |
+| 7 | SharePoint admin center | 12 | **12** | `sharepoint_validation.rego` |
 | 8 | Microsoft Teams admin center | 17 | **0** | — |
 | 9 | Microsoft Fabric | 12 | **0** | — |
-| | **Total** | **160** | **52** | |
+| | **Total** | **160** | **60** | |
 
 Evaluated ids: `1.1.1`, `1.1.3`, `1.1.4`, `1.2.1`, `1.3.1`, `1.3.2`, `1.3.4`,
 `1.3.5`, `1.3.7`, `4.1`, `4.2`, `2.1.8`, `2.1.9`, `2.1.10`, `3.1.1`, `5.2.2.1`,
 `5.2.2.2`, `5.2.2.3`, `5.3.1`, `6.1.1`, `7.2.1`, `7.2.6`, `7.2.7`, `7.2.11`.
 
-## Why coverage is 25%
+## Why coverage is 38%
 
 Coverage is bounded by **fact collection**, not by policy. The `aac.m365`
 collection currently issues ten Microsoft Graph calls. Four of its seven
@@ -60,6 +60,11 @@ Two caveats remain, both surfaced at runtime under `evidence_strength`:
 - **`6.1.2` is sampled.** Mailbox audit actions are checked across a
   bounded sample, not every mailbox. The sample size and limit appear in
   the report so a reader can judge the result's strength.
+- **All of §7 uses `Get-PnPTenant`, not the `Get-SPOTenant` CIS documents.**
+  `Microsoft.Online.SharePoint.PowerShell` is Windows-only and cannot be
+  installed in a Linux execution environment — verified absent from
+  `aac-m365-ee`. The same CSOM tenant properties are read, but the tool is
+  not the benchmark's, and that is permanent rather than a gap to close.
 - **`5.1.2.1` uses `/beta`.** Microsoft documents `/beta` as subject to
   change and unsupported for production, and CIS marks the control Manual
   with no automated procedure — so this reaches past the benchmark's own

--- a/benchmarks/cis/saas/m365_v7/COVERAGE.md
+++ b/benchmarks/cis/saas/m365_v7/COVERAGE.md
@@ -1,8 +1,8 @@
 # CIS Microsoft 365 Foundations Benchmark v7.0.0 — coverage
 
-**Version:** v1.8
+**Version:** v1.9
 **Benchmark:** CIS Microsoft 365 Foundations Benchmark **v7.0.0**, released 2026-05-20
-**Evaluated:** **108 of 160** recommendations (**68%**)
+**Evaluated:** **122 of 160** recommendations (**76%**)
 **Requires attestation:** 6 (verified to have no app-only read path)
 **Unresolved:** 10 (parked pending a live-tenant probe during the POC)
 
@@ -20,18 +20,18 @@ modules themselves.
 | 2 | Microsoft Defender | 21 | **17** | `defender_validation.rego` |
 | 3 | Microsoft Purview | 5 | **5** | `purview_validation.rego` |
 | 4 | Microsoft Intune admin center | 2 | 2 | `intune_validation.rego` |
-| 5 | Microsoft Entra admin center | 63 | 20 | `entra_validation.rego` |
+| 5 | Microsoft Entra admin center | 63 | **34** | `entra_validation.rego` |
 | 6 | Exchange admin center | 13 | **13** | `exchange_validation.rego` |
 | 7 | SharePoint admin center | 12 | **12** | `sharepoint_validation.rego` |
 | 8 | Microsoft Teams admin center | 17 | **16** | `teams_validation.rego` |
 | 9 | Microsoft Fabric | 12 | **12** | `fabric_validation.rego` |
-| | **Total** | **160** | **108** | |
+| | **Total** | **160** | **122** | |
 
 Evaluated ids: `1.1.1`, `1.1.3`, `1.1.4`, `1.2.1`, `1.3.1`, `1.3.2`, `1.3.4`,
 `1.3.5`, `1.3.7`, `4.1`, `4.2`, `2.1.8`, `2.1.9`, `2.1.10`, `3.1.1`, `5.2.2.1`,
 `5.2.2.2`, `5.2.2.3`, `5.3.1`, `6.1.1`, `7.2.1`, `7.2.6`, `7.2.7`, `7.2.11`.
 
-## Why coverage is 68%
+## Why coverage is 76%
 
 Coverage is bounded by **fact collection**, not by policy. The `aac.m365`
 collection currently issues ten Microsoft Graph calls. Four of its seven

--- a/benchmarks/cis/saas/m365_v7/COVERAGE.md
+++ b/benchmarks/cis/saas/m365_v7/COVERAGE.md
@@ -1,8 +1,8 @@
 # CIS Microsoft 365 Foundations Benchmark v7.0.0 — coverage
 
-**Version:** v1.9
+**Version:** v2.0
 **Benchmark:** CIS Microsoft 365 Foundations Benchmark **v7.0.0**, released 2026-05-20
-**Evaluated:** **122 of 160** recommendations (**76%**)
+**Evaluated:** **133 of 160** recommendations (**83%**)
 **Requires attestation:** 6 (verified to have no app-only read path)
 **Unresolved:** 10 (parked pending a live-tenant probe during the POC)
 
@@ -20,18 +20,18 @@ modules themselves.
 | 2 | Microsoft Defender | 21 | **17** | `defender_validation.rego` |
 | 3 | Microsoft Purview | 5 | **5** | `purview_validation.rego` |
 | 4 | Microsoft Intune admin center | 2 | 2 | `intune_validation.rego` |
-| 5 | Microsoft Entra admin center | 63 | **34** | `entra_validation.rego` |
+| 5 | Microsoft Entra admin center | 63 | **45** | `entra_validation.rego` |
 | 6 | Exchange admin center | 13 | **13** | `exchange_validation.rego` |
 | 7 | SharePoint admin center | 12 | **12** | `sharepoint_validation.rego` |
 | 8 | Microsoft Teams admin center | 17 | **16** | `teams_validation.rego` |
 | 9 | Microsoft Fabric | 12 | **12** | `fabric_validation.rego` |
-| | **Total** | **160** | **122** | |
+| | **Total** | **160** | **133** | |
 
 Evaluated ids: `1.1.1`, `1.1.3`, `1.1.4`, `1.2.1`, `1.3.1`, `1.3.2`, `1.3.4`,
 `1.3.5`, `1.3.7`, `4.1`, `4.2`, `2.1.8`, `2.1.9`, `2.1.10`, `3.1.1`, `5.2.2.1`,
 `5.2.2.2`, `5.2.2.3`, `5.3.1`, `6.1.1`, `7.2.1`, `7.2.6`, `7.2.7`, `7.2.11`.
 
-## Why coverage is 76%
+## Why coverage is 83%
 
 Coverage is bounded by **fact collection**, not by policy. The `aac.m365`
 collection currently issues ten Microsoft Graph calls. Four of its seven

--- a/benchmarks/cis/saas/m365_v7/COVERAGE.md
+++ b/benchmarks/cis/saas/m365_v7/COVERAGE.md
@@ -1,8 +1,8 @@
 # CIS Microsoft 365 Foundations Benchmark v7.0.0 — coverage
 
-**Version:** v1.4
+**Version:** v1.5
 **Benchmark:** CIS Microsoft 365 Foundations Benchmark **v7.0.0**, released 2026-05-20
-**Evaluated:** **60 of 160** recommendations (**38%**)
+**Evaluated:** **76 of 160** recommendations (**48%**)
 **Requires attestation:** 6 (verified to have no app-only read path)
 **Unresolved:** 10 (parked pending a live-tenant probe during the POC)
 
@@ -23,15 +23,15 @@ modules themselves.
 | 5 | Microsoft Entra admin center | 63 | 20 | `entra_validation.rego` |
 | 6 | Exchange admin center | 13 | **13** | `exchange_validation.rego` |
 | 7 | SharePoint admin center | 12 | **12** | `sharepoint_validation.rego` |
-| 8 | Microsoft Teams admin center | 17 | **0** | — |
+| 8 | Microsoft Teams admin center | 17 | **16** | `teams_validation.rego` |
 | 9 | Microsoft Fabric | 12 | **0** | — |
-| | **Total** | **160** | **60** | |
+| | **Total** | **160** | **76** | |
 
 Evaluated ids: `1.1.1`, `1.1.3`, `1.1.4`, `1.2.1`, `1.3.1`, `1.3.2`, `1.3.4`,
 `1.3.5`, `1.3.7`, `4.1`, `4.2`, `2.1.8`, `2.1.9`, `2.1.10`, `3.1.1`, `5.2.2.1`,
 `5.2.2.2`, `5.2.2.3`, `5.3.1`, `6.1.1`, `7.2.1`, `7.2.6`, `7.2.7`, `7.2.11`.
 
-## Why coverage is 38%
+## Why coverage is 48%
 
 Coverage is bounded by **fact collection**, not by policy. The `aac.m365`
 collection currently issues ten Microsoft Graph calls. Four of its seven

--- a/benchmarks/cis/saas/m365_v7/COVERAGE.md
+++ b/benchmarks/cis/saas/m365_v7/COVERAGE.md
@@ -1,8 +1,8 @@
 # CIS Microsoft 365 Foundations Benchmark v7.0.0 — coverage
 
-**Version:** v1.7
+**Version:** v1.8
 **Benchmark:** CIS Microsoft 365 Foundations Benchmark **v7.0.0**, released 2026-05-20
-**Evaluated:** **96 of 160** recommendations (**60%**)
+**Evaluated:** **108 of 160** recommendations (**68%**)
 **Requires attestation:** 6 (verified to have no app-only read path)
 **Unresolved:** 10 (parked pending a live-tenant probe during the POC)
 
@@ -24,14 +24,14 @@ modules themselves.
 | 6 | Exchange admin center | 13 | **13** | `exchange_validation.rego` |
 | 7 | SharePoint admin center | 12 | **12** | `sharepoint_validation.rego` |
 | 8 | Microsoft Teams admin center | 17 | **16** | `teams_validation.rego` |
-| 9 | Microsoft Fabric | 12 | **0** | — |
-| | **Total** | **160** | **96** | |
+| 9 | Microsoft Fabric | 12 | **12** | `fabric_validation.rego` |
+| | **Total** | **160** | **108** | |
 
 Evaluated ids: `1.1.1`, `1.1.3`, `1.1.4`, `1.2.1`, `1.3.1`, `1.3.2`, `1.3.4`,
 `1.3.5`, `1.3.7`, `4.1`, `4.2`, `2.1.8`, `2.1.9`, `2.1.10`, `3.1.1`, `5.2.2.1`,
 `5.2.2.2`, `5.2.2.3`, `5.3.1`, `6.1.1`, `7.2.1`, `7.2.6`, `7.2.7`, `7.2.11`.
 
-## Why coverage is 60%
+## Why coverage is 68%
 
 Coverage is bounded by **fact collection**, not by policy. The `aac.m365`
 collection currently issues ten Microsoft Graph calls. Four of its seven

--- a/benchmarks/cis/saas/m365_v7/admin_center_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/admin_center_validation.rego
@@ -164,6 +164,43 @@ violation contains msg if {
 	msg := "CIS 1.1.1: administrative accounts were not collected, so whether they are cloud-only could not be established -- section 1 was not evaluated (this is not a pass)"
 }
 
+
+# ── Section 1 controls sourced from Exchange Online PowerShell ────────
+# 1.3.6 and 1.3.9 are section 1 controls whose settings live on
+# Get-OrganizationConfig, which the Exchange collector already fetches.
+# Reading them from input.exchange rather than issuing a second Exchange
+# session for two fields is deliberate; the coupling is documented here so
+# it is not mistaken for a stray dependency.
+
+default exchange_org_available := false
+
+exchange_org_available if {
+	input.exchange.collected == true
+	not input.exchange.unavailable.organization_config
+	_ := input.exchange.organization_config
+}
+
+# CIS 1.3.6 -- customer lockbox.
+violation contains msg if {
+	exchange_org_available
+	input.exchange.organization_config.CustomerLockBoxEnabled == false
+	msg := "CIS 1.3.6: the customer lockbox feature is not enabled, so Microsoft support can access tenant content without explicit per-request approval"
+}
+
+# CIS 1.3.9 -- shared bookings pages.
+violation contains msg if {
+	exchange_org_available
+	input.exchange.organization_config.BookingsEnabled == true
+	input.exchange.organization_config.BookingsAuthEnabled == false
+	msg := "CIS 1.3.9: shared bookings pages are not restricted to select users -- Bookings is enabled without requiring authentication, so pages are reachable anonymously"
+}
+
+violation contains msg if {
+	input.exchange.collected == true
+	input.exchange.unavailable.organization_config
+	msg := sprintf("CIS 1.3.6: whether the customer lockbox feature is enabled could not be evaluated -- %s (this is not a pass)", [input.exchange.unavailable.organization_config])
+}
+
 compliant if {
 	collected
 	count(violation) == 0
@@ -175,8 +212,8 @@ compliance_report := {
 	"section": "1",
 	"name": "Microsoft 365 admin center",
 	"section_total_controls": 15,
-	"controls_evaluated": 9,
-	"controls": ["1.1.1", "1.1.3", "1.1.4", "1.2.1", "1.3.1", "1.3.2", "1.3.4", "1.3.5", "1.3.7"],
+	"controls_evaluated": 11,
+	"controls": ["1.1.1", "1.1.3", "1.1.4", "1.2.1", "1.3.1", "1.3.2", "1.3.4", "1.3.5", "1.3.6", "1.3.7", "1.3.9"],
 	"facts_present": collected,
 	"unavailable_facts": unavailable,
 	"violations": violation,

--- a/benchmarks/cis/saas/m365_v7/cis_m365_v7_complete.rego
+++ b/benchmarks/cis/saas/m365_v7/cis_m365_v7_complete.rego
@@ -17,6 +17,7 @@ import data.cis_m365_v7.attestation
 import data.cis_m365_v7.defender
 import data.cis_m365_v7.entra
 import data.cis_m365_v7.exchange
+import data.cis_m365_v7.fabric
 import data.cis_m365_v7.intune
 import data.cis_m365_v7.purview
 import data.cis_m365_v7.sharepoint
@@ -28,14 +29,7 @@ BENCHMARK_TOTAL_CONTROLS := 160
 # Sections with no fact collector at all. Declared explicitly so that a
 # reader (or an auditor) sees the gap rather than inferring coverage from
 # the absence of violations.
-not_evaluated := [
-	{
-		"section": "9",
-		"name": "Microsoft Fabric",
-		"section_total_controls": 12,
-		"reason": "collector returns only Microsoft Secure Score; Fabric tenant settings require the Fabric Admin REST API, not Graph",
-	},
-]
+not_evaluated := []
 
 section_reports := [
 	admin_center.compliance_report,
@@ -46,6 +40,7 @@ section_reports := [
 	exchange.compliance_report,
 	sharepoint.compliance_report,
 	teams.compliance_report,
+	fabric.compliance_report,
 ]
 
 # array.concat takes exactly two arrays -- fold rather than vararg.

--- a/benchmarks/cis/saas/m365_v7/cis_m365_v7_complete.rego
+++ b/benchmarks/cis/saas/m365_v7/cis_m365_v7_complete.rego
@@ -20,6 +20,7 @@ import data.cis_m365_v7.exchange
 import data.cis_m365_v7.intune
 import data.cis_m365_v7.purview
 import data.cis_m365_v7.sharepoint
+import data.cis_m365_v7.teams
 import rego.v1
 
 BENCHMARK_TOTAL_CONTROLS := 160
@@ -28,12 +29,6 @@ BENCHMARK_TOTAL_CONTROLS := 160
 # reader (or an auditor) sees the gap rather than inferring coverage from
 # the absence of violations.
 not_evaluated := [
-	{
-		"section": "8",
-		"name": "Microsoft Teams admin center",
-		"section_total_controls": 17,
-		"reason": "collector returns only a Teams app count and Microsoft Secure Score; neither establishes a CIS control",
-	},
 	{
 		"section": "9",
 		"name": "Microsoft Fabric",
@@ -50,6 +45,7 @@ section_reports := [
 	entra.compliance_report,
 	exchange.compliance_report,
 	sharepoint.compliance_report,
+	teams.compliance_report,
 ]
 
 # array.concat takes exactly two arrays -- fold rather than vararg.

--- a/benchmarks/cis/saas/m365_v7/defender_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/defender_validation.rego
@@ -11,11 +11,22 @@
 #                                        spf_present, dkim_present,
 #                                        dmarc_present}
 #
-# NOT EVALUATED in this module: every Defender policy control (Safe Links,
-# Safe Attachments, anti-phishing, anti-spam, connection filtering --
-# 2.1.1 through 2.1.7 and 2.1.11 onward). The current collector returns
-# only Microsoft Secure Score, which is a different control set from the
-# CIS benchmark and cannot establish these controls. See COVERAGE.md.
+# The policy controls (Safe Links, Safe Attachments, anti-phishing,
+# anti-spam, connection filtering) come from Exchange Online PowerShell
+# via aac.m365.m365_defender_ps_facts. That REPLACES the Microsoft Secure
+# Score wrapper the pre-v7 library used: Secure Score is Microsoft's own
+# scoring model with its own control set, and an implementationStatus
+# from it does not establish a CIS recommendation.
+#
+# NOT EVALUATED: 2.2.1, 2.4.3 and 2.4.5. CIS marks all three Manual with
+# no PowerShell audit procedure; they are reported as unresolved by the
+# attestation module.
+#
+# Input contract (aac.m365.m365_defender_ps_facts) -- see that module for
+# the control-to-cmdlet mapping. input.defender.unavailable records any
+# cmdlet the tenant does not expose (a tenant without Defender for Office
+# 365 lacks the ATP cmdlets entirely), so those controls report as
+# unevaluable rather than compliant.
 
 package cis_m365_v7.defender
 
@@ -55,6 +66,171 @@ violation contains msg if {
 	msg := "CIS 2.1.8: verified-domain facts not collected -- SPF, DKIM and DMARC controls could not be evaluated (this is not a pass)"
 }
 
+
+# ── Defender policy controls (Exchange Online PowerShell) ─────────────
+
+default defender_unavailable := {}
+
+defender_unavailable := input.defender.unavailable
+
+default defender_collected := false
+
+defender_collected if {
+	input.defender.collected == true
+}
+
+policy_available(key) if {
+	defender_collected
+	not defender_unavailable[key]
+}
+
+# CIS 2.1.1 -- Safe Links for Office applications.
+violation contains msg if {
+	policy_available("safe_links_policies")
+	some p in input.defender.safe_links_policies
+	p.EnableSafeLinksForOffice == false
+	msg := sprintf("CIS 2.1.1: Safe Links policy '%s' does not enable Safe Links for Office applications, so links in documents are not rewritten or checked at click time", [p.Name])
+}
+
+# CIS 2.1.2 -- Common Attachment Types Filter.
+violation contains msg if {
+	policy_available("malware_filter_policies")
+	some p in input.defender.malware_filter_policies
+	p.EnableFileFilter == false
+	msg := sprintf("CIS 2.1.2: malware filter policy '%s' has the common attachment types filter disabled, so executable attachment types are not blocked by type", [p.Identity])
+}
+
+# CIS 2.1.3 -- notify internal senders of malware.
+violation contains msg if {
+	policy_available("malware_filter_policies")
+	some p in input.defender.malware_filter_policies
+	p.EnableInternalSenderAdminNotifications == false
+	msg := sprintf("CIS 2.1.3: malware filter policy '%s' does not send notifications for internal users sending malware, so a compromised internal mailbox goes unnoticed", [p.Identity])
+}
+
+# CIS 2.1.4 -- Safe Attachments policy enabled.
+violation contains msg if {
+	policy_available("safe_attachment_policies")
+	count(input.defender.safe_attachment_policies) == 0
+	msg := "CIS 2.1.4: no Safe Attachments policy is enabled, so attachments are not detonated before delivery"
+}
+
+violation contains msg if {
+	policy_available("safe_attachment_policies")
+	some p in input.defender.safe_attachment_policies
+	p.Enable == false
+	msg := sprintf("CIS 2.1.4: Safe Attachments policy '%s' exists but is not enabled", [p.Name])
+}
+
+# CIS 2.1.5 -- Safe Attachments for SharePoint, OneDrive and Teams.
+violation contains msg if {
+	policy_available("atp_policy_for_o365")
+	input.defender.atp_policy_for_o365.EnableATPForSPOTeamsODB == false
+	msg := "CIS 2.1.5: Safe Attachments for SharePoint, OneDrive and Microsoft Teams is not enabled, so files stored there are not detonated"
+}
+
+# CIS 2.1.6 -- spam policies notify administrators.
+violation contains msg if {
+	policy_available("outbound_spam_policies")
+	some p in input.defender.outbound_spam_policies
+	p.NotifyOutboundSpam == false
+	msg := sprintf("CIS 2.1.6: Exchange Online spam policy '%s' is not set to notify administrators when outbound spam is detected", [p.Name])
+}
+
+# CIS 2.1.7 -- an anti-phishing policy exists.
+violation contains msg if {
+	policy_available("anti_phish_policies")
+	count(input.defender.anti_phish_policies) == 0
+	msg := "CIS 2.1.7: no anti-phishing policy has been created, so impersonation and spoof protection are at their defaults"
+}
+
+violation contains msg if {
+	policy_available("anti_phish_policies")
+	some p in input.defender.anti_phish_policies
+	p.Enabled == false
+	msg := sprintf("CIS 2.1.7: anti-phishing policy '%s' has been created but is not enabled", [p.Name])
+}
+
+# CIS 2.1.11 -- comprehensive attachment filtering.
+MIN_FILTERED_FILE_TYPES := 100
+
+violation contains msg if {
+	policy_available("malware_filter_policies")
+	some p in input.defender.malware_filter_policies
+	count(object.get(p, "FileTypeFilter", [])) < MIN_FILTERED_FILE_TYPES
+	msg := sprintf("CIS 2.1.11: malware filter policy '%s' filters %d file types; comprehensive attachment filtering expects at least %d", [p.Identity, count(object.get(p, "FileTypeFilter", [])), MIN_FILTERED_FILE_TYPES])
+}
+
+# CIS 2.1.12 / 2.1.13 -- connection filter.
+violation contains msg if {
+	policy_available("connection_filter_policies")
+	some p in input.defender.connection_filter_policies
+	count(object.get(p, "IPAllowList", [])) > 0
+	msg := sprintf("CIS 2.1.12: connection filter policy '%s' uses an IP allow list, which bypasses spam and phishing evaluation for those senders", [p.Name])
+}
+
+violation contains msg if {
+	policy_available("connection_filter_policies")
+	some p in input.defender.connection_filter_policies
+	p.EnableSafeList == true
+	msg := sprintf("CIS 2.1.13: connection filter policy '%s' has the safe list on, which trusts a third-party sender list wholesale", [p.Name])
+}
+
+# CIS 2.1.14 -- inbound anti-spam allow lists.
+violation contains msg if {
+	policy_available("content_filter_policies")
+	some p in input.defender.content_filter_policies
+	count(object.get(p, "AllowedSenderDomains", [])) > 0
+	msg := sprintf("CIS 2.1.14: inbound anti-spam policy '%s' contains allowed sender domains; a spoofed sender in an allowed domain is delivered unfiltered", [p.Name])
+}
+
+# CIS 2.1.15 -- outbound spam message limits.
+violation contains msg if {
+	policy_available("outbound_spam_policies")
+	some p in input.defender.outbound_spam_policies
+	object.get(p, "RecipientLimitExternalPerHour", 0) == 0
+	msg := sprintf("CIS 2.1.15: outbound spam policy '%s' has no external recipient-per-hour limit, so a compromised mailbox can send without a throttle", [p.Name])
+}
+
+# CIS 2.4.2 -- strict protection for priority accounts.
+violation contains msg if {
+	policy_available("eop_protection_rules")
+	count(input.defender.eop_protection_rules) == 0
+	msg := "CIS 2.4.2: no EOP protection policy rule exists, so priority accounts do not have strict protection applied"
+}
+
+# CIS 2.4.4 -- zero-hour auto purge for Teams.
+violation contains msg if {
+	policy_available("teams_protection_policy")
+	input.defender.teams_protection_policy.ZapEnabled == false
+	msg := "CIS 2.4.4: zero-hour auto purge for Microsoft Teams is off, so malicious messages already delivered to Teams are not retracted"
+}
+
+# Fail closed on every Defender cmdlet the tenant did not expose.
+DEFENDER_FACT_CONTROLS := {
+	"safe_links_policies": "2.1.1",
+	"malware_filter_policies": "2.1.2",
+	"safe_attachment_policies": "2.1.4",
+	"atp_policy_for_o365": "2.1.5",
+	"outbound_spam_policies": "2.1.6",
+	"anti_phish_policies": "2.1.7",
+	"connection_filter_policies": "2.1.12",
+	"content_filter_policies": "2.1.14",
+	"eop_protection_rules": "2.4.2",
+	"teams_protection_policy": "2.4.4",
+}
+
+violation contains msg if {
+	some key, reason in defender_unavailable
+	control := object.get(DEFENDER_FACT_CONTROLS, key, "2.1.1")
+	msg := sprintf("CIS %s: could not be evaluated -- %s (this is not a pass)", [control, reason])
+}
+
+violation contains msg if {
+	not defender_collected
+	msg := "CIS 2.1.1: Defender policy facts were not collected, so whether Safe Links for Office applications is enabled could not be established (this is not a pass)"
+}
+
 compliant if {
 	facts_present
 	count(violation) == 0
@@ -66,8 +242,12 @@ compliance_report := {
 	"section": "2",
 	"name": "Microsoft Defender",
 	"section_total_controls": 21,
-	"controls_evaluated": 3,
-	"controls": ["2.1.8", "2.1.9", "2.1.10"],
+	"controls_evaluated": 17,
+	"controls": [
+		"2.1.1", "2.1.2", "2.1.3", "2.1.4", "2.1.5", "2.1.6", "2.1.7",
+		"2.1.8", "2.1.9", "2.1.10", "2.1.11", "2.1.12", "2.1.13",
+		"2.1.14", "2.1.15", "2.4.2", "2.4.4",
+	],
 	"facts_present": facts_present,
 	"violations": violation,
 	"violation_count": count(violation),

--- a/benchmarks/cis/saas/m365_v7/entra_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/entra_validation.rego
@@ -234,6 +234,202 @@ violation contains msg if {
 	msg := "CIS 5.3.1: Privileged Identity Management is not in use; privileged role assignments are standing rather than activated on demand"
 }
 
+
+# ── 5.2.2.x -- the Conditional Access cluster ────────────────────────
+# Fourteen further controls, all evaluable from the Conditional Access
+# policies already collected. CIS documents these as portal steps, so
+# every one of them reaches its answer by a path the benchmark does not
+# describe -- recorded in evidence_strength for the subsection rather
+# than per control.
+#
+# Shared shape: a control is satisfied when SOME enabled policy has the
+# required condition and control. A disabled or report-only policy
+# enforces nothing and must not satisfy anything.
+
+session(p) := object.get(p, "session_controls", {})
+
+# CIS 5.2.2.4 -- sign-in frequency, non-persistent browser sessions.
+default signin_frequency_enforced := false
+
+signin_frequency_enforced if {
+	some p in enabled_policies
+	object.get(session(p), ["signInFrequency", "isEnabled"], false) == true
+	object.get(session(p), ["persistentBrowser", "mode"], "") == "never"
+}
+
+violation contains msg if {
+	available("conditional_access_policies")
+	not signin_frequency_enforced
+	msg := "CIS 5.2.2.4: no enabled Conditional Access policy sets a sign-in frequency with browser sessions made non-persistent, so a stolen session cookie stays valid indefinitely"
+}
+
+# CIS 5.2.2.5 -- phishing-resistant MFA for administrators.
+default phishing_resistant_admin_mfa := false
+
+phishing_resistant_admin_mfa if {
+	some p in enabled_policies
+	targets_admin_roles(p)
+	contains(lower(object.get(p, ["grant_controls", "authenticationStrength", "displayName"], "")), "phishing-resistant")
+}
+
+violation contains msg if {
+	available("conditional_access_policies")
+	not phishing_resistant_admin_mfa
+	msg := "CIS 5.2.2.5: phishing-resistant MFA strength is not required for administrators; a policy requiring generic MFA still admits phishable factors"
+}
+
+# CIS 5.2.2.6 / 5.2.2.7 / 5.2.2.8 -- Identity Protection risk policies.
+risk_policy_exists(field) if {
+	some p in enabled_policies
+	count(object.get(p, ["conditions", field], [])) > 0
+}
+
+violation contains msg if {
+	available("conditional_access_policies")
+	not risk_policy_exists("userRiskLevels")
+	msg := "CIS 5.2.2.6: no enabled Identity Protection user risk policy exists, so a user flagged as compromised is not challenged or blocked"
+}
+
+violation contains msg if {
+	available("conditional_access_policies")
+	not risk_policy_exists("signInRiskLevels")
+	msg := "CIS 5.2.2.7: no enabled Identity Protection sign-in risk policy exists, so a risky sign-in is not challenged"
+}
+
+default signin_risk_blocked := false
+
+signin_risk_blocked if {
+	some p in enabled_policies
+	levels := object.get(p, ["conditions", "signInRiskLevels"], [])
+	"high" in levels
+	"medium" in levels
+}
+
+violation contains msg if {
+	available("conditional_access_policies")
+	not signin_risk_blocked
+	msg := "CIS 5.2.2.8: sign-in risk is not blocked for both medium and high risk levels"
+}
+
+# CIS 5.2.2.9 / 5.2.2.10 -- managed device required.
+requires_compliant_device(p) if {
+	some c in object.get(p, ["grant_controls", "builtInControls"], [])
+	c in {"compliantDevice", "domainJoinedDevice"}
+}
+
+default managed_device_required := false
+
+managed_device_required if {
+	some p in enabled_policies
+	requires_compliant_device(p)
+	targets_all_users(p)
+}
+
+violation contains msg if {
+	available("conditional_access_policies")
+	not managed_device_required
+	msg := "CIS 5.2.2.9: no enabled Conditional Access policy requires a managed device for authentication"
+}
+
+default managed_device_for_registration := false
+
+managed_device_for_registration if {
+	some p in enabled_policies
+	requires_compliant_device(p)
+	object.get(p, ["conditions", "applications", "includeUserActions"], []) != []
+}
+
+violation contains msg if {
+	available("conditional_access_policies")
+	not managed_device_for_registration
+	msg := "CIS 5.2.2.10: no enabled Conditional Access policy requires a managed device to register security information, so an attacker can enrol their own MFA method"
+}
+
+# CIS 5.2.2.11 -- sign-in frequency for Intune enrolment.
+default intune_enrolment_frequency := false
+
+intune_enrolment_frequency if {
+	some p in enabled_policies
+	object.get(session(p), ["signInFrequency", "frequencyInterval"], "") == "everyTime"
+}
+
+violation contains msg if {
+	available("conditional_access_policies")
+	not intune_enrolment_frequency
+	msg := "CIS 5.2.2.11: sign-in frequency for Intune enrollment is not set to every time"
+}
+
+# CIS 5.2.2.12 -- device code flow blocked.
+default device_code_blocked := false
+
+device_code_blocked if {
+	some p in enabled_policies
+	some f in object.get(p, ["conditions", "authenticationFlows", "transferMethods"], [])
+	f == "deviceCodeFlow"
+	some g in object.get(p, ["grant_controls", "builtInControls"], [])
+	g == "block"
+}
+
+violation contains msg if {
+	available("conditional_access_policies")
+	not device_code_blocked
+	msg := "CIS 5.2.2.12: the device code sign-in flow is not blocked; it is a common phishing vector because the victim authenticates on their own device"
+}
+
+# CIS 5.2.2.13 -- periodic reauthentication.
+violation contains msg if {
+	available("conditional_access_policies")
+	not signin_frequency_enforced
+	msg := "CIS 5.2.2.13: periodic reauthentication is not required for all users -- no enabled policy sets a sign-in frequency"
+}
+
+# CIS 5.2.2.14 / 5.2.2.15 -- named locations.
+violation contains msg if {
+	available("named_locations")
+	count([l | some l in input.entra.named_locations; l.is_trusted == true]) == 0
+	msg := "CIS 5.2.2.14: no trusted named locations are defined, so location cannot be used as a signal in Conditional Access"
+}
+
+violation contains msg if {
+	available("named_locations")
+	count([l |
+		some l in input.entra.named_locations
+		count(object.get(l, "countries_and_regions", [])) > 0
+	]) == 0
+	msg := "CIS 5.2.2.15: no exclusionary geographic access controls are utilized -- no country or region named location is defined"
+}
+
+# CIS 5.2.2.16 -- token protection.
+default token_protection_enforced := false
+
+token_protection_enforced if {
+	some p in enabled_policies
+	object.get(session(p), ["secureSignInSession", "isEnabled"], false) == true
+}
+
+violation contains msg if {
+	available("conditional_access_policies")
+	not token_protection_enforced
+	msg := "CIS 5.2.2.16: token protection is not enforced for session tokens, so a stolen refresh token can be replayed from another device"
+}
+
+# CIS 5.2.2.17 -- authentication transfer blocked.
+default auth_transfer_blocked := false
+
+auth_transfer_blocked if {
+	some p in enabled_policies
+	some f in object.get(p, ["conditions", "authenticationFlows", "transferMethods"], [])
+	f == "authenticationTransfer"
+	some g in object.get(p, ["grant_controls", "builtInControls"], [])
+	g == "block"
+}
+
+violation contains msg if {
+	available("conditional_access_policies")
+	not auth_transfer_blocked
+	msg := "CIS 5.2.2.17: authentication transfer is not blocked, so a session can be handed from a desktop to an attacker-controlled device"
+}
+
 # ── Fail closed on every gap the collector recorded ───────────────────
 FACT_CONTROLS := {
 	"authorization_policy": "5.1.2.2",
@@ -241,6 +437,7 @@ FACT_CONTROLS := {
 	"admin_consent_request_policy": "5.1.5.2",
 	"on_premises_synchronization": "5.1.8.1",
 	"conditional_access_policies": "5.2.2.1",
+	"named_locations": "5.2.2.14",
 	"pim_role_assignments": "5.3.1",
 	"group_settings": "5.2.3.2",
 	"mfa_registration_report": "5.2.3.4",
@@ -269,11 +466,14 @@ compliance_report := {
 	"section": "5",
 	"name": "Microsoft Entra admin center",
 	"section_total_controls": 63,
-	"controls_evaluated": 20,
+	"controls_evaluated": 34,
 	"controls": [
 		"5.1.2.1", "5.1.2.2", "5.1.2.3", "5.1.3.1", "5.1.4.6",
 		"5.1.5.1", "5.1.5.2", "5.1.6.2", "5.1.6.3", "5.1.8.1",
-		"5.2.2.1", "5.2.2.2", "5.2.2.3",
+		"5.2.2.1", "5.2.2.2", "5.2.2.3", "5.2.2.4", "5.2.2.5",
+		"5.2.2.6", "5.2.2.7", "5.2.2.8", "5.2.2.9", "5.2.2.10",
+		"5.2.2.11", "5.2.2.12", "5.2.2.13", "5.2.2.14", "5.2.2.15",
+		"5.2.2.16", "5.2.2.17",
 		"5.2.3.2", "5.2.3.3", "5.2.3.4", "5.2.3.5", "5.2.3.6", "5.2.3.7",
 		"5.3.1",
 	],
@@ -282,6 +482,7 @@ compliance_report := {
 	# 5.1.2.1 is read from a /beta endpoint, which Microsoft documents as
 	# subject to change and unsupported for production.
 	"evidence_strength": {
+		"5.2.2.x": "the 5.2.2 Conditional Access controls are evaluated from the policies Graph returns. CIS documents them as Entra portal steps and names no cmdlet, so these reach the benchmark's answer by a path it does not describe.",
 		"5.1.2.1": "collected from Microsoft Graph /beta (users/{id}/authentication/requirements); CIS marks this control Manual and documents no automated procedure",
 	},
 	"violations": violation,

--- a/benchmarks/cis/saas/m365_v7/entra_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/entra_validation.rego
@@ -430,6 +430,97 @@ violation contains msg if {
 	msg := "CIS 5.2.2.17: authentication transfer is not blocked, so a session can be handed from a desktop to an attacker-controlled device"
 }
 
+
+# ── 5.1.4.x -- device registration ───────────────────────────────────
+# Five controls from one beta policy object. CIS documents these as
+# portal steps; recorded in evidence_strength for the subsection.
+
+MAX_DEVICES_PER_USER := 20
+
+violation contains msg if {
+	available("device_registration_policy")
+	input.entra.device_registration.azure_ad_join_allowed_to_join == "all"
+	msg := "CIS 5.1.4.1: the ability to join devices to Entra is not restricted -- every user may join a device, so an attacker with credentials can register one"
+}
+
+violation contains msg if {
+	available("device_registration_policy")
+	to_number(object.get(input.entra.device_registration, "user_device_quota", 0)) > MAX_DEVICES_PER_USER
+	msg := sprintf("CIS 5.1.4.2: the maximum number of devices per user is %v; the benchmark expects a limit of %d or fewer", [input.entra.device_registration.user_device_quota, MAX_DEVICES_PER_USER])
+}
+
+violation contains msg if {
+	available("device_registration_policy")
+	input.entra.device_registration.local_admin_global_admins_enabled == true
+	msg := "CIS 5.1.4.3: the Global Administrator role is added as a local administrator during Entra join, which extends tenant-wide privilege onto every joined device"
+}
+
+violation contains msg if {
+	available("device_registration_policy")
+	input.entra.device_registration.local_admin_registering_user_enabled == "all"
+	msg := "CIS 5.1.4.4: local administrator assignment is not limited during Entra join -- the registering user becomes a local admin on the device"
+}
+
+violation contains msg if {
+	available("laps_policy")
+	input.entra.laps_enabled == false
+	msg := "CIS 5.1.4.5: Local Administrator Password Solution is not enabled, so local administrator passwords are neither randomised nor rotated"
+}
+
+# ── 5.1.5.x -- application credential management ─────────────────────
+# The app management policy expresses restrictions as a list of rules
+# rather than flags, so each control asks whether a rule of its kind
+# exists and is enabled.
+
+app_restriction_present(collection, rule_type) if {
+	some r in object.get(input.entra.app_management, collection, [])
+	r.restrictionType == rule_type
+	r.state == "enabled"
+}
+
+violation contains msg if {
+	available("app_management_policy")
+	not app_restriction_present("password_credentials", "passwordAddition")
+	msg := "CIS 5.1.5.3: password addition is not blocked for applications, so a secret can be added to an existing app registration"
+}
+
+violation contains msg if {
+	available("app_management_policy")
+	not app_restriction_present("password_credentials", "passwordLifetime")
+	msg := "CIS 5.1.5.4: no password lifetime restriction is enforced for applications, so an application password can exceed 180 days"
+}
+
+violation contains msg if {
+	available("app_management_policy")
+	not app_restriction_present("password_credentials", "symmetricKeyAddition")
+	msg := "CIS 5.1.5.5: new application passwords are not required to be system-generated, so a weak secret can be supplied by hand"
+}
+
+violation contains msg if {
+	available("app_management_policy")
+	not app_restriction_present("key_credentials", "asymmetricKeyLifetime")
+	msg := "CIS 5.1.5.6: no maximum certificate lifetime is enforced for applications, so an application certificate can exceed 180 days"
+}
+
+# ── 5.3.2 / 5.3.3 -- access reviews ──────────────────────────────────
+
+review_covers(term) if {
+	some r in input.entra.access_reviews
+	contains(lower(object.get(r, "scope_query", "")), term)
+}
+
+violation contains msg if {
+	available("access_reviews")
+	not review_covers("guest")
+	msg := "CIS 5.3.2: no access review is configured for guest users, so external access is never re-attested"
+}
+
+violation contains msg if {
+	available("access_reviews")
+	not review_covers("roleassignment")
+	msg := "CIS 5.3.3: no access review is configured for privileged roles, so standing administrative access is never re-attested"
+}
+
 # ── Fail closed on every gap the collector recorded ───────────────────
 FACT_CONTROLS := {
 	"authorization_policy": "5.1.2.2",
@@ -438,6 +529,10 @@ FACT_CONTROLS := {
 	"on_premises_synchronization": "5.1.8.1",
 	"conditional_access_policies": "5.2.2.1",
 	"named_locations": "5.2.2.14",
+	"device_registration_policy": "5.1.4.1",
+	"laps_policy": "5.1.4.5",
+	"app_management_policy": "5.1.5.3",
+	"access_reviews": "5.3.2",
 	"pim_role_assignments": "5.3.1",
 	"group_settings": "5.2.3.2",
 	"mfa_registration_report": "5.2.3.4",
@@ -466,16 +561,18 @@ compliance_report := {
 	"section": "5",
 	"name": "Microsoft Entra admin center",
 	"section_total_controls": 63,
-	"controls_evaluated": 34,
+	"controls_evaluated": 45,
 	"controls": [
 		"5.1.2.1", "5.1.2.2", "5.1.2.3", "5.1.3.1", "5.1.4.6",
-		"5.1.5.1", "5.1.5.2", "5.1.6.2", "5.1.6.3", "5.1.8.1",
+		"5.1.4.1", "5.1.4.2", "5.1.4.3", "5.1.4.4", "5.1.4.5",
+		"5.1.5.1", "5.1.5.2", "5.1.5.3", "5.1.5.4", "5.1.5.5", "5.1.5.6",
+		"5.1.6.2", "5.1.6.3", "5.1.8.1",
 		"5.2.2.1", "5.2.2.2", "5.2.2.3", "5.2.2.4", "5.2.2.5",
 		"5.2.2.6", "5.2.2.7", "5.2.2.8", "5.2.2.9", "5.2.2.10",
 		"5.2.2.11", "5.2.2.12", "5.2.2.13", "5.2.2.14", "5.2.2.15",
 		"5.2.2.16", "5.2.2.17",
 		"5.2.3.2", "5.2.3.3", "5.2.3.4", "5.2.3.5", "5.2.3.6", "5.2.3.7",
-		"5.3.1",
+		"5.3.1", "5.3.2", "5.3.3",
 	],
 	"facts_present": collected,
 	"unavailable_facts": unavailable,

--- a/benchmarks/cis/saas/m365_v7/fabric_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/fabric_validation.rego
@@ -1,0 +1,152 @@
+# CIS Microsoft 365 Foundations Benchmark v7.0.0
+# Section 9 -- Microsoft Fabric
+#
+# All 12 of section 9's recommendations are Fabric tenant settings.
+# Microsoft Graph does not expose them; they come from the Fabric /
+# Power BI admin API, a third authentication surface for this collection.
+#
+# The settingName for each control is taken from the benchmark's own
+# audit procedure, not inferred from the control title.
+#
+# TWO WAYS A SETTING PASSES: most of these settings are not simple
+# booleans. Fabric lets a setting be enabled but scoped to named security
+# groups, which is what the benchmark accepts for several controls -- the
+# question is not "is it off" but "is it off, or restricted to a defined
+# group". Treating enabled-with-scoping as a violation would flood a
+# correctly-configured tenant with false findings.
+#
+# Input contract (aac.m365.m365_fabric_admin_facts):
+#   input.fabric.settings[<settingName>] - {enabled,
+#                                           can_specify_security_groups,
+#                                           enabled_security_groups[], ...}
+#   input.fabric.unavailable             - {key: reason}
+
+package cis_m365_v7.fabric
+
+import rego.v1
+
+default compliant := false
+
+default unavailable := {}
+
+unavailable := input.fabric.unavailable
+
+default collected := false
+
+collected if {
+	input.fabric.collected == true
+}
+
+settings := object.get(input, ["fabric", "settings"], {})
+
+available(name) if {
+	collected
+	not unavailable[name]
+	not unavailable.tenant_settings
+	_ := settings[name]
+}
+
+# A setting is adequately restricted when it is off outright, or on but
+# limited to explicitly named security groups.
+restricted(name) if {
+	settings[name].enabled == false
+}
+
+restricted(name) if {
+	settings[name].enabled == true
+	count(object.get(settings[name], "enabled_security_groups", [])) > 0
+}
+
+SETTING_CONTROLS := {
+	"AllowGuestUserToAccessSharedContent": "9.1.1",
+	"ExternalSharingV2": "9.1.2",
+	"ElevatedGuestsTenant": "9.1.3",
+	"PublishToWeb": "9.1.4",
+	"RScriptVisual": "9.1.5",
+	"ShareLinkToEntireOrg": "9.1.7",
+	"EnableDatasetInPlaceSharing": "9.1.8",
+	"ServicePrincipalAccessPermissionAPIs": "9.1.10",
+	"AllowServicePrincipalsCreateAndUseProfiles": "9.1.11",
+	"ServicePrincipalAccessGlobalAPIs": "9.1.12",
+}
+
+SETTING_SUBJECTS := {
+	"AllowGuestUserToAccessSharedContent": "guest user access to Fabric is not restricted",
+	"ExternalSharingV2": "external user invitations are not restricted",
+	"ElevatedGuestsTenant": "guest access to content is not restricted",
+	"PublishToWeb": "'Publish to web' is not restricted, so reports can be exposed publicly",
+	"RScriptVisual": "interact with and share R and Python visuals is not disabled",
+	"ShareLinkToEntireOrg": "shareable links are not restricted -- links can be issued to the entire organization",
+	"EnableDatasetInPlaceSharing": "enabling of external data sharing is not restricted",
+	"ServicePrincipalAccessPermissionAPIs": "access to APIs by service principals is not restricted",
+	"AllowServicePrincipalsCreateAndUseProfiles": "service principals can create and use profiles",
+	"ServicePrincipalAccessGlobalAPIs": "service principals ability to create workspaces and connections is not restricted",
+}
+
+# ── The permissive settings: off, or scoped to a named group ─────────
+violation contains msg if {
+	some name, control in SETTING_CONTROLS
+	available(name)
+	not restricted(name)
+	msg := sprintf("CIS %s: %s (Fabric tenant setting '%s' is enabled for the whole organization)", [control, SETTING_SUBJECTS[name], name])
+}
+
+# ── CIS 9.1.6 -- sensitivity labels must be ENABLED, not restricted ───
+# The inverse of the settings above: this one is a protection, so the
+# benchmark wants it on rather than off.
+violation contains msg if {
+	available("EimInformationProtectionEdit")
+	settings.EimInformationProtectionEdit.enabled == false
+	msg := "CIS 9.1.6: 'Allow users to apply sensitivity labels for content' is disabled, so Fabric content cannot be classified"
+}
+
+# ── CIS 9.1.9 -- ResourceKey authentication must be BLOCKED ───────────
+violation contains msg if {
+	available("BlockResourceKeyAuthentication")
+	settings.BlockResourceKeyAuthentication.enabled == false
+	msg := "CIS 9.1.9: 'Block ResourceKey Authentication' is not enabled, so streaming datasets can be pushed with a resource key instead of an identity"
+}
+
+# ── Fail closed ───────────────────────────────────────────────────────
+ALL_SETTING_CONTROLS := object.union(SETTING_CONTROLS, {
+	"EimInformationProtectionEdit": "9.1.6",
+	"BlockResourceKeyAuthentication": "9.1.9",
+	"tenant_settings": "9.1.1",
+})
+
+violation contains msg if {
+	some key, reason in unavailable
+	control := object.get(ALL_SETTING_CONTROLS, key, "9.1.1")
+	msg := sprintf("CIS %s: could not be evaluated -- %s (this is not a pass)", [control, reason])
+}
+
+violation contains msg if {
+	not collected
+	msg := "CIS 9.1.1: Fabric tenant settings were not collected, so whether guest user access is restricted could not be established -- section 9 was not evaluated (this is not a pass)"
+}
+
+compliant if {
+	collected
+	count(violation) == 0
+}
+
+compliance_report := {
+	"benchmark": "CIS Microsoft 365 Foundations Benchmark",
+	"benchmark_version": "7.0.0",
+	"section": "9",
+	"name": "Microsoft Fabric",
+	"section_total_controls": 12,
+	"controls_evaluated": 12,
+	"controls": [
+		"9.1.1", "9.1.2", "9.1.3", "9.1.4", "9.1.5", "9.1.6",
+		"9.1.7", "9.1.8", "9.1.9", "9.1.10", "9.1.11", "9.1.12",
+	],
+	"facts_present": collected,
+	"unavailable_facts": unavailable,
+	"evidence_strength": {
+		"section": "collected from the Fabric admin API. CIS documents these as portal steps plus a CIS-supplied helper function; the API returns the same tenantSettings the portal displays. A setting that is enabled but scoped to named security groups is treated as restricted, which is what the benchmark accepts.",
+	},
+	"violations": violation,
+	"violation_count": count(violation),
+	"compliant": compliant,
+}

--- a/benchmarks/cis/saas/m365_v7/purview_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/purview_validation.rego
@@ -5,10 +5,19 @@
 #   input.purview.audit_log_accessible - bool; a directoryAudits probe
 #                                        returned at least one record
 #
-# NOT EVALUATED: 3.2.x (DLP), 3.3.x (labels), Insider Risk Management and
-# Communication Compliance. The Purview collector returns Secure Score plus
-# an audit-log reachability probe and an eDiscovery case count; none of
-# those establish the remaining section 3 controls. See COVERAGE.md.
+# DLP and sensitivity-label controls come from Security & Compliance
+# PowerShell (aac.m365.m365_purview_ps_facts) -- a DIFFERENT endpoint from
+# Exchange Online PowerShell despite shipping in the same module.
+#
+# NOT EVALUATED: 3.4 (Insider Risk Management) and 3.5 (Communication
+# Compliance) are empty subsection headers in v7.0.0 with no
+# recommendations under them, so there is nothing to evaluate.
+#
+# Input contract (aac.m365.m365_purview_ps_facts):
+#   input.purview_ps.dlp_policies[]   - {Name, Mode, Enabled, Workload,
+#                                        TeamsLocation, ...}
+#   input.purview_ps.label_policies[] - {Name, Mode, Enabled, Labels}
+#   input.purview_ps.unavailable      - {key: reason}
 
 package cis_m365_v7.purview
 
@@ -35,6 +44,87 @@ violation contains msg if {
 	msg := "CIS 3.1.1: audit log facts not collected -- control could not be evaluated (this is not a pass)"
 }
 
+
+# ── DLP and sensitivity labels (Security & Compliance PowerShell) ─────
+
+default ps_unavailable := {}
+
+ps_unavailable := input.purview_ps.unavailable
+
+default ps_collected := false
+
+ps_collected if {
+	input.purview_ps.collected == true
+}
+
+ps_available(key) if {
+	ps_collected
+	not ps_unavailable[key]
+}
+
+dlp_policies := object.get(input, ["purview_ps", "dlp_policies"], [])
+
+label_policies := object.get(input, ["purview_ps", "label_policies"], [])
+
+# A policy in Test mode reports matches but enforces nothing, so it does
+# not satisfy a control asking for DLP to be enabled.
+enforcing(p) if {
+	p.Enabled == true
+	not startswith(lower(object.get(p, "Mode", "")), "test")
+}
+
+# CIS 3.2.1 -- DLP policies enabled.
+violation contains msg if {
+	ps_available("dlp_policies")
+	count([p | some p in dlp_policies; enforcing(p)]) == 0
+	msg := "CIS 3.2.1: no DLP policy is enabled and enforcing -- a policy in Test mode reports matches but does not prevent the data loss it detects"
+}
+
+# CIS 3.2.2 -- DLP covers Microsoft Teams.
+violation contains msg if {
+	ps_available("dlp_policies")
+	count([p |
+		some p in dlp_policies
+		enforcing(p)
+		count(object.get(p, "TeamsLocation", [])) > 0
+	]) == 0
+	msg := "CIS 3.2.2: no enabled DLP policy covers Microsoft Teams, so sensitive content shared in chats and channels is not inspected"
+}
+
+# CIS 3.2.3 -- DLP published for Copilot.
+violation contains msg if {
+	ps_available("dlp_policies")
+	count([p |
+		some p in dlp_policies
+		enforcing(p)
+		contains(lower(object.get(p, "Workload", "")), "copilot")
+	]) == 0
+	msg := "CIS 3.2.3: no DLP policy is published for Copilot users, so content Copilot can surface is not covered by data loss prevention"
+}
+
+# CIS 3.3.1 -- sensitivity label policies published.
+violation contains msg if {
+	ps_available("label_policies")
+	count([p | some p in label_policies; p.Enabled == true]) == 0
+	msg := "CIS 3.3.1: no Information Protection sensitivity label policy is published, so users have no labels to classify content with"
+}
+
+PURVIEW_PS_CONTROLS := {
+	"dlp_policies": "3.2.1",
+	"label_policies": "3.3.1",
+}
+
+violation contains msg if {
+	some key, reason in ps_unavailable
+	control := object.get(PURVIEW_PS_CONTROLS, key, "3.2.1")
+	msg := sprintf("CIS %s: could not be evaluated -- %s (this is not a pass)", [control, reason])
+}
+
+violation contains msg if {
+	not ps_collected
+	msg := "CIS 3.2.1: Purview DLP facts were not collected, so whether DLP policies are enabled could not be established (this is not a pass)"
+}
+
 compliant if {
 	facts_present
 	count(violation) == 0
@@ -46,8 +136,8 @@ compliance_report := {
 	"section": "3",
 	"name": "Microsoft Purview",
 	"section_total_controls": 5,
-	"controls_evaluated": 1,
-	"controls": ["3.1.1"],
+	"controls_evaluated": 5,
+	"controls": ["3.1.1", "3.2.1", "3.2.2", "3.2.3", "3.3.1"],
 	"facts_present": facts_present,
 	"violations": violation,
 	"violation_count": count(violation),

--- a/benchmarks/cis/saas/m365_v7/sharepoint_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/sharepoint_validation.rego
@@ -1,12 +1,29 @@
 # CIS Microsoft 365 Foundations Benchmark v7.0.0
 # Section 7 -- SharePoint admin center
 #
-# Input contract (from the aac.m365 collection, /admin/sharepoint/settings):
-#   input.sharepoint.sharing_capability          - str
-#   input.sharepoint.default_sharing_link_type   - str
-#   input.sharepoint.default_link_permission     - str
-#   input.sharepoint.legacy_auth_protocols_enabled - bool
-#   input.sharepoint.settings_reachable          - bool
+# All 12 of section 7's recommendations are evaluated here, from a single
+# tenant object.
+#
+# DELIBERATE, PERMANENT DEVIATION FROM THE BENCHMARK'S PROCEDURE:
+# CIS audits these with Get-SPOTenant, which lives in
+# Microsoft.Online.SharePoint.PowerShell -- a Windows-only module that
+# cannot be installed in a Linux execution environment (verified absent
+# from aac-m365-ee). Facts come from Get-PnPTenant instead, which reads
+# the same CSOM tenant properties. Values are equivalent; the tool is not
+# the one CIS documents, so the report carries an evidence note for the
+# whole section rather than implying the benchmark's own procedure was
+# followed.
+#
+# This also SUPERSEDES the previous Graph-based evaluation of 7.2.1,
+# 7.2.6, 7.2.7 and 7.2.11 via /admin/sharepoint/settings. Those reached
+# the right answer by a path CIS does not document at all; the tenant
+# properties below are at least the same underlying settings CIS reads.
+#
+# Input contract (aac.m365.m365_sharepoint_ps_facts):
+#   input.sharepoint.tenant              - the collected tenant properties
+#   input.sharepoint.missing_properties[] - expected properties ABSENT from
+#                                           the object (fail closed on these)
+#   input.sharepoint.unavailable         - {key: reason}
 
 package cis_m365_v7.sharepoint
 
@@ -14,48 +31,147 @@ import rego.v1
 
 default compliant := false
 
-default facts_present := false
+# Sharing capability values, most to least permissive. The benchmark wants
+# anything other than the fully-external settings.
+PERMISSIVE_SHARING := {"ExternalUserAndGuestSharing", "ExistingExternalUserSharingOnly"}
+ANONYMOUS_SHARING := "ExternalUserAndGuestSharing"
 
-facts_present if {
-	input.sharepoint.settings_reachable == true
+default unavailable := {}
+
+unavailable := input.sharepoint.unavailable
+
+default collected := false
+
+collected if {
+	input.sharepoint.collected == true
 }
 
-# CIS 7.2.1 -- modern authentication required for SharePoint applications.
-violation contains msg if {
-	facts_present
-	input.sharepoint.legacy_auth_protocols_enabled == true
-	msg := "CIS 7.2.1: legacy authentication protocols are permitted for SharePoint applications; modern authentication is not required, so clients can bypass Conditional Access"
+tenant := object.get(input, ["sharepoint", "tenant"], {})
+
+# A control is evaluable only when the collector actually returned the
+# property it depends on. A property that PnP did not return is recorded
+# by the collector, so a renamed or wrong property name fails closed here
+# rather than reading as null and passing.
+available(prop) if {
+	collected
+	not unavailable[prop]
+	_ := tenant[prop]
 }
 
-# CIS 7.2.6 -- SharePoint external sharing must be restricted. The most
-# permissive setting allows sharing with anonymous external users.
+# ── CIS 7.2.1 -- modern authentication required ──────────────────────
 violation contains msg if {
-	facts_present
-	input.sharepoint.sharing_capability == "ExternalUserAndGuestSharing"
-	msg := "CIS 7.2.6: SharePoint external sharing is set to the most permissive value (ExternalUserAndGuestSharing); restrict to ExistingExternalUserSharingOnly or Disabled"
+	available("LegacyAuthProtocolsEnabled")
+	tenant.LegacyAuthProtocolsEnabled == true
+	msg := "CIS 7.2.1: legacy authentication protocols are permitted, so modern authentication is not required for SharePoint applications and clients can bypass Conditional Access"
 }
 
-# CIS 7.2.7 -- link sharing must be restricted in SharePoint and OneDrive.
+# ── CIS 7.2.2 -- Azure AD B2B integration ────────────────────────────
 violation contains msg if {
-	facts_present
-	input.sharepoint.default_sharing_link_type == "AnonymousAccess"
-	msg := "CIS 7.2.7: the default sharing link is anonymous, so newly created links are world-readable; restrict link sharing to specific people or the organization"
+	available("EnableAzureADB2BIntegration")
+	tenant.EnableAzureADB2BIntegration == false
+	msg := "CIS 7.2.2: SharePoint and OneDrive integration with Azure AD B2B is not enabled, so external guests are not governed by Entra guest identities"
 }
 
-# CIS 7.2.11 -- the default sharing link permission should be view, not edit.
+# ── CIS 7.2.3 / 7.2.6 -- external and SharePoint sharing ─────────────
 violation contains msg if {
-	facts_present
-	input.sharepoint.default_link_permission == "Edit"
-	msg := "CIS 7.2.11: the SharePoint default sharing link permission grants Edit; a default of View limits accidental modification by recipients"
+	available("SharingCapability")
+	tenant.SharingCapability == ANONYMOUS_SHARING
+	msg := "CIS 7.2.3: external content sharing is set to the most permissive value (ExternalUserAndGuestSharing), which allows anonymous links"
 }
 
 violation contains msg if {
-	not facts_present
-	msg := "CIS 7.2.1: SharePoint tenant settings were not reachable -- external sharing and authentication controls could not be evaluated (this is not a pass)"
+	available("SharingCapability")
+	tenant.SharingCapability in PERMISSIVE_SHARING
+	msg := sprintf("CIS 7.2.6: SharePoint external sharing is '%s'; restrict it to New and existing guests or Only people in your organization", [tenant.SharingCapability])
+}
+
+# ── CIS 7.2.4 -- OneDrive sharing ────────────────────────────────────
+violation contains msg if {
+	available("OneDriveSharingCapability")
+	tenant.OneDriveSharingCapability in PERMISSIVE_SHARING
+	msg := sprintf("CIS 7.2.4: OneDrive content sharing is '%s' and is not restricted; OneDrive inherits the tenant default unless set separately", [tenant.OneDriveSharingCapability])
+}
+
+# ── CIS 7.2.5 -- guests resharing items they do not own ──────────────
+violation contains msg if {
+	available("PreventExternalUsersFromResharing")
+	tenant.PreventExternalUsersFromResharing == false
+	msg := "CIS 7.2.5: SharePoint guest users can share items they don't own, so access granted to one external party can be forwarded to another"
+}
+
+# ── CIS 7.2.7 -- link sharing ────────────────────────────────────────
+violation contains msg if {
+	available("DefaultSharingLinkType")
+	tenant.DefaultSharingLinkType == "AnonymousAccess"
+	msg := "CIS 7.2.7: link sharing in SharePoint and OneDrive defaults to anonymous access, so newly created links are world-readable"
+}
+
+# ── CIS 7.2.8 -- sharing restricted by security group ────────────────
+violation contains msg if {
+	available("SharingDomainRestrictionMode")
+	tenant.SharingDomainRestrictionMode == "None"
+	msg := "CIS 7.2.8: external sharing is not restricted by security group or domain; any user may share with any external party"
+}
+
+# ── CIS 7.2.9 -- guest access expiry ─────────────────────────────────
+violation contains msg if {
+	available("ExternalUserExpirationRequired")
+	tenant.ExternalUserExpirationRequired == false
+	msg := "CIS 7.2.9: guest access to a site or OneDrive does not expire automatically, so external access persists indefinitely after a project ends"
+}
+
+# ── CIS 7.2.10 -- reauthentication with verification code ────────────
+violation contains msg if {
+	available("EmailAttestationRequired")
+	tenant.EmailAttestationRequired == false
+	msg := "CIS 7.2.10: reauthentication with a verification code is not restricted, so an external recipient's link stays valid without re-proving control of the mailbox"
+}
+
+# ── CIS 7.2.11 -- default sharing link permission ────────────────────
+violation contains msg if {
+	available("DefaultLinkPermission")
+	tenant.DefaultLinkPermission == "Edit"
+	msg := "CIS 7.2.11: the SharePoint default sharing link permission is set to Edit; a default of View limits accidental modification by recipients"
+}
+
+# ── CIS 7.3.1 -- infected file download ──────────────────────────────
+violation contains msg if {
+	available("DisallowInfectedFileDownload")
+	tenant.DisallowInfectedFileDownload == false
+	msg := "CIS 7.3.1: Office 365 SharePoint infected files are not disallowed for download, so a file Defender has flagged can still be retrieved"
+}
+
+# ── Fail closed ───────────────────────────────────────────────────────
+# The collector records every expected-but-absent property, naming the
+# controls it blocks. Surface each as its own violation.
+PROPERTY_CONTROLS := {
+	"LegacyAuthProtocolsEnabled": "7.2.1",
+	"EnableAzureADB2BIntegration": "7.2.2",
+	"SharingCapability": "7.2.3",
+	"OneDriveSharingCapability": "7.2.4",
+	"PreventExternalUsersFromResharing": "7.2.5",
+	"DefaultSharingLinkType": "7.2.7",
+	"SharingDomainRestrictionMode": "7.2.8",
+	"ExternalUserExpirationRequired": "7.2.9",
+	"EmailAttestationRequired": "7.2.10",
+	"DefaultLinkPermission": "7.2.11",
+	"DisallowInfectedFileDownload": "7.3.1",
+	"tenant": "7.2.1",
+}
+
+violation contains msg if {
+	some key, reason in unavailable
+	control := object.get(PROPERTY_CONTROLS, key, "7.2.1")
+	msg := sprintf("CIS %s: could not be evaluated -- %s (this is not a pass)", [control, reason])
+}
+
+violation contains msg if {
+	not collected
+	msg := "CIS 7.2.1: SharePoint tenant facts were not collected, so whether modern authentication is required could not be established -- section 7 was not evaluated (this is not a pass)"
 }
 
 compliant if {
-	facts_present
+	collected
 	count(violation) == 0
 }
 
@@ -65,9 +181,16 @@ compliance_report := {
 	"section": "7",
 	"name": "SharePoint admin center",
 	"section_total_controls": 12,
-	"controls_evaluated": 4,
-	"controls": ["7.2.1", "7.2.6", "7.2.7", "7.2.11"],
-	"facts_present": facts_present,
+	"controls_evaluated": 12,
+	"controls": [
+		"7.2.1", "7.2.2", "7.2.3", "7.2.4", "7.2.5", "7.2.6",
+		"7.2.7", "7.2.8", "7.2.9", "7.2.10", "7.2.11", "7.3.1",
+	],
+	"facts_present": collected,
+	"unavailable_facts": unavailable,
+	"evidence_strength": {
+		"section": "collected with Get-PnPTenant, not the Get-SPOTenant the benchmark documents -- Microsoft.Online.SharePoint.PowerShell is Windows-only and cannot run in a Linux execution environment. The same CSOM tenant properties are read.",
+	},
 	"violations": violation,
 	"violation_count": count(violation),
 	"compliant": compliant,

--- a/benchmarks/cis/saas/m365_v7/teams_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/teams_validation.rego
@@ -1,0 +1,225 @@
+# CIS Microsoft 365 Foundations Benchmark v7.0.0
+# Section 8 -- Microsoft Teams admin center
+#
+# 16 of section 8's 17 recommendations are evaluated here. All four
+# cmdlets CIS names were verified present in the aac-m365-ee image, so
+# unlike section 7 this section follows the benchmark's own audit
+# procedure exactly -- no tooling deviation to declare.
+#
+# NOT EVALUATED: 8.4.1 (app permission policies). CIS marks it Manual and
+# names no cmdlet. Get-CsTeamsAppPermissionPolicy plausibly covers it, but
+# that is an assumption, and assuming is the defect this library exists to
+# avoid. It is reported as unresolved by the attestation module until a
+# live-tenant probe settles it.
+#
+# POLICY COLLECTIONS: meeting and messaging policies are collections, not
+# single objects. The Global policy is the tenant default and is what the
+# benchmark audits, but a permissive NON-global policy still governs every
+# user it is assigned to. Both are checked -- passing on Global alone
+# would miss a permissive policy assigned to real users.
+#
+# Input contract (aac.m365.m365_teams_ps_facts):
+#   input.teams.client_configuration       - object
+#   input.teams.federation_configuration   - object
+#   input.teams.meeting_policies[]         - all policies
+#   input.teams.meeting_policies_global    - the Global policy, or null
+#   input.teams.messaging_policies[]       - all policies
+#   input.teams.unavailable                - {key: reason}
+
+package cis_m365_v7.teams
+
+import rego.v1
+
+default compliant := false
+
+APPROVED_STORAGE_FIELDS := ["AllowDropBox", "AllowBox", "AllowGoogleDrive", "AllowShareFile", "AllowEgnyte"]
+
+default unavailable := {}
+
+unavailable := input.teams.unavailable
+
+default collected := false
+
+collected if {
+	input.teams.collected == true
+}
+
+available(key) if {
+	collected
+	not unavailable[key]
+}
+
+client_config := object.get(input, ["teams", "client_configuration"], {})
+
+federation := object.get(input, ["teams", "federation_configuration"], {})
+
+meeting_policies := object.get(input, ["teams", "meeting_policies"], [])
+
+messaging_policies := object.get(input, ["teams", "messaging_policies"], [])
+
+# ── CIS 8.1.1 -- external file sharing limited to approved services ──
+violation contains msg if {
+	available("client_configuration")
+	some field in APPROVED_STORAGE_FIELDS
+	client_config[field] == true
+	msg := sprintf("CIS 8.1.1: external file sharing in Teams permits '%s'; only approved cloud storage services should be enabled", [field])
+}
+
+# ── CIS 8.1.2 -- email into channel ──────────────────────────────────
+violation contains msg if {
+	available("client_configuration")
+	client_config.AllowEmailIntoChannel == true
+	msg := "CIS 8.1.2: users can send emails to a channel email address, which accepts mail from outside the tenant into a Teams channel"
+}
+
+# ── CIS 8.2.1 -- external domains restricted ─────────────────────────
+violation contains msg if {
+	available("federation_configuration")
+	federation.AllowFederatedUsers == true
+	count(object.get(federation, "AllowedDomains", [])) == 0
+	msg := "CIS 8.2.1: external domains are not restricted in the Teams admin center -- federation is open to every domain rather than an allow list"
+}
+
+# ── CIS 8.2.2 -- communication with unmanaged Teams users ────────────
+violation contains msg if {
+	available("federation_configuration")
+	federation.AllowTeamsConsumer == true
+	msg := "CIS 8.2.2: communication with unmanaged Teams users is not disabled, so staff can be contacted by personal Teams accounts"
+}
+
+# ── CIS 8.2.3 -- external users initiating conversations ─────────────
+violation contains msg if {
+	available("federation_configuration")
+	federation.AllowTeamsConsumerInbound == true
+	msg := "CIS 8.2.3: external Teams users can initiate conversations; inbound contact from unmanaged accounts should be blocked"
+}
+
+# ── CIS 8.2.4 -- trial tenants ───────────────────────────────────────
+violation contains msg if {
+	available("federation_configuration")
+	federation.ExternalAccessWithTrialTenants == "Allowed"
+	msg := "CIS 8.2.4: the organization can communicate with accounts in trial Teams tenants, which are trivially created and commonly used for impersonation"
+}
+
+# ── Meeting policies (8.5.1 through 8.5.9) ───────────────────────────
+# Every policy is checked, not just Global: a permissive non-global policy
+# governs every user it is assigned to.
+
+violation contains msg if {
+	available("meeting_policies")
+	some p in meeting_policies
+	p.AllowAnonymousUsersToJoinMeeting == true
+	msg := sprintf("CIS 8.5.1: meeting policy '%s' lets anonymous users join a meeting", [p.Identity])
+}
+
+violation contains msg if {
+	available("meeting_policies")
+	some p in meeting_policies
+	p.AllowAnonymousUsersToStartMeeting == true
+	msg := sprintf("CIS 8.5.2: meeting policy '%s' lets anonymous users and dial-in callers start a meeting, so a meeting can run with no organizer present", [p.Identity])
+}
+
+violation contains msg if {
+	available("meeting_policies")
+	some p in meeting_policies
+	not p.AutoAdmittedUsers in {"EveryoneInCompany", "EveryoneInCompanyExcludingGuests", "InvitedUsers", "OrganizerOnly"}
+	msg := sprintf("CIS 8.5.3: meeting policy '%s' admits '%s' automatically; only people in the org should bypass the lobby", [p.Identity, p.AutoAdmittedUsers])
+}
+
+violation contains msg if {
+	available("meeting_policies")
+	some p in meeting_policies
+	p.AllowPSTNUsersToBypassLobby == true
+	msg := sprintf("CIS 8.5.4: meeting policy '%s' lets users dialing in bypass the lobby", [p.Identity])
+}
+
+violation contains msg if {
+	available("meeting_policies")
+	some p in meeting_policies
+	p.MeetingChatEnabledType == "Enabled"
+	msg := sprintf("CIS 8.5.5: meeting policy '%s' allows meeting chat for anonymous users", [p.Identity])
+}
+
+violation contains msg if {
+	available("meeting_policies")
+	some p in meeting_policies
+	p.DesignatedPresenterRoleMode != "OrganizerOnlyUserOverride"
+	msg := sprintf("CIS 8.5.6: meeting policy '%s' does not restrict presenting to organizers and co-organizers", [p.Identity])
+}
+
+violation contains msg if {
+	available("meeting_policies")
+	some p in meeting_policies
+	p.AllowExternalParticipantGiveRequestControl == true
+	msg := sprintf("CIS 8.5.7: meeting policy '%s' lets external participants give or request control of a shared screen", [p.Identity])
+}
+
+violation contains msg if {
+	available("meeting_policies")
+	some p in meeting_policies
+	p.MeetingChatEnabledType == "EnabledExceptAnonymous"
+	msg := sprintf("CIS 8.5.8: meeting policy '%s' leaves external meeting chat on", [p.Identity])
+}
+
+violation contains msg if {
+	available("meeting_policies")
+	some p in meeting_policies
+	p.AllowCloudRecording == true
+	msg := sprintf("CIS 8.5.9: meeting policy '%s' has meeting recording on by default", [p.Identity])
+}
+
+# ── CIS 8.6.1 -- users can report security concerns ──────────────────
+violation contains msg if {
+	available("messaging_policies")
+	some p in messaging_policies
+	p.AllowSecurityEndUserReporting == false
+	msg := sprintf("CIS 8.6.1: messaging policy '%s' does not let users report security concerns in Teams, removing the reporting path for suspicious messages", [p.Identity])
+}
+
+# ── Fail closed ───────────────────────────────────────────────────────
+FACT_CONTROLS := {
+	"client_configuration": "8.1.1",
+	"federation_configuration": "8.2.1",
+	"meeting_policies": "8.5.1",
+	"messaging_policies": "8.6.1",
+}
+
+violation contains msg if {
+	some key, reason in unavailable
+	control := object.get(FACT_CONTROLS, key, "8.1.1")
+	msg := sprintf("CIS %s: could not be evaluated -- %s (this is not a pass)", [control, reason])
+}
+
+violation contains msg if {
+	not collected
+	msg := "CIS 8.1.1: Teams facts were not collected, so whether external file sharing is limited to approved cloud storage services could not be established -- section 8 was not evaluated (this is not a pass)"
+}
+
+compliant if {
+	collected
+	count(violation) == 0
+}
+
+compliance_report := {
+	"benchmark": "CIS Microsoft 365 Foundations Benchmark",
+	"benchmark_version": "7.0.0",
+	"section": "8",
+	"name": "Microsoft Teams admin center",
+	"section_total_controls": 17,
+	"controls_evaluated": 16,
+	"controls": [
+		"8.1.1", "8.1.2",
+		"8.2.1", "8.2.2", "8.2.3", "8.2.4",
+		"8.5.1", "8.5.2", "8.5.3", "8.5.4", "8.5.5",
+		"8.5.6", "8.5.7", "8.5.8", "8.5.9",
+		"8.6.1",
+	],
+	"facts_present": collected,
+	"unavailable_facts": unavailable,
+	"evidence_strength": {
+		"section": "collected with the cmdlets CIS documents (Get-CsTeamsClientConfiguration, Get-CsTenantFederationConfiguration, Get-CsTeamsMeetingPolicy, Get-CsTeamsMessagingPolicy), all verified present in the execution environment. Meeting and messaging policies are evaluated across ALL policies, not only Global, because a permissive non-global policy still governs the users it is assigned to.",
+	},
+	"violations": violation,
+	"violation_count": count(violation),
+	"compliant": compliant,
+}

--- a/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
+++ b/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
@@ -64,7 +64,7 @@ test_1_1_3_too_few_global_admins if {
 	r := admin_center.compliance_report with input as admins(1)
 	r.compliant == false
 	some v in r.violations
-	contains(v, "CIS 1.1.3")
+	contains(v, "CIS 1.1.3:")
 }
 
 test_1_1_3_too_many_global_admins if {
@@ -90,19 +90,19 @@ domains(spf, dkim, dmarc) := {"exchange": {"verified_domains": [{
 test_2_1_8_missing_spf if {
 	r := defender.compliance_report with input as domains(false, true, true)
 	some v in r.violations
-	contains(v, "CIS 2.1.8")
+	contains(v, "CIS 2.1.8:")
 }
 
 test_2_1_9_missing_dkim if {
 	r := defender.compliance_report with input as domains(true, false, true)
 	some v in r.violations
-	contains(v, "CIS 2.1.9")
+	contains(v, "CIS 2.1.9:")
 }
 
 test_2_1_10_missing_dmarc if {
 	r := defender.compliance_report with input as domains(true, true, false)
 	some v in r.violations
-	contains(v, "CIS 2.1.10")
+	contains(v, "CIS 2.1.10:")
 }
 
 test_mail_authentication_controls_satisfied if {
@@ -111,9 +111,9 @@ test_mail_authentication_controls_satisfied if {
 	# compliant, so assert on the three controls it actually covers.
 	r := defender.compliance_report with input as domains(true, true, true)
 	every v in r.violations {
-		not contains(v, "CIS 2.1.8")
-		not contains(v, "CIS 2.1.9")
-		not contains(v, "CIS 2.1.10")
+		not contains(v, "CIS 2.1.8:")
+		not contains(v, "CIS 2.1.9:")
+		not contains(v, "CIS 2.1.10:")
 	}
 }
 
@@ -123,7 +123,7 @@ test_3_1_1_audit_log_unavailable if {
 	r := purview.compliance_report with input as {"purview": {"audit_log_accessible": false}}
 	r.compliant == false
 	some v in r.violations
-	contains(v, "CIS 3.1.1")
+	contains(v, "CIS 3.1.1:")
 }
 
 test_3_1_1_audit_log_available_satisfies_its_control if {
@@ -131,7 +131,7 @@ test_3_1_1_audit_log_available_satisfies_its_control if {
 	# audit-log-only fixture cannot make the section compliant. Assert on
 	# the control it actually establishes.
 	r := purview.compliance_report with input as {"purview": {"audit_log_accessible": true}}
-	every v in r.violations { not contains(v, "CIS 3.1.1") }
+	every v in r.violations { not contains(v, "CIS 3.1.1:") }
 }
 
 # ── CIS 5.2.2.x / 5.3.1 -- Conditional Access and PIM ─────────────────
@@ -168,19 +168,19 @@ block_legacy := {
 test_5_2_2_2_no_mfa_for_all_users if {
 	r := entra.compliance_report with input as ca_tenant([mfa_admins, block_legacy], true)
 	some v in r.violations
-	contains(v, "CIS 5.2.2.2")
+	contains(v, "CIS 5.2.2.2:")
 }
 
 test_5_2_2_3_legacy_auth_not_blocked if {
 	r := entra.compliance_report with input as ca_tenant([mfa_all_users, mfa_admins], true)
 	some v in r.violations
-	contains(v, "CIS 5.2.2.3")
+	contains(v, "CIS 5.2.2.3:")
 }
 
 test_5_3_1_pim_not_in_use if {
 	r := entra.compliance_report with input as ca_tenant([mfa_all_users, mfa_admins, block_legacy], false)
 	some v in r.violations
-	contains(v, "CIS 5.3.1")
+	contains(v, "CIS 5.3.1:")
 }
 
 test_entra_conditional_access_controls_satisfied if {
@@ -189,9 +189,9 @@ test_entra_conditional_access_controls_satisfied if {
 	# controls stop firing, which is what this fixture establishes.
 	r := entra.compliance_report with input as ca_tenant([mfa_all_users, mfa_admins, block_legacy], true)
 	every v in r.violations {
-		not contains(v, "CIS 5.2.2.1")
-		not contains(v, "CIS 5.2.2.2")
-		not contains(v, "CIS 5.2.2.3")
+		not contains(v, "CIS 5.2.2.1:")
+		not contains(v, "CIS 5.2.2.2:")
+		not contains(v, "CIS 5.2.2.3:")
 	}
 }
 
@@ -200,7 +200,7 @@ test_disabled_policy_does_not_satisfy_control if {
 	disabled := object.union(mfa_all_users, {"state": "disabled"})
 	r := entra.compliance_report with input as ca_tenant([disabled], true)
 	some v in r.violations
-	contains(v, "CIS 5.2.2.2")
+	contains(v, "CIS 5.2.2.2:")
 }
 
 # ── CIS 6.1.1 -- mailbox auditing ─────────────────────────────────────
@@ -213,7 +213,7 @@ test_6_1_1_audit_disabled_read_directly if {
 	}}
 	r.compliant == false
 	some v in r.violations
-	contains(v, "CIS 6.1.1")
+	contains(v, "CIS 6.1.1:")
 }
 
 test_6_5_4_smtp_auth_enabled if {
@@ -222,7 +222,7 @@ test_6_5_4_smtp_auth_enabled if {
 		"transport_config": {"SmtpClientAuthenticationDisabled": false},
 	}}
 	some v in r.violations
-	contains(v, "CIS 6.5.4")
+	contains(v, "CIS 6.5.4:")
 }
 
 test_6_1_3_audit_bypass_flagged if {
@@ -231,7 +231,7 @@ test_6_1_3_audit_bypass_flagged if {
 		"audit_bypass_associations": [{"Identity": "svc@c.com"}],
 	}}
 	some v in r.violations
-	contains(v, "CIS 6.1.3")
+	contains(v, "CIS 6.1.3:")
 }
 
 test_6_2_2_scl_bypass_whitelist_flagged if {
@@ -241,7 +241,7 @@ test_6_2_2_scl_bypass_whitelist_flagged if {
 			"SetSCL": -1, "SenderDomainIs": ["partner.com"]}],
 	}}
 	some v in r.violations
-	contains(v, "CIS 6.2.2")
+	contains(v, "CIS 6.2.2:")
 }
 
 test_6_1_2_declares_its_sampling_limit if {
@@ -262,25 +262,25 @@ sp(props) := {"sharepoint": {
 test_7_2_1_legacy_auth_enabled if {
 	r := sharepoint.compliance_report with input as sp({"LegacyAuthProtocolsEnabled": true})
 	some v in r.violations
-	contains(v, "CIS 7.2.1")
+	contains(v, "CIS 7.2.1:")
 }
 
 test_7_2_6_most_permissive_sharing if {
 	r := sharepoint.compliance_report with input as sp({"SharingCapability": "ExternalUserAndGuestSharing"})
 	some v in r.violations
-	contains(v, "CIS 7.2.6")
+	contains(v, "CIS 7.2.6:")
 }
 
 test_7_2_7_anonymous_default_link if {
 	r := sharepoint.compliance_report with input as sp({"DefaultSharingLinkType": "AnonymousAccess"})
 	some v in r.violations
-	contains(v, "CIS 7.2.7")
+	contains(v, "CIS 7.2.7:")
 }
 
 test_7_2_11_default_link_permission_edit if {
 	r := sharepoint.compliance_report with input as sp({"DefaultLinkPermission": "Edit"})
 	some v in r.violations
-	contains(v, "CIS 7.2.11")
+	contains(v, "CIS 7.2.11:")
 }
 
 test_sharepoint_hardened_passes if {
@@ -310,7 +310,7 @@ test_7_2_8_missing_property_blocks_its_control if {
 	}}
 	r.compliant == false
 	some v in r.violations
-	contains(v, "CIS 7.2.8")
+	contains(v, "CIS 7.2.8:")
 	contains(v, "not a pass")
 }
 
@@ -325,8 +325,8 @@ test_sharepoint_declares_the_cmdlet_deviation if {
 test_orchestrator_reports_partial_coverage_honestly if {
 	r := main.compliance_report with input as {}
 	r.benchmark_total_controls == 160
-	r.controls_evaluated == 108
-	r.controls_not_evaluated == 52
+	r.controls_evaluated == 122
+	r.controls_not_evaluated == 38
 	count(r.sections_not_evaluated) == 0
 }
 
@@ -363,13 +363,13 @@ test_1_1_1_on_prem_synced_admin if {
 		{"user_principal_name": "a@c.com", "on_premises_sync_enabled": true},
 	], "global_admin_count": 3})
 	some v in r.violations
-	contains(v, "CIS 1.1.1")
+	contains(v, "CIS 1.1.1:")
 }
 
 test_1_2_1_public_group_flagged if {
 	r := ac.compliance_report with input as ac_input({"public_groups": [{"display_name": "All Co"}]})
 	some v in r.violations
-	contains(v, "CIS 1.2.1")
+	contains(v, "CIS 1.2.1:")
 }
 
 test_1_3_1_password_expiry_configured if {
@@ -377,14 +377,14 @@ test_1_3_1_password_expiry_configured if {
 		{"id": "c.com", "is_verified": true, "password_validity_period_in_days": 90},
 	]})
 	some v in r.violations
-	contains(v, "CIS 1.3.1")
+	contains(v, "CIS 1.3.1:")
 }
 
 test_1_3_1_never_expires_passes if {
 	r := ac.compliance_report with input as ac_input({"domains": [
 		{"id": "c.com", "is_verified": true, "password_validity_period_in_days": 2147483647},
 	]})
-	every v in r.violations { not contains(v, "CIS 1.3.1") }
+	every v in r.violations { not contains(v, "CIS 1.3.1:") }
 }
 
 # The whole point of the `unavailable` contract: a denied endpoint must
@@ -396,7 +396,7 @@ test_unavailable_fact_raises_the_blocked_control if {
 	}}
 	r.compliant == false
 	some v in r.violations
-	contains(v, "CIS 1.3.1")
+	contains(v, "CIS 1.3.1:")
 	contains(v, "not a pass")
 }
 
@@ -414,7 +414,7 @@ test_4_1_secure_by_default_off if {
 		"enrollment_platform_restrictions": [{"display_name": "d", "platforms": {}}],
 	}}
 	some v in r.violations
-	contains(v, "CIS 4.1")
+	contains(v, "CIS 4.1:")
 }
 
 test_4_2_personal_enrollment_permitted if {
@@ -425,7 +425,7 @@ test_4_2_personal_enrollment_permitted if {
 		}}],
 	}}
 	some v in r.violations
-	contains(v, "CIS 4.2")
+	contains(v, "CIS 4.2:")
 }
 
 test_intune_missing_permission_is_not_a_pass if {
@@ -453,7 +453,7 @@ test_complete_attestation_satisfies_the_control if {
 		"attested_by": "operator@example.com", "attested_on": "2026-08-14",
 		"evidence_ref": "screenshot-001.png",
 	}]}
-	every v in r.violations { not contains(v, "CIS 5.2.4.1") }
+	every v in r.violations { not contains(v, "CIS 5.2.4.1:") }
 }
 
 test_attestation_missing_provenance_is_inadmissible if {
@@ -461,7 +461,7 @@ test_attestation_missing_provenance_is_inadmissible if {
 		"control_id": "5.2.4.1", "observed": "All", "attested_by": "operator@example.com",
 	}]}
 	some v in r.violations
-	contains(v, "CIS 5.2.4.1")
+	contains(v, "CIS 5.2.4.1:")
 	contains(v, "not admissible")
 }
 
@@ -511,7 +511,7 @@ test_authorization_policy_cluster_fires_all_seven if {
 	r := entra.compliance_report with input as entra_input(permissive_authz)
 	every c in ["5.1.2.2", "5.1.2.3", "5.1.3.1", "5.1.4.6", "5.1.5.1", "5.1.6.2", "5.1.6.3"] {
 		some v in r.violations
-		contains(v, sprintf("CIS %s", [c]))
+		contains(v, sprintf("CIS %s:", [c]))
 	}
 }
 
@@ -519,7 +519,7 @@ test_authorization_policy_cluster_silent_when_hardened if {
 	r := entra.compliance_report with input as entra_input(hardened_authz)
 	every v in r.violations {
 		every c in ["5.1.2.2", "5.1.2.3", "5.1.3.1", "5.1.4.6", "5.1.5.1", "5.1.6.2", "5.1.6.3"] {
-			not contains(v, sprintf("CIS %s", [c]))
+			not contains(v, sprintf("CIS %s:", [c]))
 		}
 	}
 }
@@ -527,13 +527,13 @@ test_authorization_policy_cluster_silent_when_hardened if {
 test_5_2_3_5_weak_methods_enabled if {
 	r := entra.compliance_report with input as entra_input({"weak_methods_enabled": ["sms"]})
 	some v in r.violations
-	contains(v, "CIS 5.2.3.5")
+	contains(v, "CIS 5.2.3.5:")
 }
 
 test_5_2_3_7_email_otp_enabled if {
 	r := entra.compliance_report with input as entra_input({"email_otp_state": "enabled"})
 	some v in r.violations
-	contains(v, "CIS 5.2.3.7")
+	contains(v, "CIS 5.2.3.7:")
 }
 
 test_5_2_3_4_member_not_mfa_capable if {
@@ -542,7 +542,7 @@ test_5_2_3_4_member_not_mfa_capable if {
 		"members_not_mfa_capable": [{"user_principal_name": "a@c.com"}],
 	}})
 	some v in r.violations
-	contains(v, "CIS 5.2.3.4")
+	contains(v, "CIS 5.2.3.4:")
 }
 
 test_5_1_2_1_legacy_per_user_mfa_flagged if {
@@ -552,7 +552,7 @@ test_5_1_2_1_legacy_per_user_mfa_flagged if {
 		"api_version": "beta",
 	}})
 	some v in r.violations
-	contains(v, "CIS 5.1.2.1")
+	contains(v, "CIS 5.1.2.1:")
 }
 
 # 5.1.8.1 only applies to hybrid tenants -- a cloud-only tenant must not
@@ -561,7 +561,7 @@ test_5_1_8_1_not_raised_for_cloud_only_tenant if {
 	r := entra.compliance_report with input as entra_input({"on_premises_sync": {
 		"configured": false, "password_sync_enabled": null,
 	}})
-	every v in r.violations { not contains(v, "CIS 5.1.8.1") }
+	every v in r.violations { not contains(v, "CIS 5.1.8.1:") }
 }
 
 test_5_1_8_1_raised_for_hybrid_without_hash_sync if {
@@ -569,7 +569,7 @@ test_5_1_8_1_raised_for_hybrid_without_hash_sync if {
 		"configured": true, "password_sync_enabled": false,
 	}})
 	some v in r.violations
-	contains(v, "CIS 5.1.8.1")
+	contains(v, "CIS 5.1.8.1:")
 }
 
 test_entra_declares_the_beta_evidence_caveat if {
@@ -584,7 +584,7 @@ test_entra_unavailable_fact_names_the_blocked_control if {
 	}}
 	r.compliant == false
 	some v in r.violations
-	contains(v, "CIS 5.1.2.2")
+	contains(v, "CIS 5.1.2.2:")
 	contains(v, "not a pass")
 }
 
@@ -597,13 +597,13 @@ teams_input(extra) := {"teams": object.union({"collected": true, "unavailable": 
 test_8_1_1_unapproved_storage_provider if {
 	r := teams.compliance_report with input as teams_input({"client_configuration": {"AllowDropBox": true}})
 	some v in r.violations
-	contains(v, "CIS 8.1.1")
+	contains(v, "CIS 8.1.1:")
 }
 
 test_8_2_2_unmanaged_teams_users_allowed if {
 	r := teams.compliance_report with input as teams_input({"federation_configuration": {"AllowTeamsConsumer": true}})
 	some v in r.violations
-	contains(v, "CIS 8.2.2")
+	contains(v, "CIS 8.2.2:")
 }
 
 test_8_2_1_open_federation_with_no_allow_list if {
@@ -611,14 +611,14 @@ test_8_2_1_open_federation_with_no_allow_list if {
 		"AllowFederatedUsers": true, "AllowedDomains": [],
 	}})
 	some v in r.violations
-	contains(v, "CIS 8.2.1")
+	contains(v, "CIS 8.2.1:")
 }
 
 test_8_2_1_not_raised_when_an_allow_list_exists if {
 	r := teams.compliance_report with input as teams_input({"federation_configuration": {
 		"AllowFederatedUsers": true, "AllowedDomains": ["partner.com"],
 	}})
-	every v in r.violations { not contains(v, "CIS 8.2.1") }
+	every v in r.violations { not contains(v, "CIS 8.2.1:") }
 }
 
 test_8_5_1_anonymous_join_in_global_policy if {
@@ -626,7 +626,7 @@ test_8_5_1_anonymous_join_in_global_policy if {
 		{"Identity": "Global", "AllowAnonymousUsersToJoinMeeting": true},
 	]})
 	some v in r.violations
-	contains(v, "CIS 8.5.1")
+	contains(v, "CIS 8.5.1:")
 }
 
 # The reason all policies are checked, not just Global: a hardened Global
@@ -637,7 +637,7 @@ test_permissive_non_global_policy_is_not_masked_by_a_clean_global if {
 		{"Identity": "Tag:Contractors", "AllowAnonymousUsersToJoinMeeting": true},
 	]})
 	some v in r.violations
-	contains(v, "CIS 8.5.1")
+	contains(v, "CIS 8.5.1:")
 	contains(v, "Contractors")
 }
 
@@ -646,7 +646,7 @@ test_8_5_4_pstn_bypasses_lobby if {
 		{"Identity": "Global", "AllowPSTNUsersToBypassLobby": true},
 	]})
 	some v in r.violations
-	contains(v, "CIS 8.5.4")
+	contains(v, "CIS 8.5.4:")
 }
 
 test_8_6_1_security_reporting_disabled if {
@@ -654,7 +654,7 @@ test_8_6_1_security_reporting_disabled if {
 		{"Identity": "Global", "AllowSecurityEndUserReporting": false},
 	]})
 	some v in r.violations
-	contains(v, "CIS 8.6.1")
+	contains(v, "CIS 8.6.1:")
 }
 
 test_teams_absent_facts_is_not_a_pass if {
@@ -669,7 +669,7 @@ test_teams_unavailable_fact_names_the_blocked_control if {
 		"unavailable": {"meeting_policies": "Teams PowerShell module is not installed"},
 	}}
 	some v in r.violations
-	contains(v, "CIS 8.5.1")
+	contains(v, "CIS 8.5.1:")
 	contains(v, "not a pass")
 }
 
@@ -693,7 +693,7 @@ test_2_1_1_safe_links_not_enabled_for_office if {
 		{"Name": "Default", "EnableSafeLinksForOffice": false},
 	]})
 	some v in r.violations
-	contains(v, "CIS 2.1.1")
+	contains(v, "CIS 2.1.1:")
 }
 
 test_2_1_2_attachment_type_filter_disabled if {
@@ -701,13 +701,13 @@ test_2_1_2_attachment_type_filter_disabled if {
 		{"Identity": "Default", "EnableFileFilter": false},
 	]})
 	some v in r.violations
-	contains(v, "CIS 2.1.2")
+	contains(v, "CIS 2.1.2:")
 }
 
 test_2_1_4_no_safe_attachments_policy if {
 	r := defender.compliance_report with input as def_input({"safe_attachment_policies": []})
 	some v in r.violations
-	contains(v, "CIS 2.1.4")
+	contains(v, "CIS 2.1.4:")
 }
 
 test_2_1_12_ip_allow_list_in_use if {
@@ -715,7 +715,7 @@ test_2_1_12_ip_allow_list_in_use if {
 		{"Name": "Default", "IPAllowList": ["203.0.113.10"]},
 	]})
 	some v in r.violations
-	contains(v, "CIS 2.1.12")
+	contains(v, "CIS 2.1.12:")
 }
 
 test_2_1_14_allowed_sender_domains if {
@@ -723,13 +723,13 @@ test_2_1_14_allowed_sender_domains if {
 		{"Name": "Default", "AllowedSenderDomains": ["partner.com"]},
 	]})
 	some v in r.violations
-	contains(v, "CIS 2.1.14")
+	contains(v, "CIS 2.1.14:")
 }
 
 test_2_4_4_teams_zap_off if {
 	r := defender.compliance_report with input as def_input({"teams_protection_policy": {"ZapEnabled": false}})
 	some v in r.violations
-	contains(v, "CIS 2.4.4")
+	contains(v, "CIS 2.4.4:")
 }
 
 # A tenant without Defender for Office 365 has no ATP cmdlets at all. That
@@ -742,7 +742,7 @@ test_tenant_without_defender_reports_unevaluable_not_compliant if {
 	}}
 	r.compliant == false
 	some v in r.violations
-	contains(v, "CIS 2.1.4")
+	contains(v, "CIS 2.1.4:")
 	contains(v, "not a pass")
 }
 
@@ -757,7 +757,7 @@ pv(extra) := {"purview_ps": object.union({"collected": true, "unavailable": {}},
 test_3_2_1_no_enforcing_dlp_policy if {
 	r := purview.compliance_report with input as pv({"dlp_policies": []})
 	some v in r.violations
-	contains(v, "CIS 3.2.1")
+	contains(v, "CIS 3.2.1:")
 }
 
 # A policy in Test mode reports matches but prevents nothing, so it must
@@ -767,7 +767,7 @@ test_3_2_1_test_mode_policy_does_not_satisfy_the_control if {
 		{"Name": "Pilot", "Enabled": true, "Mode": "TestWithNotifications"},
 	]})
 	some v in r.violations
-	contains(v, "CIS 3.2.1")
+	contains(v, "CIS 3.2.1:")
 }
 
 test_3_2_2_dlp_does_not_cover_teams if {
@@ -775,13 +775,13 @@ test_3_2_2_dlp_does_not_cover_teams if {
 		{"Name": "Default", "Enabled": true, "Mode": "Enforce", "TeamsLocation": []},
 	]})
 	some v in r.violations
-	contains(v, "CIS 3.2.2")
+	contains(v, "CIS 3.2.2:")
 }
 
 test_3_3_1_no_published_label_policy if {
 	r := purview.compliance_report with input as pv({"label_policies": []})
 	some v in r.violations
-	contains(v, "CIS 3.3.1")
+	contains(v, "CIS 3.3.1:")
 }
 
 test_purview_ps_unavailable_is_not_a_pass if {
@@ -790,7 +790,7 @@ test_purview_ps_unavailable_is_not_a_pass if {
 		"unavailable": {"dlp_policies": "purview access denied (blocks 3.2.1, 3.2.2, 3.2.3)"},
 	}}
 	some v in r.violations
-	contains(v, "CIS 3.2.1")
+	contains(v, "CIS 3.2.1:")
 	contains(v, "not a pass")
 }
 
@@ -802,7 +802,7 @@ test_1_3_6_customer_lockbox_disabled if {
 		"exchange": {"collected": true, "unavailable": {}, "organization_config": {"CustomerLockBoxEnabled": false}},
 	}
 	some v in r.violations
-	contains(v, "CIS 1.3.6")
+	contains(v, "CIS 1.3.6:")
 }
 
 test_1_3_9_bookings_without_auth if {
@@ -811,7 +811,7 @@ test_1_3_9_bookings_without_auth if {
 		"exchange": {"collected": true, "unavailable": {}, "organization_config": {"BookingsEnabled": true, "BookingsAuthEnabled": false}},
 	}
 	some v in r.violations
-	contains(v, "CIS 1.3.9")
+	contains(v, "CIS 1.3.9:")
 }
 
 # ── Section 9 -- Fabric ───────────────────────────────────────────────
@@ -823,7 +823,7 @@ fab(settings) := {"fabric": {"collected": true, "unavailable": {}, "settings": s
 test_9_1_4_publish_to_web_open_to_whole_org if {
 	r := fabric.compliance_report with input as fab({"PublishToWeb": {"enabled": true, "enabled_security_groups": []}})
 	some v in r.violations
-	contains(v, "CIS 9.1.4")
+	contains(v, "CIS 9.1.4:")
 }
 
 # Fabric settings are not simple booleans: enabled-but-scoped to named
@@ -833,12 +833,12 @@ test_enabled_but_scoped_to_a_security_group_is_accepted if {
 	r := fabric.compliance_report with input as fab({"PublishToWeb": {
 		"enabled": true, "enabled_security_groups": [{"name": "BI-Publishers"}],
 	}})
-	every v in r.violations { not contains(v, "CIS 9.1.4") }
+	every v in r.violations { not contains(v, "CIS 9.1.4:") }
 }
 
 test_9_1_4_disabled_outright_is_accepted if {
 	r := fabric.compliance_report with input as fab({"PublishToWeb": {"enabled": false}})
-	every v in r.violations { not contains(v, "CIS 9.1.4") }
+	every v in r.violations { not contains(v, "CIS 9.1.4:") }
 }
 
 # 9.1.6 and 9.1.9 are the inverse of the others -- they are protections,
@@ -846,13 +846,13 @@ test_9_1_4_disabled_outright_is_accepted if {
 test_9_1_6_sensitivity_labels_disabled if {
 	r := fabric.compliance_report with input as fab({"EimInformationProtectionEdit": {"enabled": false}})
 	some v in r.violations
-	contains(v, "CIS 9.1.6")
+	contains(v, "CIS 9.1.6:")
 }
 
 test_9_1_9_resource_key_auth_not_blocked if {
 	r := fabric.compliance_report with input as fab({"BlockResourceKeyAuthentication": {"enabled": false}})
 	some v in r.violations
-	contains(v, "CIS 9.1.9")
+	contains(v, "CIS 9.1.9:")
 }
 
 # The Fabric-specific failure an operator will actually hit: valid token,
@@ -864,7 +864,7 @@ test_service_principal_not_enabled_for_fabric_apis if {
 	}}
 	r.compliant == false
 	some v in r.violations
-	contains(v, "CIS 9.1.1")
+	contains(v, "CIS 9.1.1:")
 	contains(v, "not a pass")
 }
 
@@ -875,7 +875,7 @@ test_missing_setting_blocks_its_control if {
 		"settings": {},
 	}}
 	some v in r.violations
-	contains(v, "CIS 9.1.7")
+	contains(v, "CIS 9.1.7:")
 }
 
 test_fabric_absent_facts_is_not_a_pass if {
@@ -886,4 +886,82 @@ test_fabric_absent_facts_is_not_a_pass if {
 
 test_fabric_report_survives_undefined_input if {
 	count(fabric.compliance_report) > 0
+}
+
+# ── 5.2.2.x -- the Conditional Access cluster ─────────────────────────
+
+ca_full(policies, locations) := {"entra": {
+	"collected": true,
+	"unavailable": {},
+	"conditional_access_policies": policies,
+	"named_locations": locations,
+}}
+
+hardened_ca := {
+	"id": "p-all",
+	"state": "enabled",
+	"conditions": {
+		"users": {"includeUsers": ["All"], "includeRoles": ["ga"]},
+		"clientAppTypes": ["exchangeActiveSync", "other"],
+		"signInRiskLevels": ["high", "medium"],
+		"userRiskLevels": ["high"],
+		"applications": {"includeUserActions": ["urn:user:registersecurityinfo"]},
+		"authenticationFlows": {"transferMethods": ["deviceCodeFlow", "authenticationTransfer"]},
+	},
+	"grant_controls": {
+		"builtInControls": ["mfa", "block", "compliantDevice"],
+		"authenticationStrength": {"displayName": "Phishing-resistant MFA"},
+	},
+	"session_controls": {
+		"signInFrequency": {"isEnabled": true, "frequencyInterval": "everyTime"},
+		"persistentBrowser": {"mode": "never"},
+		"secureSignInSession": {"isEnabled": true},
+	},
+}
+
+trusted_locations := [
+	{"id": "l1", "display_name": "HQ", "is_trusted": true, "countries_and_regions": []},
+	{"id": "l2", "display_name": "Permitted countries", "is_trusted": false, "countries_and_regions": ["GB", "US"]},
+]
+
+test_5_2_2_cluster_silent_on_a_hardened_tenant if {
+	r := entra.compliance_report with input as ca_full([hardened_ca], trusted_locations)
+	every v in r.violations {
+		every c in ["5.2.2.4", "5.2.2.5", "5.2.2.6", "5.2.2.7", "5.2.2.8",
+			"5.2.2.9", "5.2.2.10", "5.2.2.11", "5.2.2.12", "5.2.2.13",
+			"5.2.2.14", "5.2.2.15", "5.2.2.16", "5.2.2.17"] {
+			not contains(v, sprintf("CIS %s:", [c]))
+		}
+	}
+}
+
+test_5_2_2_cluster_fires_on_an_empty_tenant if {
+	r := entra.compliance_report with input as ca_full([], [])
+	every c in ["5.2.2.4", "5.2.2.5", "5.2.2.6", "5.2.2.7", "5.2.2.8",
+		"5.2.2.9", "5.2.2.10", "5.2.2.11", "5.2.2.12", "5.2.2.13",
+		"5.2.2.14", "5.2.2.15", "5.2.2.16", "5.2.2.17"] {
+		some v in r.violations
+		contains(v, sprintf("CIS %s:", [c]))
+	}
+}
+
+# A policy that exists but is disabled enforces nothing. This is the
+# single most likely way a tenant looks compliant while being wide open.
+test_disabled_policy_satisfies_no_conditional_access_control if {
+	disabled := object.union(hardened_ca, {"state": "disabled"})
+	r := entra.compliance_report with input as ca_full([disabled], trusted_locations)
+	some v in r.violations
+	contains(v, "CIS 5.2.2.4:")
+}
+
+test_report_only_policy_satisfies_nothing if {
+	ro := object.union(hardened_ca, {"state": "enabledForReportingButNotEnforced"})
+	r := entra.compliance_report with input as ca_full([ro], trusted_locations)
+	some v in r.violations
+	contains(v, "CIS 5.2.2.16:")
+}
+
+test_5_2_2_x_declares_the_undocumented_path if {
+	r := entra.compliance_report with input as {}
+	contains(r.evidence_strength["5.2.2.x"], "path it does not describe")
 }

--- a/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
+++ b/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
@@ -22,9 +22,12 @@ test_admin_center_absent_facts_is_not_a_pass if {
 }
 
 test_defender_absent_facts_is_not_a_pass if {
+	# Section 2 now spans 17 controls across two fact sources (DNS for
+	# SPF/DKIM/DMARC, Exchange PowerShell for the policy controls), so
+	# empty input raises a violation per source rather than exactly one.
 	r := defender.compliance_report with input as {}
 	r.compliant == false
-	count(r.violations) == 1
+	count(r.violations) >= 2
 }
 
 test_entra_absent_facts_is_not_a_pass if {
@@ -102,9 +105,16 @@ test_2_1_10_missing_dmarc if {
 	contains(v, "CIS 2.1.10")
 }
 
-test_all_mail_auth_present_passes if {
+test_mail_authentication_controls_satisfied if {
+	# A domains-only fixture establishes SPF/DKIM/DMARC and nothing else.
+	# With 17 controls in the section it cannot make the whole section
+	# compliant, so assert on the three controls it actually covers.
 	r := defender.compliance_report with input as domains(true, true, true)
-	r.compliant == true
+	every v in r.violations {
+		not contains(v, "CIS 2.1.8")
+		not contains(v, "CIS 2.1.9")
+		not contains(v, "CIS 2.1.10")
+	}
 }
 
 # ── CIS 3.1.1 -- unified audit log ────────────────────────────────────
@@ -312,8 +322,8 @@ test_sharepoint_declares_the_cmdlet_deviation if {
 test_orchestrator_reports_partial_coverage_honestly if {
 	r := main.compliance_report with input as {}
 	r.benchmark_total_controls == 160
-	r.controls_evaluated == 76
-	r.controls_not_evaluated == 84
+	r.controls_evaluated == 90
+	r.controls_not_evaluated == 70
 	count(r.sections_not_evaluated) == 1
 }
 
@@ -669,4 +679,70 @@ test_teams_declares_it_followed_the_documented_cmdlets if {
 
 test_teams_report_survives_undefined_input if {
 	count(teams.compliance_report) > 0
+}
+
+# ── Section 2 -- Defender policy controls (Exchange Online PowerShell) ─
+
+def_input(extra) := {"defender": object.union({"collected": true, "unavailable": {}}, extra)}
+
+test_2_1_1_safe_links_not_enabled_for_office if {
+	r := defender.compliance_report with input as def_input({"safe_links_policies": [
+		{"Name": "Default", "EnableSafeLinksForOffice": false},
+	]})
+	some v in r.violations
+	contains(v, "CIS 2.1.1")
+}
+
+test_2_1_2_attachment_type_filter_disabled if {
+	r := defender.compliance_report with input as def_input({"malware_filter_policies": [
+		{"Identity": "Default", "EnableFileFilter": false},
+	]})
+	some v in r.violations
+	contains(v, "CIS 2.1.2")
+}
+
+test_2_1_4_no_safe_attachments_policy if {
+	r := defender.compliance_report with input as def_input({"safe_attachment_policies": []})
+	some v in r.violations
+	contains(v, "CIS 2.1.4")
+}
+
+test_2_1_12_ip_allow_list_in_use if {
+	r := defender.compliance_report with input as def_input({"connection_filter_policies": [
+		{"Name": "Default", "IPAllowList": ["203.0.113.10"]},
+	]})
+	some v in r.violations
+	contains(v, "CIS 2.1.12")
+}
+
+test_2_1_14_allowed_sender_domains if {
+	r := defender.compliance_report with input as def_input({"content_filter_policies": [
+		{"Name": "Default", "AllowedSenderDomains": ["partner.com"]},
+	]})
+	some v in r.violations
+	contains(v, "CIS 2.1.14")
+}
+
+test_2_4_4_teams_zap_off if {
+	r := defender.compliance_report with input as def_input({"teams_protection_policy": {"ZapEnabled": false}})
+	some v in r.violations
+	contains(v, "CIS 2.4.4")
+}
+
+# A tenant without Defender for Office 365 has no ATP cmdlets at all. That
+# must report as unevaluable, not as compliance -- the absence of a policy
+# you cannot query is not evidence the control is met.
+test_tenant_without_defender_reports_unevaluable_not_compliant if {
+	r := defender.compliance_report with input as {"defender": {
+		"collected": true,
+		"unavailable": {"safe_attachment_policies": "exchange cmdlet returned no output (blocks 2.1.4)"},
+	}}
+	r.compliant == false
+	some v in r.violations
+	contains(v, "CIS 2.1.4")
+	contains(v, "not a pass")
+}
+
+test_defender_report_survives_undefined_input if {
+	count(defender.compliance_report) > 0
 }

--- a/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
+++ b/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
@@ -325,8 +325,8 @@ test_sharepoint_declares_the_cmdlet_deviation if {
 test_orchestrator_reports_partial_coverage_honestly if {
 	r := main.compliance_report with input as {}
 	r.benchmark_total_controls == 160
-	r.controls_evaluated == 122
-	r.controls_not_evaluated == 38
+	r.controls_evaluated == 133
+	r.controls_not_evaluated == 27
 	count(r.sections_not_evaluated) == 0
 }
 
@@ -964,4 +964,73 @@ test_report_only_policy_satisfies_nothing if {
 test_5_2_2_x_declares_the_undocumented_path if {
 	r := entra.compliance_report with input as {}
 	contains(r.evidence_strength["5.2.2.x"], "path it does not describe")
+}
+
+# ── 5.1.4.x / 5.1.5.x / 5.3.x ─────────────────────────────────────────
+
+test_5_1_4_1_device_join_open_to_all if {
+	r := entra.compliance_report with input as entra_input({"device_registration": {
+		"azure_ad_join_allowed_to_join": "all",
+	}})
+	some v in r.violations
+	contains(v, "CIS 5.1.4.1:")
+}
+
+test_5_1_4_3_global_admin_as_local_admin if {
+	r := entra.compliance_report with input as entra_input({"device_registration": {
+		"local_admin_global_admins_enabled": true,
+	}})
+	some v in r.violations
+	contains(v, "CIS 5.1.4.3:")
+}
+
+test_5_1_4_5_laps_disabled if {
+	r := entra.compliance_report with input as entra_input({"laps_enabled": false})
+	some v in r.violations
+	contains(v, "CIS 5.1.4.5:")
+}
+
+# The app management policy expresses restrictions as a list of rules,
+# not flags -- a rule present but disabled must not satisfy the control.
+test_5_1_5_3_disabled_restriction_does_not_satisfy_the_control if {
+	r := entra.compliance_report with input as entra_input({"app_management": {
+		"password_credentials": [{"restrictionType": "passwordAddition", "state": "disabled"}],
+	}})
+	some v in r.violations
+	contains(v, "CIS 5.1.5.3:")
+}
+
+test_5_1_5_3_enabled_restriction_satisfies_the_control if {
+	r := entra.compliance_report with input as entra_input({"app_management": {
+		"password_credentials": [{"restrictionType": "passwordAddition", "state": "enabled"}],
+	}})
+	every v in r.violations { not contains(v, "CIS 5.1.5.3:") }
+}
+
+test_5_3_2_no_guest_access_review if {
+	r := entra.compliance_report with input as entra_input({"access_reviews": [
+		{"id": "r1", "scope_query": "/roleAssignments", "status": "InProgress"},
+	]})
+	some v in r.violations
+	contains(v, "CIS 5.3.2:")
+}
+
+test_5_3_3_no_privileged_role_access_review if {
+	r := entra.compliance_report with input as entra_input({"access_reviews": [
+		{"id": "r1", "scope_query": "/groups/guests", "status": "InProgress"},
+	]})
+	some v in r.violations
+	contains(v, "CIS 5.3.3:")
+}
+
+# A beta sub-resource older tenants do not expose must block its control,
+# not read as "LAPS is off".
+test_missing_laps_endpoint_blocks_its_control_rather_than_failing_it if {
+	r := entra.compliance_report with input as {"entra": {
+		"collected": true,
+		"unavailable": {"laps_policy": "not found (/policies/deviceRegistrationPolicy/localAdminPassword)"},
+	}}
+	some v in r.violations
+	contains(v, "CIS 5.1.4.5:")
+	contains(v, "not a pass")
 }

--- a/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
+++ b/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
@@ -126,9 +126,12 @@ test_3_1_1_audit_log_unavailable if {
 	contains(v, "CIS 3.1.1")
 }
 
-test_3_1_1_audit_log_available_passes if {
+test_3_1_1_audit_log_available_satisfies_its_control if {
+	# Section 3 now spans 5 controls across two fact sources, so an
+	# audit-log-only fixture cannot make the section compliant. Assert on
+	# the control it actually establishes.
 	r := purview.compliance_report with input as {"purview": {"audit_log_accessible": true}}
-	r.compliant == true
+	every v in r.violations { not contains(v, "CIS 3.1.1") }
 }
 
 # ── CIS 5.2.2.x / 5.3.1 -- Conditional Access and PIM ─────────────────
@@ -322,8 +325,8 @@ test_sharepoint_declares_the_cmdlet_deviation if {
 test_orchestrator_reports_partial_coverage_honestly if {
 	r := main.compliance_report with input as {}
 	r.benchmark_total_controls == 160
-	r.controls_evaluated == 90
-	r.controls_not_evaluated == 70
+	r.controls_evaluated == 96
+	r.controls_not_evaluated == 64
 	count(r.sections_not_evaluated) == 1
 }
 
@@ -745,4 +748,68 @@ test_tenant_without_defender_reports_unevaluable_not_compliant if {
 
 test_defender_report_survives_undefined_input if {
 	count(defender.compliance_report) > 0
+}
+
+# ── Section 3 -- DLP and sensitivity labels ───────────────────────────
+
+pv(extra) := {"purview_ps": object.union({"collected": true, "unavailable": {}}, extra)}
+
+test_3_2_1_no_enforcing_dlp_policy if {
+	r := purview.compliance_report with input as pv({"dlp_policies": []})
+	some v in r.violations
+	contains(v, "CIS 3.2.1")
+}
+
+# A policy in Test mode reports matches but prevents nothing, so it must
+# not satisfy a control asking for DLP to be enabled.
+test_3_2_1_test_mode_policy_does_not_satisfy_the_control if {
+	r := purview.compliance_report with input as pv({"dlp_policies": [
+		{"Name": "Pilot", "Enabled": true, "Mode": "TestWithNotifications"},
+	]})
+	some v in r.violations
+	contains(v, "CIS 3.2.1")
+}
+
+test_3_2_2_dlp_does_not_cover_teams if {
+	r := purview.compliance_report with input as pv({"dlp_policies": [
+		{"Name": "Default", "Enabled": true, "Mode": "Enforce", "TeamsLocation": []},
+	]})
+	some v in r.violations
+	contains(v, "CIS 3.2.2")
+}
+
+test_3_3_1_no_published_label_policy if {
+	r := purview.compliance_report with input as pv({"label_policies": []})
+	some v in r.violations
+	contains(v, "CIS 3.3.1")
+}
+
+test_purview_ps_unavailable_is_not_a_pass if {
+	r := purview.compliance_report with input as {"purview_ps": {
+		"collected": true,
+		"unavailable": {"dlp_policies": "purview access denied (blocks 3.2.1, 3.2.2, 3.2.3)"},
+	}}
+	some v in r.violations
+	contains(v, "CIS 3.2.1")
+	contains(v, "not a pass")
+}
+
+# ── Section 1 controls sourced from the Exchange collector ────────────
+
+test_1_3_6_customer_lockbox_disabled if {
+	r := ac.compliance_report with input as {
+		"admin_center": {"collected": true, "unavailable": {}},
+		"exchange": {"collected": true, "unavailable": {}, "organization_config": {"CustomerLockBoxEnabled": false}},
+	}
+	some v in r.violations
+	contains(v, "CIS 1.3.6")
+}
+
+test_1_3_9_bookings_without_auth if {
+	r := ac.compliance_report with input as {
+		"admin_center": {"collected": true, "unavailable": {}},
+		"exchange": {"collected": true, "unavailable": {}, "organization_config": {"BookingsEnabled": true, "BookingsAuthEnabled": false}},
+	}
+	some v in r.violations
+	contains(v, "CIS 1.3.9")
 }

--- a/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
+++ b/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
@@ -240,41 +240,71 @@ test_6_1_2_declares_its_sampling_limit if {
 
 # ── CIS 7.2.x -- SharePoint sharing ───────────────────────────────────
 
-sp(cap, link, perm, legacy) := {"sharepoint": {
-	"settings_reachable": true,
-	"sharing_capability": cap,
-	"default_sharing_link_type": link,
-	"default_link_permission": perm,
-	"legacy_auth_protocols_enabled": legacy,
+sp(props) := {"sharepoint": {
+	"collected": true,
+	"unavailable": {},
+	"tenant": props,
 }}
 
 test_7_2_1_legacy_auth_enabled if {
-	r := sharepoint.compliance_report with input as sp("Disabled", "Internal", "View", true)
+	r := sharepoint.compliance_report with input as sp({"LegacyAuthProtocolsEnabled": true})
 	some v in r.violations
 	contains(v, "CIS 7.2.1")
 }
 
 test_7_2_6_most_permissive_sharing if {
-	r := sharepoint.compliance_report with input as sp("ExternalUserAndGuestSharing", "Internal", "View", false)
+	r := sharepoint.compliance_report with input as sp({"SharingCapability": "ExternalUserAndGuestSharing"})
 	some v in r.violations
 	contains(v, "CIS 7.2.6")
 }
 
 test_7_2_7_anonymous_default_link if {
-	r := sharepoint.compliance_report with input as sp("Disabled", "AnonymousAccess", "View", false)
+	r := sharepoint.compliance_report with input as sp({"DefaultSharingLinkType": "AnonymousAccess"})
 	some v in r.violations
 	contains(v, "CIS 7.2.7")
 }
 
 test_7_2_11_default_link_permission_edit if {
-	r := sharepoint.compliance_report with input as sp("Disabled", "Internal", "Edit", false)
+	r := sharepoint.compliance_report with input as sp({"DefaultLinkPermission": "Edit"})
 	some v in r.violations
 	contains(v, "CIS 7.2.11")
 }
 
 test_sharepoint_hardened_passes if {
-	r := sharepoint.compliance_report with input as sp("Disabled", "Internal", "View", false)
+	r := sharepoint.compliance_report with input as sp({
+		"LegacyAuthProtocolsEnabled": false,
+		"EnableAzureADB2BIntegration": true,
+		"SharingCapability": "Disabled",
+		"OneDriveSharingCapability": "Disabled",
+		"PreventExternalUsersFromResharing": true,
+		"DefaultSharingLinkType": "Internal",
+		"SharingDomainRestrictionMode": "AllowList",
+		"ExternalUserExpirationRequired": true,
+		"EmailAttestationRequired": true,
+		"DefaultLinkPermission": "View",
+		"DisallowInfectedFileDownload": true,
+	})
 	r.compliant == true
+}
+
+# A property PnP did not return must block its control, not read as null
+# and pass -- the property name could be wrong or renamed.
+test_7_2_8_missing_property_blocks_its_control if {
+	r := sharepoint.compliance_report with input as {"sharepoint": {
+		"collected": true,
+		"unavailable": {"SharingDomainRestrictionMode": "Get-PnPTenant did not return the property"},
+		"tenant": {},
+	}}
+	r.compliant == false
+	some v in r.violations
+	contains(v, "CIS 7.2.8")
+	contains(v, "not a pass")
+}
+
+test_sharepoint_declares_the_cmdlet_deviation if {
+	r := sharepoint.compliance_report with input as {}
+	contains(r.evidence_strength.section, "Get-PnPTenant")
+	contains(r.evidence_strength.section, "Windows-only")
 }
 
 # ── Orchestrator accounting ───────────────────────────────────────────
@@ -282,8 +312,8 @@ test_sharepoint_hardened_passes if {
 test_orchestrator_reports_partial_coverage_honestly if {
 	r := main.compliance_report with input as {}
 	r.benchmark_total_controls == 160
-	r.controls_evaluated == 52
-	r.controls_not_evaluated == 108
+	r.controls_evaluated == 60
+	r.controls_not_evaluated == 100
 	count(r.sections_not_evaluated) == 2
 }
 

--- a/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
+++ b/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
@@ -312,9 +312,9 @@ test_sharepoint_declares_the_cmdlet_deviation if {
 test_orchestrator_reports_partial_coverage_honestly if {
 	r := main.compliance_report with input as {}
 	r.benchmark_total_controls == 160
-	r.controls_evaluated == 60
-	r.controls_not_evaluated == 100
-	count(r.sections_not_evaluated) == 2
+	r.controls_evaluated == 76
+	r.controls_not_evaluated == 84
+	count(r.sections_not_evaluated) == 1
 }
 
 test_orchestrator_exposes_no_bare_compliant_field if {
@@ -573,4 +573,100 @@ test_entra_unavailable_fact_names_the_blocked_control if {
 	some v in r.violations
 	contains(v, "CIS 5.1.2.2")
 	contains(v, "not a pass")
+}
+
+# ── Section 8 -- Teams ────────────────────────────────────────────────
+
+import data.cis_m365_v7.teams as teams
+
+teams_input(extra) := {"teams": object.union({"collected": true, "unavailable": {}}, extra)}
+
+test_8_1_1_unapproved_storage_provider if {
+	r := teams.compliance_report with input as teams_input({"client_configuration": {"AllowDropBox": true}})
+	some v in r.violations
+	contains(v, "CIS 8.1.1")
+}
+
+test_8_2_2_unmanaged_teams_users_allowed if {
+	r := teams.compliance_report with input as teams_input({"federation_configuration": {"AllowTeamsConsumer": true}})
+	some v in r.violations
+	contains(v, "CIS 8.2.2")
+}
+
+test_8_2_1_open_federation_with_no_allow_list if {
+	r := teams.compliance_report with input as teams_input({"federation_configuration": {
+		"AllowFederatedUsers": true, "AllowedDomains": [],
+	}})
+	some v in r.violations
+	contains(v, "CIS 8.2.1")
+}
+
+test_8_2_1_not_raised_when_an_allow_list_exists if {
+	r := teams.compliance_report with input as teams_input({"federation_configuration": {
+		"AllowFederatedUsers": true, "AllowedDomains": ["partner.com"],
+	}})
+	every v in r.violations { not contains(v, "CIS 8.2.1") }
+}
+
+test_8_5_1_anonymous_join_in_global_policy if {
+	r := teams.compliance_report with input as teams_input({"meeting_policies": [
+		{"Identity": "Global", "AllowAnonymousUsersToJoinMeeting": true},
+	]})
+	some v in r.violations
+	contains(v, "CIS 8.5.1")
+}
+
+# The reason all policies are checked, not just Global: a hardened Global
+# policy does not protect users assigned a permissive one.
+test_permissive_non_global_policy_is_not_masked_by_a_clean_global if {
+	r := teams.compliance_report with input as teams_input({"meeting_policies": [
+		{"Identity": "Global", "AllowAnonymousUsersToJoinMeeting": false},
+		{"Identity": "Tag:Contractors", "AllowAnonymousUsersToJoinMeeting": true},
+	]})
+	some v in r.violations
+	contains(v, "CIS 8.5.1")
+	contains(v, "Contractors")
+}
+
+test_8_5_4_pstn_bypasses_lobby if {
+	r := teams.compliance_report with input as teams_input({"meeting_policies": [
+		{"Identity": "Global", "AllowPSTNUsersToBypassLobby": true},
+	]})
+	some v in r.violations
+	contains(v, "CIS 8.5.4")
+}
+
+test_8_6_1_security_reporting_disabled if {
+	r := teams.compliance_report with input as teams_input({"messaging_policies": [
+		{"Identity": "Global", "AllowSecurityEndUserReporting": false},
+	]})
+	some v in r.violations
+	contains(v, "CIS 8.6.1")
+}
+
+test_teams_absent_facts_is_not_a_pass if {
+	r := teams.compliance_report with input as {}
+	r.compliant == false
+	count(r.violations) > 0
+}
+
+test_teams_unavailable_fact_names_the_blocked_control if {
+	r := teams.compliance_report with input as {"teams": {
+		"collected": true,
+		"unavailable": {"meeting_policies": "Teams PowerShell module is not installed"},
+	}}
+	some v in r.violations
+	contains(v, "CIS 8.5.1")
+	contains(v, "not a pass")
+}
+
+# Section 8 follows CIS's own cmdlets, unlike section 7 -- the note should
+# say so rather than claiming a deviation that does not exist here.
+test_teams_declares_it_followed_the_documented_cmdlets if {
+	r := teams.compliance_report with input as {}
+	contains(r.evidence_strength.section, "cmdlets CIS documents")
+}
+
+test_teams_report_survives_undefined_input if {
+	count(teams.compliance_report) > 0
 }

--- a/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
+++ b/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
@@ -325,9 +325,9 @@ test_sharepoint_declares_the_cmdlet_deviation if {
 test_orchestrator_reports_partial_coverage_honestly if {
 	r := main.compliance_report with input as {}
 	r.benchmark_total_controls == 160
-	r.controls_evaluated == 96
-	r.controls_not_evaluated == 64
-	count(r.sections_not_evaluated) == 1
+	r.controls_evaluated == 108
+	r.controls_not_evaluated == 52
+	count(r.sections_not_evaluated) == 0
 }
 
 test_orchestrator_exposes_no_bare_compliant_field if {
@@ -812,4 +812,78 @@ test_1_3_9_bookings_without_auth if {
 	}
 	some v in r.violations
 	contains(v, "CIS 1.3.9")
+}
+
+# ── Section 9 -- Fabric ───────────────────────────────────────────────
+
+import data.cis_m365_v7.fabric as fabric
+
+fab(settings) := {"fabric": {"collected": true, "unavailable": {}, "settings": settings}}
+
+test_9_1_4_publish_to_web_open_to_whole_org if {
+	r := fabric.compliance_report with input as fab({"PublishToWeb": {"enabled": true, "enabled_security_groups": []}})
+	some v in r.violations
+	contains(v, "CIS 9.1.4")
+}
+
+# Fabric settings are not simple booleans: enabled-but-scoped to named
+# security groups is what the benchmark accepts. Treating that as a
+# violation would flood a correctly-configured tenant with false findings.
+test_enabled_but_scoped_to_a_security_group_is_accepted if {
+	r := fabric.compliance_report with input as fab({"PublishToWeb": {
+		"enabled": true, "enabled_security_groups": [{"name": "BI-Publishers"}],
+	}})
+	every v in r.violations { not contains(v, "CIS 9.1.4") }
+}
+
+test_9_1_4_disabled_outright_is_accepted if {
+	r := fabric.compliance_report with input as fab({"PublishToWeb": {"enabled": false}})
+	every v in r.violations { not contains(v, "CIS 9.1.4") }
+}
+
+# 9.1.6 and 9.1.9 are the inverse of the others -- they are protections,
+# so the benchmark wants them ON.
+test_9_1_6_sensitivity_labels_disabled if {
+	r := fabric.compliance_report with input as fab({"EimInformationProtectionEdit": {"enabled": false}})
+	some v in r.violations
+	contains(v, "CIS 9.1.6")
+}
+
+test_9_1_9_resource_key_auth_not_blocked if {
+	r := fabric.compliance_report with input as fab({"BlockResourceKeyAuthentication": {"enabled": false}})
+	some v in r.violations
+	contains(v, "CIS 9.1.9")
+}
+
+# The Fabric-specific failure an operator will actually hit: valid token,
+# refused API, because the admin-portal switch does not name the app.
+test_service_principal_not_enabled_for_fabric_apis if {
+	r := fabric.compliance_report with input as {"fabric": {
+		"collected": true,
+		"unavailable": {"tenant_settings": "Fabric admin API returned 403 -- Service principals can use Fabric APIs must name a security group containing this app"},
+	}}
+	r.compliant == false
+	some v in r.violations
+	contains(v, "CIS 9.1.1")
+	contains(v, "not a pass")
+}
+
+test_missing_setting_blocks_its_control if {
+	r := fabric.compliance_report with input as {"fabric": {
+		"collected": true,
+		"unavailable": {"ShareLinkToEntireOrg": "the Fabric admin API did not return the setting"},
+		"settings": {},
+	}}
+	some v in r.violations
+	contains(v, "CIS 9.1.7")
+}
+
+test_fabric_absent_facts_is_not_a_pass if {
+	r := fabric.compliance_report with input as {}
+	r.compliant == false
+	count(r.violations) > 0
+}
+
+test_fabric_report_survives_undefined_input if {
+	count(fabric.compliance_report) > 0
 }

--- a/scripts/check_cis_ids.py
+++ b/scripts/check_cis_ids.py
@@ -90,21 +90,34 @@ def scan(policy_dir: pathlib.Path, prefix: str):
 
 SECTION_DECL = re.compile(r'"section":\s*"(\d+)"')
 SECTION_TOTAL = re.compile(r'"section_total_controls":\s*(\d+)')
-# A control id used as an object key, e.g. in a lookup table:
-#     REQUIRES_ATTESTATION := {"5.2.4.1": "...", ...}
-# These never appear in a `CIS <id>` literal because the message is built
-# with sprintf, so the citation scan cannot see them. Check them directly
-# or a whole table of ids goes unverified.
-KEYED_ID = re.compile(r'"(\d+(?:\.\d+)+)"\s*:')
+# A control id that appears as a quoted STRING rather than inside a
+# `CIS <id>` message. Three shapes, all of which have bitten this guard:
+#
+#   as a key    REQUIRES_ATTESTATION := {"5.2.4.1": "..."}
+#   as a value  SETTING_CONTROLS := {"PublishToWeb": "9.1.4"}
+#   in a list   "controls": ["9.1.1", "9.1.2", ...]
+#
+# None appear in a `CIS <id>` literal when the message is built with
+# sprintf, so the citation scan cannot see any of them. Matching any
+# quoted id covers all three -- narrowing to one shape is what let the
+# section 9 ids through unverified.
+QUOTED_ID = re.compile(r'"(\d+(?:\.\d+)+)"')
+# Version strings are dotted numbers too. "benchmark_version": "7.0.0"
+# is not a citation of control 7.0.0 -- exclude those lines rather than
+# narrowing the id pattern, which would reintroduce the blind spot.
+VERSION_LINE = re.compile(r'(benchmark_version|benchmark_released|"version")')
 
 
 def keyed_ids(policy_dir: pathlib.Path):
-    """Yield (file, line_no, control_id) for ids used as object keys."""
+    """Yield (file, line_no, control_id) for ids appearing as quoted
+    strings anywhere in a policy file."""
     for rego in sorted(policy_dir.rglob("*.rego")):
         if rego.name.startswith("test_") or rego.name.endswith("_test.rego"):
             continue
         for n, line in enumerate(rego.read_text(encoding="utf-8").splitlines(), 1):
-            for m in KEYED_ID.finditer(line):
+            if VERSION_LINE.search(line):
+                continue
+            for m in QUOTED_ID.finditer(line):
                 yield rego, n, m.group(1)
 
 


### PR DESCRIPTION
Coverage **52 → 60 of 160**. §7 joins §6 at full coverage — all 12 controls, from a single `Get-PnPTenant` call.

## A permanent deviation, recorded rather than hidden

CIS audits every §7 control with `Get-SPOTenant`, which lives in `Microsoft.Online.SharePoint.PowerShell` — **a Windows-only module that cannot be installed in a Linux EE**. Verified absent from the built `aac-m365-ee` image rather than assumed:

```
SPO module present: False
Get-PnPTenant / Get-PnPTenantSite / Get-PnPSite: present
```

`Get-PnPTenant` reads the same CSOM tenant properties, so values are equivalent — but the tool is not the benchmark's. The report carries a section-level `evidence_strength` note. **This is not a gap to close later**; it cannot be closed while the EE is Linux.

Had I written the collector from CIS's cmdlet list without checking the image, all 12 controls would have failed at runtime.

## Supersedes the Graph path for four controls

`7.2.1`, `7.2.6`, `7.2.7`, `7.2.11` were read from Graph `/admin/sharepoint/settings` — the right answer by a path CIS doesn't document at all. The tenant properties are at least the same underlying settings the benchmark reads.

## Fail closed on property names I couldn't verify

Without a live tenant I can't confirm PnP's property names. So the collector fetches the **whole** tenant object rather than a `Select-Object` list — selecting a non-existent property yields null, indistinguishable from a genuinely-null setting — and records every expected-but-absent property, naming the controls it blocks. Wrong or renamed property → controls report unevaluable, not pass. Covered by a test.

## Verification

- `opa test . --ignore .github` → **407/407**
- guard → 60 cited ids + 18 lookup ids, coherent, totals match

🤖 Generated with [Claude Code](https://claude.com/claude-code)