### PR TITLE
fix(cis/m365_v7): six controls were in no coverage bucket at all

### DIFF
--- a/.github/workflows/opa-test.yml
+++ b/.github/workflows/opa-test.yml
@@ -7,6 +7,7 @@ on:
       - '**/*.rego'
       - '.github/workflows/opa-test.yml'
       - 'scripts/check_cis_ids.py'
+      - 'scripts/check_cis_coverage.py'
       - '**/data/cis_*_index.json'
   pull_request:
     branches: [main]
@@ -14,6 +15,7 @@ on:
       - '**/*.rego'
       - '.github/workflows/opa-test.yml'
       - 'scripts/check_cis_ids.py'
+      - 'scripts/check_cis_coverage.py'
       - '**/data/cis_*_index.json'
 
 permissions:
@@ -125,6 +127,23 @@ jobs:
           # enumeration, and that the message corresponds to the control
           # that id actually names.
           python3 scripts/check_cis_ids.py \
+            --enumeration benchmarks/cis/saas/m365_v7/data/cis_m365_v7_index.json \
+            --policy-dir benchmarks/cis/saas/m365_v7
+
+      - name: Verify every recommendation is accounted for exactly once
+        run: |
+          # check_cis_ids.py verifies the ids we DO cite. It cannot see a
+          # control that nothing mentions -- and neither can opa test,
+          # which asserts against the ids the modules declare. On
+          # 2026-08-25 six controls were found in no bucket at all: not
+          # evaluated, not attested, not flagged, and so absent from the
+          # report, which described a 154-recommendation benchmark.
+          #
+          # This checks the four buckets against the benchmark's own
+          # enumeration as a set partition. Counts summing to 160 is
+          # weaker: two buckets could double-claim one control while a
+          # third lost one, and the total would still balance.
+          python3 scripts/check_cis_coverage.py \
             --enumeration benchmarks/cis/saas/m365_v7/data/cis_m365_v7_index.json \
             --policy-dir benchmarks/cis/saas/m365_v7
 

--- a/benchmarks/cis/saas/m365_v7/COVERAGE.md
+++ b/benchmarks/cis/saas/m365_v7/COVERAGE.md
@@ -1,10 +1,30 @@
 # CIS Microsoft 365 Foundations Benchmark v7.0.0 — coverage
 
-**Version:** v2.1
+**Version:** v2.2
 **Benchmark:** CIS Microsoft 365 Foundations Benchmark **v7.0.0**, released 2026-05-20
-**Evaluated:** **138 of 160** recommendations (**86%**)
-**Requires attestation:** 6 (verified to have no app-only read path)
-**Unresolved:** 10 (parked pending a live-tenant probe during the POC)
+
+| Bucket | Controls | Meaning |
+|---|---|---|
+| Evaluated | **138** | assessed from collected facts |
+| Requires attestation | 6 | verified to have no app-only read path |
+| Unresolved | 10 | collectability unestablished; parked pending a live-tenant probe |
+| Not implemented | 6 | automatable, the collector does not make the call yet |
+| **Total** | **160** | the whole benchmark |
+
+**Coverage: 138 of 160 (86%).** The four buckets must sum to 160 — every
+recommendation is claimed by exactly one. `scripts/check_cis_coverage.py`
+fails CI otherwise, and `compliance_report.coverage_accounting` publishes
+the sum so a reader can check it without running anything.
+
+> **Corrected 2026-08-25.** Through v2.1 this file read
+> "138 evaluated + 6 attestation + 10 unresolved" — which is 154, not 160.
+> Six controls (`1.2.2`, `1.3.3`, `2.4.1`, `5.1.6.1`, `5.3.4`, `5.3.5`)
+> were in no bucket: not evaluated, not attested, not flagged, and so
+> absent from the assessment entirely. Two of them were described in a
+> module comment as already reported here; they were not. An omitted
+> control is indistinguishable from a passing one, which is the same
+> defect class this rewrite exists to correct — so the partition is now
+> machine-checked rather than restated.
 
 This file exists because a partial assessment that does not say it is
 partial reads as a clean bill of health. Everything below is measured, not
@@ -103,7 +123,9 @@ until an operator attests with dated, attributed evidence. An omitted
 control is indistinguishable from a passing one, so they are never simply
 dropped.
 
-Two categories, deliberately not merged:
+Three categories, deliberately not merged — the distinction between "the
+platform will not tell us", "we have not checked" and "we have not built
+it" is the whole value of the ledger:
 
 - **Requires attestation (6)** — verified to have no app-only read path.
   The five SSPR controls (`5.2.4.1`–`5.2.4.5`) have no API at all; `5.1.2.4`
@@ -112,6 +134,23 @@ Two categories, deliberately not merged:
 - **Unresolved (10)** — not yet checked against a live tenant. These are
   **not** claimed as limits; several may prove collectable. Parked pending a
   POC probe with app-only credentials.
+- **Not implemented (6)** — automatable, and our own analysis names the
+  audit path. This is our backlog, not a platform limit, and each entry
+  carries the call that would close it:
+
+  | Control | Subject | What the collector must add |
+  |---|---|---|
+  | `1.2.2` | sign-in to shared mailboxes is blocked | `Get-EXOMailbox -RecipientTypeDetails SharedMailbox` joined to the Entra `accountEnabled` flag — today the mailbox query selects only audit properties and `/users` selects only `id` and `userPrincipalName` |
+  | `1.3.3` | external calendar sharing is not available | `Get-SharingPolicy`, not among the nine Exchange cmdlets run |
+  | `2.4.1` | priority account protection | Defender priority-account configuration |
+  | `5.1.6.1` | invitations only to allowed domains | the Graph B2B management policy carrying the domain allow/block list |
+  | `5.3.4` | approval required to activate Global Administrator | Graph PIM role-management policy rules |
+  | `5.3.5` | approval required to activate Privileged Role Administrator | same call as `5.3.4` |
+
+  Closing all six moves coverage to **144 of 160 (90%)**, the ceiling
+  `docs/m365/CIS_M365_V7_AUTOMATION_LIMITS.md` §8 already states. The work
+  is collector-side, in the `aac.m365` collection in the compliance repo —
+  not in this library.
 
 An attestation missing `attested_by`, `attested_on` or `evidence_ref` is
 rejected as inadmissible rather than accepted. The report marks

--- a/benchmarks/cis/saas/m365_v7/COVERAGE.md
+++ b/benchmarks/cis/saas/m365_v7/COVERAGE.md
@@ -16,6 +16,16 @@ recommendation is claimed by exactly one. `scripts/check_cis_coverage.py`
 fails CI otherwise, and `compliance_report.coverage_accounting` publishes
 the sum so a reader can check it without running anything.
 
+What that guard does **not** establish: the evaluated bucket is read from
+the section modules' own `controls` arrays, so it proves the declared ids
+partition the benchmark, not that each id has a violation rule behind it.
+An id added to a `controls` array with no logic would still be counted.
+`check_cis_ids.py` catches the common case — a control with a real
+violation message has its id and wording checked against the benchmark —
+but an id present only in a `controls` array and a lookup table passes
+both guards. Treat the count as "declared and cross-checked", not
+"proven executable".
+
 > **Corrected 2026-08-25.** Through v2.1 this file read
 > "138 evaluated + 6 attestation + 10 unresolved" — which is 154, not 160.
 > Six controls (`1.2.2`, `1.3.3`, `2.4.1`, `5.1.6.1`, `5.3.4`, `5.3.5`)

--- a/benchmarks/cis/saas/m365_v7/README.md
+++ b/benchmarks/cis/saas/m365_v7/README.md
@@ -1,8 +1,9 @@
 # CIS Microsoft 365 Foundations Benchmark v7.0.0 — Rego Library
 
-**Version:** v1.0
+**Version:** v1.1
 **Benchmark:** CIS Microsoft 365 Foundations Benchmark **v7.0.0** (released 2026-05-20)
-**Coverage:** 14 of 160 recommendations — see [COVERAGE.md](COVERAGE.md)
+**Coverage:** 138 of 160 recommendations evaluated; the remaining 22 are
+each claimed by a named bucket — see [COVERAGE.md](COVERAGE.md)
 
 ## Sections
 
@@ -92,8 +93,24 @@ the control could not be evaluated. A missing fact never reads as a pass.
 opa test benchmarks/cis/saas/m365_v7/ benchmarks/cis/saas/m365_v7/tests/ -v
 ```
 
-31 tests covering each control's violation path, its passing path, the
+122 tests covering each control's violation path, its passing path, the
 fail-closed path, and the orchestrator's coverage accounting.
+
+Tests alone cannot establish coverage — they assert against the ids the
+modules declare, so a control no module mentions is invisible to them.
+Two CI guards check the modules against the benchmark's own enumeration:
+
+```bash
+# every cited id exists, and its message matches the control it names
+python3 scripts/check_cis_ids.py \
+  --enumeration benchmarks/cis/saas/m365_v7/data/cis_m365_v7_index.json \
+  --policy-dir benchmarks/cis/saas/m365_v7
+
+# all 160 recommendations are claimed by exactly one bucket
+python3 scripts/check_cis_coverage.py \
+  --enumeration benchmarks/cis/saas/m365_v7/data/cis_m365_v7_index.json \
+  --policy-dir benchmarks/cis/saas/m365_v7
+```
 
 ## Relationship to `../m365/`
 

--- a/benchmarks/cis/saas/m365_v7/admin_center_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/admin_center_validation.rego
@@ -1,10 +1,18 @@
 # CIS Microsoft 365 Foundations Benchmark v7.0.0
 # Section 1 -- Microsoft 365 admin center
 #
-# 9 of section 1's 15 recommendations name Microsoft Graph in the
-# benchmark's own Audit procedure and are evaluated here. The remaining 6
-# need Exchange Online PowerShell (1.3.3, 1.3.6, 1.3.9), are Manual
-# (1.1.2, 1.3.8), or are pending (see COVERAGE.md).
+# 11 of section 1's 15 recommendations are evaluated here, via Microsoft
+# Graph and Exchange Online PowerShell. The other four are carried by the
+# ledger in attestation_validation.rego, never dropped:
+#
+#   1.1.2, 1.3.8    unresolved      collectability not yet established
+#   1.2.2, 1.3.3    not_implemented automatable; the collector does not
+#                                   make the call yet
+#
+# Keep this list accurate. Section 1 previously described itself as
+# "9 of 15" with 1.3.6 and 1.3.9 unimplemented long after both were built,
+# and 1.2.2 was named nowhere at all -- which is how it came to be missing
+# from the report entirely.
 #
 # Every control id below is verified against the benchmark by
 # scripts/check_cis_ids.py, which fails CI if an id does not exist or if

--- a/benchmarks/cis/saas/m365_v7/attestation_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/attestation_validation.rego
@@ -1,11 +1,13 @@
 # CIS Microsoft 365 Foundations Benchmark v7.0.0
-# Controls that no collector can establish
+# The ledger of controls this library does not evaluate
 #
 # An omitted control is indistinguishable from a passing one. These
 # controls therefore still appear in the assessment -- as violations --
 # until an operator attests to them with dated, attributed evidence.
 #
-# TWO DISTINCT CATEGORIES, deliberately not merged:
+# THREE DISTINCT CATEGORIES, deliberately not merged. Together with the
+# section modules' evaluated ids they partition all 160 recommendations;
+# scripts/check_cis_coverage.py fails CI if they ever stop doing so.
 #
 #   requires_attestation  Verified to have no app-only read path. Either no
 #                         API exists at all (the SSPR settings), or the API
@@ -18,6 +20,15 @@
 #                         collectable. They are parked pending a live-tenant
 #                         probe during the POC. Reporting them as
 #                         "requires attestation" would overstate the limit.
+#
+#   not_implemented       Known automatable -- our own analysis names the
+#                         audit path -- but the collector does not make the
+#                         call yet. This is OUR gap, not the platform's, and
+#                         saying so is the difference between a backlog item
+#                         and a limitation. Added 2026-08-25 after six
+#                         controls were found in no category at all: not
+#                         evaluated, not attested, not unresolved, and so
+#                         absent from the report entirely.
 #
 # See docs/m365/CIS_M365_V7_AUTOMATION_LIMITS.md in the compliance repo for
 # how each was established.
@@ -56,6 +67,38 @@ UNRESOLVED := {
 	"8.4.1": "app permission policies configured",
 }
 
+# Automatable, but the collector does not make the call yet.
+#
+# Each entry names the audit path, so this reads as a work list rather
+# than a disclaimer. Subjects are paraphrased from the shipped keyword
+# digest -- CIS titles are not reproduced verbatim (see README).
+NOT_IMPLEMENTED := {
+	"1.2.2": {
+		"subject": "sign-in to shared mailboxes is blocked",
+		"collector": "Get-EXOMailbox -RecipientTypeDetails SharedMailbox, joined to the Entra accountEnabled flag; today the mailbox query selects only audit properties and /users selects only id and userPrincipalName",
+	},
+	"1.3.3": {
+		"subject": "external sharing of calendars is not available",
+		"collector": "Get-SharingPolicy via Exchange Online PowerShell; not among the nine cmdlets the collector runs",
+	},
+	"2.4.1": {
+		"subject": "priority account protection is enabled and configured",
+		"collector": "Defender priority-account configuration; the Defender collector reads only the anti-phish, anti-spam, malware, Safe Links and Safe Attachments policies",
+	},
+	"5.1.6.1": {
+		"subject": "collaboration invitations are sent only to allowed domains",
+		"collector": "the Graph B2B management policy carrying the invitation allow/block domain list; the Entra collector does not request it",
+	},
+	"5.3.4": {
+		"subject": "approval is required to activate the Global Administrator role",
+		"collector": "Graph PIM role-management policy rules; the Entra collector reads roleEligibilityScheduleInstances but not the policy rules that govern activation",
+	},
+	"5.3.5": {
+		"subject": "approval is required to activate the Privileged Role Administrator role",
+		"collector": "Graph PIM role-management policy rules, as for 5.3.4",
+	},
+}
+
 attestations := object.get(input, "attestations", [])
 
 attested_ids := {a.control_id |
@@ -80,7 +123,7 @@ violation contains msg if {
 
 violation contains msg if {
 	some cid in incomplete_ids
-	subject := object.get(REQUIRES_ATTESTATION, cid, object.get(UNRESOLVED, cid, "control"))
+	subject := object.get(REQUIRES_ATTESTATION, cid, object.get(UNRESOLVED, cid, object.get(NOT_IMPLEMENTED, [cid, "subject"], "control")))
 	msg := sprintf("CIS %s: %s -- an attestation was supplied but is missing attested_by, attested_on or evidence_ref, so it is not admissible evidence (this is not a pass)", [cid, subject])
 }
 
@@ -90,6 +133,16 @@ violation contains msg if {
 	some cid, subject in UNRESOLVED
 	not cid in attested_ids
 	msg := sprintf("CIS %s: %s -- collectability is unresolved pending a live-tenant probe; not yet evaluated (this is not a pass)", [cid, subject])
+}
+
+# ── Controls we know how to collect but have not built yet ────────────
+# Stated as our own backlog, not as a platform limit. Before 2026-08-25
+# these six were absent from the report altogether, which read as though
+# the benchmark had 154 recommendations.
+violation contains msg if {
+	some cid, entry in NOT_IMPLEMENTED
+	not cid in attested_ids
+	msg := sprintf("CIS %s: %s -- automatable, but the collector does not make the call yet, so this control was not evaluated (this is not a pass)", [cid, entry.subject])
 }
 
 compliant if {
@@ -105,6 +158,8 @@ compliance_report := {
 	"requires_attestation_count": count(REQUIRES_ATTESTATION),
 	"unresolved": UNRESOLVED,
 	"unresolved_count": count(UNRESOLVED),
+	"not_implemented": NOT_IMPLEMENTED,
+	"not_implemented_count": count(NOT_IMPLEMENTED),
 	"attested_control_ids": attested_ids,
 	"attested_count": count(attested_ids),
 	# Evidence provenance must survive into the report: an auditor has to

--- a/benchmarks/cis/saas/m365_v7/cis_m365_v7_complete.rego
+++ b/benchmarks/cis/saas/m365_v7/cis_m365_v7_complete.rego
@@ -2,11 +2,18 @@
 #
 # Aggregates the per-section reports and, just as importantly, states what
 # is NOT evaluated. The benchmark defines 160 recommendations across nine
-# sections; this library evaluates 14 of them. A caller that reads only
-# `compliant` from a partial assessment would draw a false conclusion, so
-# this report deliberately does not expose a bare tenant-wide `compliant`
-# boolean. It exposes `assessed_controls_compliant` -- true only of the
-# controls actually evaluated -- alongside the coverage that qualifies it.
+# sections. A caller that reads only `compliant` from a partial assessment
+# would draw a false conclusion, so this report deliberately does not
+# expose a bare tenant-wide `compliant` boolean. It exposes
+# `assessed_controls_compliant` -- true only of the controls actually
+# evaluated -- alongside the coverage that qualifies it.
+#
+# `coverage_accounting` proves the report describes the whole benchmark:
+# every recommendation must land in exactly one of four buckets. Until
+# 2026-08-25 six landed in none, so the buckets summed to 154 and the
+# report silently described a benchmark that does not exist. A count that
+# does not add up is the one kind of coverage error a reader can catch
+# unaided, so it is published rather than merely asserted in a test.
 #
 # OPA query path: /v1/data/cis_m365_v7/main/compliance_report
 
@@ -58,6 +65,31 @@ controls_evaluated := count(evaluated_controls)
 
 controls_not_evaluated := BENCHMARK_TOTAL_CONTROLS - controls_evaluated
 
+# The four buckets must partition the benchmark. Anything not evaluated
+# has to be claimed by a named reason -- an unclaimed control is one the
+# report does not mention at all, which reads exactly like a pass.
+accounted_controls := (
+	(controls_evaluated + count(attestation.REQUIRES_ATTESTATION)) +
+	count(attestation.UNRESOLVED)
+) + count(attestation.NOT_IMPLEMENTED)
+
+default accounting_balanced := false
+
+accounting_balanced if {
+	accounted_controls == BENCHMARK_TOTAL_CONTROLS
+}
+
+coverage_accounting := {
+	"benchmark_total": BENCHMARK_TOTAL_CONTROLS,
+	"evaluated": controls_evaluated,
+	"requires_attestation": count(attestation.REQUIRES_ATTESTATION),
+	"unresolved": count(attestation.UNRESOLVED),
+	"not_implemented": count(attestation.NOT_IMPLEMENTED),
+	"accounted": accounted_controls,
+	"unaccounted": BENCHMARK_TOTAL_CONTROLS - accounted_controls,
+	"balanced": accounting_balanced,
+}
+
 default assessed_controls_compliant := false
 
 assessed_controls_compliant if {
@@ -73,6 +105,7 @@ compliance_report := {
 	"controls_not_evaluated": controls_not_evaluated,
 	"coverage_percentage": round(controls_evaluated * 100 / BENCHMARK_TOTAL_CONTROLS),
 	"evaluated_control_ids": evaluated_controls,
+	"coverage_accounting": coverage_accounting,
 	"sections_evaluated": section_reports,
 	"sections_not_evaluated": not_evaluated,
 	# Controls with no collector path are reported, never omitted -- an

--- a/benchmarks/cis/saas/m365_v7/entra_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/entra_validation.rego
@@ -2,18 +2,29 @@
 # Section 5 -- Microsoft Entra admin center
 #
 # Section 5 is the largest in the benchmark: 63 of its 160
-# recommendations, 39% of the whole. 20 are evaluated here.
+# recommendations, 39% of the whole. 50 are evaluated here.
 #
 # DROPPED FROM THE PRE-v7 LIBRARY: the "Security Defaults" check. v7.0.0
 # has no Security Defaults recommendation. The check was removed rather
 # than renumbered -- inventing an id is the defect this rewrite exists to
 # fix.
 #
-# NOT EVALUATED, deliberately: 5.1.6.1 (allowed collaboration domains) and
-# 5.3.4 (Global Administrator activation approval). CIS names no cmdlet
-# for either and their endpoint is not established. Guessing one would
-# manufacture a result; they are reported by the attestation module as
-# unresolved until the live-tenant probe.
+# NOT EVALUATED HERE. The other 13 of section 5 are carried by the ledger
+# in attestation_validation.rego:
+#
+#   5.1.2.4, 5.2.4.1-5   requires_attestation  no app-only read path
+#   5.1.2.5, 5.1.2.6,
+#   5.1.3.2, 5.1.3.3     unresolved            collectability unestablished
+#   5.1.6.1, 5.3.4,
+#   5.3.5                not_implemented       Graph exposes these; the
+#                                              collector does not ask
+#
+# This comment previously asserted that 5.1.6.1 and 5.3.4 "are reported by
+# the attestation module as unresolved". They were not in any of its maps,
+# and 5.3.5 was named nowhere at all -- so all three were silently absent
+# from the assessment. A comment is not a mechanism: the report says what
+# it emits, not what a source file claims it emits. That gap is now
+# enforced by scripts/check_cis_coverage.py rather than described here.
 #
 # Input contract (aac.m365.m365_entra_facts) -- see the module for the
 # control-to-endpoint mapping. /policies/authorizationPolicy alone carries

--- a/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
+++ b/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
@@ -443,8 +443,76 @@ test_uncollectable_controls_are_reported_not_omitted if {
 	r.compliant == false
 	r.requires_attestation_count == 6
 	r.unresolved_count == 10
+	r.not_implemented_count == 6
 	# An omitted control is indistinguishable from a passing one.
-	count(r.violations) == 16
+	count(r.violations) == 22
+}
+
+# ── The 2026-08-25 accounting hole ────────────────────────────────────
+# Six controls were in no bucket: not evaluated, not attested, not
+# unresolved. They appeared nowhere in the report, so the assessment
+# described a 154-recommendation benchmark. These tests pin the
+# partition; scripts/check_cis_coverage.py enforces it against the
+# benchmark enumeration, which is the check that can actually see a
+# control nothing mentions.
+
+test_not_implemented_controls_are_reported if {
+	r := att.compliance_report with input as {}
+	every cid in ["1.2.2", "1.3.3", "2.4.1", "5.1.6.1", "5.3.4", "5.3.5"] {
+		some v in r.violations
+		contains(v, sprintf("CIS %s:", [cid]))
+	}
+}
+
+test_not_implemented_is_stated_as_our_gap_not_a_limit if {
+	r := att.compliance_report with input as {}
+	some v in r.violations
+	contains(v, "CIS 5.3.4:")
+	# The distinction that matters: we can collect this, we just have not.
+	contains(v, "the collector does not make the call yet")
+	contains(v, "this is not a pass")
+}
+
+test_not_implemented_names_its_collector_path if {
+	# Each entry is a work item, not a disclaimer -- it must say what to build.
+	every cid in ["1.2.2", "1.3.3", "2.4.1", "5.1.6.1", "5.3.4", "5.3.5"] {
+		count(att.NOT_IMPLEMENTED[cid].collector) > 0
+	}
+}
+
+test_not_implemented_can_be_closed_by_attestation if {
+	r := att.compliance_report with input as {"attestations": [{
+		"control_id": "1.3.3", "observed": "no sharing policy grants calendar sharing",
+		"attested_by": "operator@example.com", "attested_on": "2026-08-25",
+		"evidence_ref": "get-sharingpolicy-001.txt",
+	}]}
+	every v in r.violations { not contains(v, "CIS 1.3.3:") }
+}
+
+test_buckets_do_not_overlap if {
+	att_ids := {cid | some cid, _ in att.REQUIRES_ATTESTATION}
+	unres := {cid | some cid, _ in att.UNRESOLVED}
+	notimpl := {cid | some cid, _ in att.NOT_IMPLEMENTED}
+	evaluated := {cid | some cid in main.compliance_report.evaluated_control_ids}
+	count(att_ids & unres) == 0
+	count(att_ids & notimpl) == 0
+	count(unres & notimpl) == 0
+	count(evaluated & (att_ids | (unres | notimpl))) == 0
+}
+
+test_coverage_accounting_balances_to_the_whole_benchmark if {
+	a := main.compliance_report.coverage_accounting with input as {}
+	a.benchmark_total == 160
+	a.accounted == 160
+	a.unaccounted == 0
+	a.balanced == true
+}
+
+test_coverage_accounting_is_published_not_just_asserted if {
+	# A reader has to be able to check the sum without running the tests.
+	r := main.compliance_report with input as {}
+	r.coverage_accounting.evaluated + r.coverage_accounting.requires_attestation +
+		r.coverage_accounting.unresolved + r.coverage_accounting.not_implemented == r.benchmark_total_controls
 }
 
 test_complete_attestation_satisfies_the_control if {

--- a/scripts/check_cis_coverage.py
+++ b/scripts/check_cis_coverage.py
@@ -29,6 +29,24 @@ The check is a set partition, not an arithmetic one. Counts summing to 160
 is strictly weaker: two buckets could double-claim a control while a third
 lost one, and the total would still balance.
 
+Two boundaries worth knowing:
+
+  Absent package is a FAILURE here, deliberately diverging from
+  check_cis_ids.py, which returns 0 when a tree cites no ids at all
+  ("nothing to check"). That early-out is right for a citation guard and
+  wrong for a coverage one: a tree with no buckets accounts for nothing,
+  which is the maximal version of the defect. Pointed at a tree without
+  the package, this reports four undefined buckets and exits 1.
+
+  `evaluated` is self-declared. It flattens the section modules' static
+  `controls` arrays, so this proves the declared ids partition the
+  benchmark -- not that each has a violation rule behind it. An id added
+  to a `controls` array with no logic would still count. check_cis_ids.py
+  closes part of that gap (a control with a real message gets its id and
+  wording checked), but an id appearing only in a `controls` array and a
+  lookup table passes both. Evaluating that would mean asserting on rule
+  bodies; for now it is a known limit rather than a silent one.
+
 Usage:
     check_cis_coverage.py --enumeration <enum.json> --policy-dir <dir>
                           [--package cis_m365_v7] [--opa opa]

--- a/scripts/check_cis_coverage.py
+++ b/scripts/check_cis_coverage.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Assert that every benchmark recommendation is accounted for exactly once.
+
+This is the guard for the defect found on 2026-08-25: the m365_v7 modules
+evaluated 138 controls, the attestation ledger claimed 6 more as requiring
+attestation and 10 as unresolved -- and the remaining **six** (1.2.2,
+1.3.3, 2.4.1, 5.1.6.1, 5.3.4, 5.3.5) were in no category at all. They were
+not evaluated, not attested, not flagged, and so appeared nowhere in the
+assessment. The report described a 154-recommendation benchmark.
+
+Two of the six were even documented as excluded in a module comment
+("they are reported by the attestation module as unresolved") -- a promise
+the code did not keep. A comment is invisible to whoever reads the report.
+
+Why the existing guards could not catch it:
+
+  check_cis_ids.py  verifies that every id we *do* cite is real and that
+                    the message matches. It is a correctness guard. A
+                    control we never mention is, to it, simply not there.
+
+  opa test          asserts against the ids the modules declare. A control
+                    absent from every module is absent from every test.
+
+Only a check against the benchmark's own enumeration can find a control
+that nothing mentions -- the same reasoning that motivated check_cis_ids.py,
+applied to coverage rather than to citation.
+
+The check is a set partition, not an arithmetic one. Counts summing to 160
+is strictly weaker: two buckets could double-claim a control while a third
+lost one, and the total would still balance.
+
+Usage:
+    check_cis_coverage.py --enumeration <enum.json> --policy-dir <dir>
+                          [--package cis_m365_v7] [--opa opa]
+
+Exit 0 if the buckets exactly partition the enumeration, 1 otherwise.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import shutil
+import subprocess
+import sys
+
+
+# Bucket name -> Rego path, relative to the policy package. `evaluated`
+# is flattened from the section reports; the other three are the ledger's
+# own maps, whose keys are control ids.
+BUCKETS = {
+    "evaluated": "main.compliance_report.evaluated_control_ids",
+    "requires_attestation": "attestation.REQUIRES_ATTESTATION",
+    "unresolved": "attestation.UNRESOLVED",
+    "not_implemented": "attestation.NOT_IMPLEMENTED",
+}
+
+
+def sort_key(control_id: str):
+    """Order ids numerically per component: 5.3.10 sorts after 5.3.9."""
+    return tuple(int(p) for p in control_id.split("."))
+
+
+def opa_eval(opa: str, policy_dir: pathlib.Path, query: str):
+    """Evaluate a query against the policy tree with empty input.
+
+    Empty input is deliberate: bucket membership is static, and evaluating
+    with facts would make the guard depend on a fixture.
+    """
+    proc = subprocess.run(
+        [opa, "eval", "-d", str(policy_dir), "-I", "--format", "raw", query],
+        input="{}",
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(f"opa eval failed for {query}:\n{proc.stderr}\n")
+        raise SystemExit(2)
+    # An undefined rule exits 0 with empty output. That is not an error to
+    # opa, but it is one here: a bucket that does not exist claims nothing,
+    # so every control it should have held becomes unaccounted. Report it
+    # as a named failure rather than crashing on the empty string.
+    if not proc.stdout.strip():
+        return None
+    return json.loads(proc.stdout)
+
+
+def collect(opa: str, policy_dir: pathlib.Path, package: str):
+    """Return {bucket_name: set_of_control_ids}.
+
+    A list result is used as-is; an object result contributes its keys,
+    which is how the three ledger maps are shaped.
+    """
+    found, undefined = {}, []
+    for name, path in BUCKETS.items():
+        value = opa_eval(opa, policy_dir, f"data.{package}.{path}")
+        if value is None:
+            undefined.append((name, f"data.{package}.{path}"))
+            found[name] = set()
+        else:
+            found[name] = set(value) if isinstance(value, (list, dict)) else set()
+    return found, undefined
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--enumeration", required=True, type=pathlib.Path)
+    ap.add_argument("--policy-dir", required=True, type=pathlib.Path)
+    ap.add_argument("--package", default="cis_m365_v7")
+    ap.add_argument("--opa", default="opa")
+    args = ap.parse_args()
+
+    opa = shutil.which(args.opa)
+    if not opa:
+        sys.stderr.write(f"opa not found on PATH (looked for {args.opa!r})\n")
+        return 2
+
+    doc = json.loads(args.enumeration.read_text(encoding="utf-8"))
+    enumerated = {r["control_id"] for r in doc["recommendations"]}
+    label = f"{doc['benchmark']} v{doc['version']}"
+
+    buckets, undefined = collect(opa, args.policy_dir, args.package)
+
+    print(f"benchmark : {label} ({len(enumerated)} recommendations)")
+    print(f"policies  : {args.policy_dir}")
+    for name in BUCKETS:
+        mark = "  (undefined)" if name in {n for n, _ in undefined} else ""
+        print(f"  {name:22} {len(buckets[name]):>4}{mark}")
+    print(f"  {'TOTAL':22} {sum(len(v) for v in buckets.values()):>4}\n")
+
+    failures = []
+
+    if undefined:
+        failures.append("undefined")
+        print(f"FAIL: {len(undefined)} bucket(s) do not exist in the policy tree")
+        for name, path in undefined:
+            print(f"    {name:22} {path}")
+        print("      A bucket that is undefined claims nothing, so the controls")
+        print("      it should hold fall out of the accounting entirely.\n")
+
+    # Check 1: nothing may be claimed by two buckets. A control both
+    # evaluated and listed as unresolved would inflate the total and hide
+    # a genuine gap elsewhere.
+    seen: dict[str, str] = {}
+    overlaps: list[tuple[str, str, str]] = []
+    for name in BUCKETS:
+        for cid in sorted(buckets[name], key=sort_key):
+            if cid in seen:
+                overlaps.append((cid, seen[cid], name))
+            else:
+                seen[cid] = name
+    if overlaps:
+        failures.append("overlap")
+        print(f"FAIL: {len(overlaps)} control(s) claimed by more than one bucket")
+        for cid, first, second in overlaps:
+            print(f"    {cid:10} in both {first} and {second}")
+        print()
+
+    # Check 2: every bucket entry must be a real recommendation. Catches a
+    # typo'd id in a hand-maintained ledger map, which would otherwise
+    # silently substitute for the control it was meant to represent.
+    for name in BUCKETS:
+        stray = sorted(buckets[name] - enumerated, key=sort_key)
+        if stray:
+            failures.append("stray")
+            print(f"FAIL: {name} names {len(stray)} id(s) absent from the benchmark")
+            for cid in stray:
+                print(f"    {cid}  -- no such control")
+            print()
+
+    # Check 3: the defect this guard exists for. Anything the benchmark
+    # defines and no bucket claims is missing from the report entirely,
+    # and an omitted control reads exactly like a passing one.
+    unaccounted = sorted(enumerated - set(seen), key=sort_key)
+    if unaccounted:
+        failures.append("unaccounted")
+        print(f"FAIL: {len(unaccounted)} recommendation(s) are in no bucket at all")
+        print("      Not evaluated, not attested, not flagged -- absent from the")
+        print("      assessment, which is indistinguishable from passing.\n")
+        by_section: dict[int, list[str]] = {}
+        sections = {r["control_id"]: r for r in doc["recommendations"]}
+        for cid in unaccounted:
+            by_section.setdefault(sections[cid]["section"], []).append(cid)
+        for sec in sorted(by_section):
+            name = sections[by_section[sec][0]]["section_name"]
+            print(f"  section {sec} -- {name}")
+            for cid in by_section[sec]:
+                rec = sections[cid]
+                kws = " ".join(rec.get("title_keywords", []))
+                print(f"    {cid:10} {rec['assessment']:10} {kws}")
+        print()
+        print("      Add each to a section module (if collectable) or to the")
+        print("      appropriate map in attestation_validation.rego. A control")
+        print("      we cannot yet collect is still reported -- never dropped.")
+        print()
+
+    if failures:
+        print(f"FAILED: {len(set(failures))} check(s) -- the buckets do not partition the benchmark")
+        return 1
+
+    print(f"OK: all {len(enumerated)} recommendations accounted for exactly once")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What was wrong

The m365_v7 report described a **154-recommendation benchmark**. CIS v7.0.0 has 160.

| Bucket | Controls |
|---|---|
| Evaluated | 138 |
| Requires attestation | 6 |
| Unresolved | 10 |
| **Sum** | **154** |

Six controls were in **no** category — not evaluated, not attested, not flagged, and so absent from the assessment entirely:

| Control | Subject | CIS assessment |
|---|---|---|
| `1.2.2` | sign-in to shared mailboxes is blocked | Automated |
| `1.3.3` | external sharing of calendars is not available | Automated |
| `2.4.1` | priority account protection | Automated |
| `5.1.6.1` | invitations only to allowed domains | Automated |
| `5.3.4` | approval required to activate Global Administrator | Automated |
| `5.3.5` | approval required to activate Privileged Role Administrator | Automated |

All six are **Automated** in CIS and automatable by our own analysis — `docs/m365/CIS_M365_V7_AUTOMATION_LIMITS.md` §8 already counts them inside its 144-control ceiling (109 + 34 + 1). They were simply never built, and nothing in the shipped report said so.

Worse, `entra_validation.rego` asserted two of them were already handled:

> NOT EVALUATED, deliberately: 5.1.6.1 ... and 5.3.4 ... **they are reported by the attestation module as unresolved** until the live-tenant probe.

They were in none of its maps. `5.3.5` was named nowhere in the tree at all. A comment is not a mechanism — the report emits what the code emits, not what a source file claims.

**An omitted control is indistinguishable from a passing one.** That is the same defect class the whole v7 rewrite exists to correct.

## Why neither existing guard caught it

- `check_cis_ids.py` verifies that every id we **do** cite is real and that the message matches. A control we never mention is, to it, simply not there.
- `opa test` asserts against the ids the modules **declare**. A control absent from every module is absent from every test.

Only a check against the benchmark's own enumeration can find a control that nothing mentions — the reasoning that motivated `check_cis_ids.py`, applied to coverage rather than citation.

## Changes

- **`attestation_validation.rego`** — third bucket, `not_implemented`, holding the six with the specific collector call each needs. Kept distinct from the other two on purpose: *"we have not built it"* is a backlog item, *"the platform will not tell us"* is a limitation, and reporting ours as theirs overstates the limit.
- **`cis_m365_v7_complete.rego`** — publishes `coverage_accounting`, so a reader can check the buckets sum to 160 without running anything. A count that does not add up is the one coverage error a reader can catch unaided.
- **`scripts/check_cis_coverage.py`** — new CI guard. Checks the four buckets against the enumeration as a **set partition**, not an arithmetic one: counts summing to 160 is strictly weaker, since two buckets could double-claim a control while a third lost one and the total would still balance. It also checks for stray ids and undefined buckets.
- **Stale claims corrected** — README `14 of 160` (v1.0-era), orchestrator `evaluates 14 of them`, section 1 `9 of 15` (really 11), section 5 `20 are evaluated` (really 50), and COVERAGE.md, whose totals summed to 154 on its face.

## The guard is proven in both directions

Against the pre-fix tree at `50b502c`:

```
  evaluated               138
  requires_attestation      6
  unresolved               10
  not_implemented           0  (undefined)
  TOTAL                   154

FAIL: 6 recommendation(s) are in no bucket at all
FAILED: 2 check(s) -- the buckets do not partition the benchmark   exit=1
```

Against this branch:

```
  TOTAL                   160
OK: all 160 recommendations accounted for exactly once             exit=0
```

## Verification

| Check | Result |
|---|---|
| `opa test . --ignore .github` | **470/470** (floor 348) |
| `check_cis_ids.py` | OK — **160** distinct keyed ids, was 154 |
| `check_cis_coverage.py` | OK — all 160 accounted for exactly once |
| deprecated-tree guard | still correctly rejects `m365/` |
| full report, realistic input | all 6 surface as violations; `balanced: true` |

## Scope

**Coverage is unchanged at 138/160 (86%).** This makes the other 22 visible; it does not evaluate them. Closing the six is collector-side work in the `aac.m365` collection in the compliance repo, and would reach **144/160 (90%)** — the ceiling the limits doc already states. `COVERAGE.md` now carries the exact call each one needs.

## Note for review

This touches `.github/workflows/opa-test.yml` (one added step, static paths, no untrusted input) — a protected path. I have **not** added the `Approved-By` trailer, since that represents your approval and I don't have it yet. Say go and I'll amend it in before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNF5rAx6FGZi7TXtU2mJsf