### PR TITLE
feat(cis/m365_v7): Authenticator hardening, smart lockout, group creation

### DIFF
--- a/benchmarks/cis/saas/m365_v7/COVERAGE.md
+++ b/benchmarks/cis/saas/m365_v7/COVERAGE.md
@@ -1,8 +1,8 @@
 # CIS Microsoft 365 Foundations Benchmark v7.0.0 — coverage
 
-**Version:** v2.0
+**Version:** v2.1
 **Benchmark:** CIS Microsoft 365 Foundations Benchmark **v7.0.0**, released 2026-05-20
-**Evaluated:** **133 of 160** recommendations (**83%**)
+**Evaluated:** **138 of 160** recommendations (**86%**)
 **Requires attestation:** 6 (verified to have no app-only read path)
 **Unresolved:** 10 (parked pending a live-tenant probe during the POC)
 
@@ -20,18 +20,18 @@ modules themselves.
 | 2 | Microsoft Defender | 21 | **17** | `defender_validation.rego` |
 | 3 | Microsoft Purview | 5 | **5** | `purview_validation.rego` |
 | 4 | Microsoft Intune admin center | 2 | 2 | `intune_validation.rego` |
-| 5 | Microsoft Entra admin center | 63 | **45** | `entra_validation.rego` |
+| 5 | Microsoft Entra admin center | 63 | **50** | `entra_validation.rego` |
 | 6 | Exchange admin center | 13 | **13** | `exchange_validation.rego` |
 | 7 | SharePoint admin center | 12 | **12** | `sharepoint_validation.rego` |
 | 8 | Microsoft Teams admin center | 17 | **16** | `teams_validation.rego` |
 | 9 | Microsoft Fabric | 12 | **12** | `fabric_validation.rego` |
-| | **Total** | **160** | **133** | |
+| | **Total** | **160** | **138** | |
 
 Evaluated ids: `1.1.1`, `1.1.3`, `1.1.4`, `1.2.1`, `1.3.1`, `1.3.2`, `1.3.4`,
 `1.3.5`, `1.3.7`, `4.1`, `4.2`, `2.1.8`, `2.1.9`, `2.1.10`, `3.1.1`, `5.2.2.1`,
 `5.2.2.2`, `5.2.2.3`, `5.3.1`, `6.1.1`, `7.2.1`, `7.2.6`, `7.2.7`, `7.2.11`.
 
-## Why coverage is 83%
+## Why coverage is 86%
 
 Coverage is bounded by **fact collection**, not by policy. The `aac.m365`
 collection currently issues ten Microsoft Graph calls. Four of its seven

--- a/benchmarks/cis/saas/m365_v7/entra_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/entra_validation.rego
@@ -521,6 +521,56 @@ violation contains msg if {
 	msg := "CIS 5.3.3: no access review is configured for privileged roles, so standing administrative access is never re-attested"
 }
 
+
+# ── Authenticator hardening and smart lockout ────────────────────────
+# Five more controls, all riding on policy objects already fetched --
+# they were simply not projected into the facts. CIS documents these as
+# portal steps.
+
+MAX_LOCKOUT_THRESHOLD := 10
+MIN_LOCKOUT_DURATION_SECONDS := 60
+
+# CIS 5.2.3.1 -- Authenticator must show app and location, and require
+# number matching, so a push cannot be approved blind.
+violation contains msg if {
+	available("authentication_methods_policy")
+	input.entra.authenticator.state == "enabled"
+	some feature in ["number_matching_state", "show_app_information_state", "show_geographic_location_state"]
+	input.entra.authenticator[feature] != "enabled"
+	msg := sprintf("CIS 5.2.3.1: Microsoft Authenticator is not configured to protect against MFA fatigue -- '%s' is not enabled, so a push can be approved without seeing what is being approved", [feature])
+}
+
+# CIS 5.2.3.10 -- companion applications.
+violation contains msg if {
+	available("authentication_methods_policy")
+	input.entra.authenticator.companion_app_allowed_state == "enabled"
+	msg := "CIS 5.2.3.10: Microsoft Authenticator on companion applications is not disabled, which widens the surface on which an approval can be granted"
+}
+
+# CIS 5.2.3.8 / 5.2.3.9 -- smart lockout.
+violation contains msg if {
+	available("group_settings")
+	input.entra.lockout.settings_present == true
+	to_number(input.entra.lockout.threshold) > MAX_LOCKOUT_THRESHOLD
+	msg := sprintf("CIS 5.2.3.8: the account lockout threshold is %v; the benchmark expects '10' or less", [input.entra.lockout.threshold])
+}
+
+violation contains msg if {
+	available("group_settings")
+	input.entra.lockout.settings_present == true
+	to_number(input.entra.lockout.duration_seconds) < MIN_LOCKOUT_DURATION_SECONDS
+	msg := sprintf("CIS 5.2.3.9: the account lockout duration in seconds is %v; the benchmark expects at least %d", [input.entra.lockout.duration_seconds, MIN_LOCKOUT_DURATION_SECONDS])
+}
+
+# CIS 5.1.3.4 -- Microsoft 365 group creation restricted.
+violation contains msg if {
+	available("group_settings")
+	input.entra.group_creation.settings_present == true
+	lower(object.get(input.entra.group_creation, "enabled", "")) == "true"
+	input.entra.group_creation.allowed_group_id == ""
+	msg := "CIS 5.1.3.4: users can create Microsoft 365 groups in Azure portals, APIs or PowerShell with no restricting group -- group membership drives access, so unmanaged creation undermines authorization"
+}
+
 # ── Fail closed on every gap the collector recorded ───────────────────
 FACT_CONTROLS := {
 	"authorization_policy": "5.1.2.2",
@@ -561,9 +611,9 @@ compliance_report := {
 	"section": "5",
 	"name": "Microsoft Entra admin center",
 	"section_total_controls": 63,
-	"controls_evaluated": 45,
+	"controls_evaluated": 50,
 	"controls": [
-		"5.1.2.1", "5.1.2.2", "5.1.2.3", "5.1.3.1", "5.1.4.6",
+		"5.1.2.1", "5.1.2.2", "5.1.2.3", "5.1.3.1", "5.1.3.4", "5.1.4.6",
 		"5.1.4.1", "5.1.4.2", "5.1.4.3", "5.1.4.4", "5.1.4.5",
 		"5.1.5.1", "5.1.5.2", "5.1.5.3", "5.1.5.4", "5.1.5.5", "5.1.5.6",
 		"5.1.6.2", "5.1.6.3", "5.1.8.1",
@@ -571,7 +621,8 @@ compliance_report := {
 		"5.2.2.6", "5.2.2.7", "5.2.2.8", "5.2.2.9", "5.2.2.10",
 		"5.2.2.11", "5.2.2.12", "5.2.2.13", "5.2.2.14", "5.2.2.15",
 		"5.2.2.16", "5.2.2.17",
-		"5.2.3.2", "5.2.3.3", "5.2.3.4", "5.2.3.5", "5.2.3.6", "5.2.3.7",
+		"5.2.3.1", "5.2.3.2", "5.2.3.3", "5.2.3.4", "5.2.3.5", "5.2.3.6",
+		"5.2.3.7", "5.2.3.8", "5.2.3.9", "5.2.3.10",
 		"5.3.1", "5.3.2", "5.3.3",
 	],
 	"facts_present": collected,

--- a/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
+++ b/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
@@ -325,8 +325,8 @@ test_sharepoint_declares_the_cmdlet_deviation if {
 test_orchestrator_reports_partial_coverage_honestly if {
 	r := main.compliance_report with input as {}
 	r.benchmark_total_controls == 160
-	r.controls_evaluated == 133
-	r.controls_not_evaluated == 27
+	r.controls_evaluated == 138
+	r.controls_not_evaluated == 22
 	count(r.sections_not_evaluated) == 0
 }
 
@@ -1033,4 +1033,71 @@ test_missing_laps_endpoint_blocks_its_control_rather_than_failing_it if {
 	some v in r.violations
 	contains(v, "CIS 5.1.4.5:")
 	contains(v, "not a pass")
+}
+
+# ── Authenticator hardening and smart lockout ─────────────────────────
+
+test_5_2_3_1_number_matching_disabled if {
+	r := entra.compliance_report with input as entra_input({"authenticator": {
+		"state": "enabled",
+		"number_matching_state": "disabled",
+		"show_app_information_state": "enabled",
+		"show_geographic_location_state": "enabled",
+	}})
+	some v in r.violations
+	contains(v, "CIS 5.2.3.1:")
+}
+
+test_5_2_3_1_fully_hardened_authenticator_passes if {
+	r := entra.compliance_report with input as entra_input({"authenticator": {
+		"state": "enabled",
+		"number_matching_state": "enabled",
+		"show_app_information_state": "enabled",
+		"show_geographic_location_state": "enabled",
+	}})
+	every v in r.violations { not contains(v, "CIS 5.2.3.1:") }
+}
+
+test_5_2_3_8_lockout_threshold_too_high if {
+	r := entra.compliance_report with input as entra_input({"lockout": {
+		"settings_present": true, "threshold": "25", "duration_seconds": "60",
+	}})
+	some v in r.violations
+	contains(v, "CIS 5.2.3.8:")
+}
+
+test_5_2_3_9_lockout_duration_too_short if {
+	r := entra.compliance_report with input as entra_input({"lockout": {
+		"settings_present": true, "threshold": "10", "duration_seconds": "30",
+	}})
+	some v in r.violations
+	contains(v, "CIS 5.2.3.9:")
+}
+
+# A tenant that has never set these has no LockoutThreshold value at all.
+# Absent is not the same as non-compliant -- treating a missing value as 0
+# would report every such tenant as failing 5.2.3.9.
+test_absent_lockout_settings_do_not_fabricate_a_finding if {
+	r := entra.compliance_report with input as entra_input({"lockout": {
+		"settings_present": false,
+	}})
+	every v in r.violations {
+		not contains(v, "CIS 5.2.3.8:")
+		not contains(v, "CIS 5.2.3.9:")
+	}
+}
+
+test_5_1_3_4_unrestricted_group_creation if {
+	r := entra.compliance_report with input as entra_input({"group_creation": {
+		"settings_present": true, "enabled": "True", "allowed_group_id": "",
+	}})
+	some v in r.violations
+	contains(v, "CIS 5.1.3.4:")
+}
+
+test_5_1_3_4_group_creation_restricted_to_a_group_passes if {
+	r := entra.compliance_report with input as entra_input({"group_creation": {
+		"settings_present": true, "enabled": "True", "allowed_group_id": "0000-group",
+	}})
+	every v in r.violations { not contains(v, "CIS 5.1.3.4:") }
 }


### PR DESCRIPTION
Coverage **133 → 138 of 160 (86%)**. §5 goes 45 → 50.

## Five controls, no new endpoint

Every one rides on a policy object the collector **already fetched** — the authentication methods policy and `/groupSettings` — and was simply not being projected into the facts:

| Control | |
|---|---|
| 5.2.3.1 | Authenticator number matching, app + location display |
| 5.2.3.10 | Authenticator companion applications |
| 5.2.3.8 | account lockout threshold |
| 5.2.3.9 | account lockout duration |
| 5.1.3.4 | Microsoft 365 group creation |

Worth carrying into the remaining tail: **the constraint isn't always a missing API.** Three of these were sitting in a response we were already parsing.

## Absent is not non-compliant

A tenant that has never configured smart lockout returns no `LockoutThreshold` at all. Treating a missing value as `0` would report every such tenant as failing 5.2.3.9 — a finding we couldn't substantiate.

The facts carry `settings_present` and the rules require it before comparing. Covered by a test asserting **no** finding when the settings are absent — the opposite of the usual fail-closed assertion, and deliberately so: fail-closed means *don't claim a pass*, not *invent a failure*.

`opa test . --ignore .github` → **463/463**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)