### PR TITLE
docs(m365_v7): paraphrase the one verbatim CIS title in the README

### DIFF
--- a/benchmarks/cis/saas/m365_v7/README.md
+++ b/benchmarks/cis/saas/m365_v7/README.md
@@ -53,8 +53,8 @@ It applies two checks:
 1. **Existence** — every cited id must appear in the benchmark.
 2. **Coherence** — the message must share a substantive word with the
    benchmark's own title for that id. This is the check that catches
-   `"CIS 1.1.1: Security Defaults..."` when `1.1.1` is actually
-   *"Ensure Administrative accounts are cloud-only"*.
+   `"CIS 1.1.1: Security Defaults..."` when `1.1.1` is actually about
+   administrative accounts being cloud-only.
 
 It runs in CI on every PR touching this tree.
 


### PR DESCRIPTION
This repo is public and Apache-2.0. CIS terms require contacting CIS Legal before reproducing portions of a benchmark — which is why the shipped enumeration is a keyword digest rather than titles.

One README example quoted a recommendation title in full to illustrate the coherence check. Paraphrased; the example works just as well describing the control as quoting it.

**Audited the whole `m365_v7` tree against all 160 titles** — this was the only occurrence, and there are now zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)