### PR TITLE
feat(cis/m365_v7): evaluate the last six automatable controls — 86% to 90%

### DIFF
--- a/benchmarks/cis/saas/m365_v7/COVERAGE.md
+++ b/benchmarks/cis/saas/m365_v7/COVERAGE.md
@@ -1,20 +1,26 @@
 # CIS Microsoft 365 Foundations Benchmark v7.0.0 — coverage
 
-**Version:** v2.2
+**Version:** v3.0
 **Benchmark:** CIS Microsoft 365 Foundations Benchmark **v7.0.0**, released 2026-05-20
 
 | Bucket | Controls | Meaning |
 |---|---|---|
-| Evaluated | **138** | assessed from collected facts |
+| Evaluated | **144** | assessed from collected facts |
 | Requires attestation | 6 | verified to have no app-only read path |
 | Unresolved | 10 | collectability unestablished; parked pending a live-tenant probe |
-| Not implemented | 6 | automatable, the collector does not make the call yet |
+| Not implemented | 0 | automatable, the collector does not make the call yet |
 | **Total** | **160** | the whole benchmark |
 
-**Coverage: 138 of 160 (86%).** The four buckets must sum to 160 — every
-recommendation is claimed by exactly one. `scripts/check_cis_coverage.py`
-fails CI otherwise, and `compliance_report.coverage_accounting` publishes
-the sum so a reader can check it without running anything.
+**Coverage: 144 of 160 (90%)** — the ceiling
+`docs/m365/CIS_M365_V7_AUTOMATION_LIMITS.md` §8 states for this tenant
+model. Everything still unevaluated is either verified uncollectable or
+parked pending a live tenant; nothing remains that we know how to collect
+and simply have not built.
+
+The four buckets must sum to 160 — every recommendation is claimed by
+exactly one. `scripts/check_cis_coverage.py` fails CI otherwise, and
+`compliance_report.coverage_accounting` publishes the sum so a reader can
+check it without running anything.
 
 What that guard does **not** establish: the evaluated bucket is read from
 the section modules' own `controls` arrays, so it proves the declared ids
@@ -46,22 +52,26 @@ modules themselves.
 
 | § | Section | Controls | Evaluated | Module |
 |---|---|---|---|---|
-| 1 | Microsoft 365 admin center | 15 | **11** | `admin_center_validation.rego` |
-| 2 | Microsoft Defender | 21 | **17** | `defender_validation.rego` |
+| 1 | Microsoft 365 admin center | 15 | **13** | `admin_center_validation.rego` |
+| 2 | Microsoft Defender | 21 | **18** | `defender_validation.rego` |
 | 3 | Microsoft Purview | 5 | **5** | `purview_validation.rego` |
 | 4 | Microsoft Intune admin center | 2 | 2 | `intune_validation.rego` |
-| 5 | Microsoft Entra admin center | 63 | **50** | `entra_validation.rego` |
+| 5 | Microsoft Entra admin center | 63 | **53** | `entra_validation.rego` |
 | 6 | Exchange admin center | 13 | **13** | `exchange_validation.rego` |
 | 7 | SharePoint admin center | 12 | **12** | `sharepoint_validation.rego` |
 | 8 | Microsoft Teams admin center | 17 | **16** | `teams_validation.rego` |
 | 9 | Microsoft Fabric | 12 | **12** | `fabric_validation.rego` |
-| | **Total** | **160** | **138** | |
+| | **Total** | **160** | **144** | |
 
-Evaluated ids: `1.1.1`, `1.1.3`, `1.1.4`, `1.2.1`, `1.3.1`, `1.3.2`, `1.3.4`,
-`1.3.5`, `1.3.7`, `4.1`, `4.2`, `2.1.8`, `2.1.9`, `2.1.10`, `3.1.1`, `5.2.2.1`,
-`5.2.2.2`, `5.2.2.3`, `5.3.1`, `6.1.1`, `7.2.1`, `7.2.6`, `7.2.7`, `7.2.11`.
+The authoritative list of evaluated ids is the report itself — this file
+does not restate it, because a hand-maintained copy drifts:
 
-## Why coverage is 86%
+```bash
+opa eval -d benchmarks/cis/saas/m365_v7 -I <<<'{}' \
+  'data.cis_m365_v7.main.compliance_report.evaluated_control_ids' --format raw
+```
+
+## Why coverage is 90%, not 100%
 
 Coverage is bounded by **fact collection**, not by policy. The `aac.m365`
 collection currently issues ten Microsoft Graph calls. Four of its seven
@@ -75,8 +85,8 @@ recommendation. Those were not carried into v7.
 | 4 — Intune | **Now collected.** Requires the `DeviceManagementConfiguration.Read.All` application permission — without it both controls report unavailable, never pass. |
 | 8 — Teams | Collector returns a Teams app count and Secure Score. Real coverage needs Teams PowerShell or Graph beta. |
 | 9 — Fabric | Collector returns Secure Score. Fabric tenant settings are only exposed by the Fabric Admin REST API, not Graph. |
-| 2 — Defender (4 of 21) | **Now collected** via Exchange Online PowerShell. Only 2.2.1, 2.4.3 and 2.4.5 outstanding — all Manual in CIS with no PowerShell audit procedure. |
-| 5 — Entra (59 of 63) | Most section 5 controls need Graph endpoints the collector does not call yet; several are only on `/beta`, and `graph.py` pins `GRAPH_BASE` to `/v1.0`. |
+| 2 — Defender (18 of 21) | Collected via Exchange Online PowerShell, plus Security & Compliance PowerShell for `2.4.1`'s alert policies. Only 2.2.1, 2.4.3 and 2.4.5 outstanding — all Manual in CIS with no PowerShell audit procedure. |
+| 5 — Entra (53 of 63) | The 10 outstanding are 6 attestation-only and 4 unresolved — no section 5 control is now blocked purely on a call we have not written. `graph.py` takes `beta=True` per call, so `/beta` endpoints are reachable where a control needs one. |
 | 6 — Exchange | **Complete.** All 13 controls via Exchange Online PowerShell in `aac-m365-ee`. |
 
 ## Evidence-strength caveats
@@ -104,7 +114,8 @@ Two caveats remain, both surfaced at runtime under `evidence_strength`:
 
 - **No tenant-wide `compliant` boolean.** The orchestrator exposes
   `assessed_controls_compliant`, which is scoped to `evaluated_control_ids`
-  only. A 14-of-160 assessment has no business emitting a benchmark verdict.
+  only. A partial assessment has no business emitting a benchmark verdict,
+  and 144 of 160 is still partial.
 - **Fail-closed everywhere.** Missing facts produce a violation stating the
   control could not be evaluated. Absent facts never read as a pass.
 
@@ -144,23 +155,30 @@ it" is the whole value of the ledger:
 - **Unresolved (10)** — not yet checked against a live tenant. These are
   **not** claimed as limits; several may prove collectable. Parked pending a
   POC probe with app-only credentials.
-- **Not implemented (6)** — automatable, and our own analysis names the
-  audit path. This is our backlog, not a platform limit, and each entry
-  carries the call that would close it:
+- **Not implemented (0)** — automatable, and our own analysis names the
+  audit path, but the collector does not make the call. **Empty as of
+  2026-08-25.** The bucket is retained because the category is real and
+  will recur: the next control we know how to collect but have not built
+  belongs here, not in *unresolved*, which would understate what we know.
 
-  | Control | Subject | What the collector must add |
-  |---|---|---|
-  | `1.2.2` | sign-in to shared mailboxes is blocked | `Get-EXOMailbox -RecipientTypeDetails SharedMailbox` joined to the Entra `accountEnabled` flag — today the mailbox query selects only audit properties and `/users` selects only `id` and `userPrincipalName` |
-  | `1.3.3` | external calendar sharing is not available | `Get-SharingPolicy`, not among the nine Exchange cmdlets run |
-  | `2.4.1` | priority account protection | Defender priority-account configuration |
-  | `5.1.6.1` | invitations only to allowed domains | the Graph B2B management policy carrying the domain allow/block list |
-  | `5.3.4` | approval required to activate Global Administrator | Graph PIM role-management policy rules |
-  | `5.3.5` | approval required to activate Privileged Role Administrator | same call as `5.3.4` |
+  The six that were here — `1.2.2`, `1.3.3`, `2.4.1`, `5.1.6.1`, `5.3.4`,
+  `5.3.5` — were built and moved into their section modules, taking
+  coverage from 138 to 144. Each query was written from the benchmark's
+  own Audit procedure rather than inferred from the control title:
 
-  Closing all six moves coverage to **144 of 160 (90%)**, the ceiling
-  `docs/m365/CIS_M365_V7_AUTOMATION_LIMITS.md` §8 already states. The work
-  is collector-side, in the `aac.m365` collection in the compliance repo —
-  not in this library.
+  | Control | Audit path now implemented |
+  |---|---|
+  | `1.2.2` | `Get-EXOMailbox -RecipientTypeDetails SharedMailbox` joined to Graph `accountEnabled` on the directory object id — the key CIS itself joins on |
+  | `1.3.3` | `Get-SharingPolicy`; every policy is checked, not only the default one the benchmark names |
+  | `2.4.1` | `Get-EmailTenantSettings` for the tenant toggle **and** `Get-ProtectionAlert` (Security & Compliance PowerShell) for the phishing and malware alert policies |
+  | `5.1.6.1` | `/beta/legacy/policies` → `B2BManagementPolicy`, whose `definition` is a JSON string |
+  | `5.3.4` / `5.3.5` | `roleManagementPolicyAssignments` → `policyId` → `.../rules/Approval_EndUser_Assignment` |
+
+  **These are measurable, not yet measured.** Whether each endpoint
+  returns data under *app-only* credentials is established only against a
+  live tenant — the same gate that keeps the 10 unresolved controls
+  parked. Until that probe runs, every one of the six fails closed with
+  "could not be evaluated" rather than passing.
 
 An attestation missing `attested_by`, `attested_on` or `evidence_ref` is
 rejected as inadmissible rather than accepted. The report marks

--- a/benchmarks/cis/saas/m365_v7/README.md
+++ b/benchmarks/cis/saas/m365_v7/README.md
@@ -1,9 +1,9 @@
 # CIS Microsoft 365 Foundations Benchmark v7.0.0 — Rego Library
 
-**Version:** v1.1
+**Version:** v1.2
 **Benchmark:** CIS Microsoft 365 Foundations Benchmark **v7.0.0** (released 2026-05-20)
-**Coverage:** 138 of 160 recommendations evaluated; the remaining 22 are
-each claimed by a named bucket — see [COVERAGE.md](COVERAGE.md)
+**Coverage:** 144 of 160 recommendations evaluated (90%); the remaining 16
+are each claimed by a named bucket — see [COVERAGE.md](COVERAGE.md)
 
 ## Sections
 
@@ -93,7 +93,7 @@ the control could not be evaluated. A missing fact never reads as a pass.
 opa test benchmarks/cis/saas/m365_v7/ benchmarks/cis/saas/m365_v7/tests/ -v
 ```
 
-122 tests covering each control's violation path, its passing path, the
+144 tests covering each control's violation path, its passing path, the
 fail-closed path, and the orchestrator's coverage accounting.
 
 Tests alone cannot establish coverage — they assert against the ids the

--- a/benchmarks/cis/saas/m365_v7/admin_center_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/admin_center_validation.rego
@@ -1,13 +1,15 @@
 # CIS Microsoft 365 Foundations Benchmark v7.0.0
 # Section 1 -- Microsoft 365 admin center
 #
-# 11 of section 1's 15 recommendations are evaluated here, via Microsoft
-# Graph and Exchange Online PowerShell. The other four are carried by the
-# ledger in attestation_validation.rego, never dropped:
+# 13 of section 1's 15 recommendations are evaluated here, via Microsoft
+# Graph and Exchange Online PowerShell. The other two -- 1.1.2 and 1.3.8 --
+# are carried as `unresolved` by the ledger in attestation_validation.rego,
+# never dropped.
 #
-#   1.1.2, 1.3.8    unresolved      collectability not yet established
-#   1.2.2, 1.3.3    not_implemented automatable; the collector does not
-#                                   make the call yet
+# 1.2.2 and 1.3.3 joined this module on 2026-08-25. Both are section 1
+# controls whose facts come from Exchange, and 1.2.2 additionally needs
+# the Graph sign-in state -- CIS's own procedure for it is a join across
+# both surfaces.
 #
 # Keep this list accurate. Section 1 previously described itself as
 # "9 of 15" with 1.3.6 and 1.3.9 unimplemented long after both were built,
@@ -209,6 +211,91 @@ violation contains msg if {
 	msg := sprintf("CIS 1.3.6: whether the customer lockbox feature is enabled could not be evaluated -- %s (this is not a pass)", [input.exchange.unavailable.organization_config])
 }
 
+# ── CIS 1.3.3 -- external sharing of calendars ────────────────────────
+# CIS audits the default sharing policy and requires Enabled to be False.
+# Every returned policy is checked, not only the default: a tenant can add
+# further sharing policies, and a second enabled one shares calendars just
+# as effectively. Checking only the default would audit the benchmark's
+# example rather than the control.
+
+default sharing_policies_available := false
+
+sharing_policies_available if {
+	input.exchange.collected == true
+	not input.exchange.unavailable.sharing_policies
+	_ := input.exchange.sharing_policies
+}
+
+violation contains msg if {
+	sharing_policies_available
+	some policy in input.exchange.sharing_policies
+	policy.Enabled == true
+	msg := sprintf("CIS 1.3.3: external sharing of calendars is available -- sharing policy '%s' is enabled, so users can share calendars with people outside the organization", [policy.Name])
+}
+
+violation contains msg if {
+	input.exchange.collected == true
+	input.exchange.unavailable.sharing_policies
+	msg := sprintf("CIS 1.3.3: whether external calendar sharing is available could not be evaluated -- %s (this is not a pass)", [input.exchange.unavailable.sharing_policies])
+}
+
+# ── CIS 1.2.2 -- sign-in to shared mailboxes must be blocked ──────────
+# The one control in this section that spans two collectors. CIS's own
+# procedure is a join: Get-EXOMailbox lists the shared mailboxes, then
+# Get-MgUser reports AccountEnabled for each. Exchange supplies the
+# mailboxes, Graph supplies the sign-in state, and they meet here on the
+# directory object id.
+#
+# A mailbox whose account is absent from the Graph map is reported as
+# unevaluated rather than passed. An account we could not find is not an
+# account we established was blocked.
+
+default shared_mailboxes_available := false
+
+shared_mailboxes_available if {
+	input.exchange.collected == true
+	not input.exchange.unavailable.shared_mailboxes
+	_ := input.exchange.shared_mailboxes
+}
+
+default sign_in_state_available := false
+
+sign_in_state_available if {
+	collected
+	not unavailable.user_sign_in_state
+	_ := input.admin_center.user_sign_in_state
+}
+
+sign_in_state := object.get(input, ["admin_center", "user_sign_in_state"], {})
+
+violation contains msg if {
+	shared_mailboxes_available
+	sign_in_state_available
+	some mailbox in input.exchange.shared_mailboxes
+	sign_in_state[mailbox.ExternalDirectoryObjectId].account_enabled == true
+	msg := sprintf("CIS 1.2.2: sign-in to shared mailbox '%s' is not blocked -- its Entra account is enabled, so it can be signed into directly rather than only accessed through delegation", [mailbox.UserPrincipalName])
+}
+
+violation contains msg if {
+	shared_mailboxes_available
+	sign_in_state_available
+	some mailbox in input.exchange.shared_mailboxes
+	not sign_in_state[mailbox.ExternalDirectoryObjectId]
+	msg := sprintf("CIS 1.2.2: whether sign-in to shared mailbox '%s' is blocked could not be evaluated -- no directory account matched its object id (this is not a pass)", [mailbox.UserPrincipalName])
+}
+
+violation contains msg if {
+	input.exchange.collected == true
+	input.exchange.unavailable.shared_mailboxes
+	msg := sprintf("CIS 1.2.2: whether sign-in to shared mailboxes is blocked could not be evaluated -- the shared mailbox list is unavailable: %s (this is not a pass)", [input.exchange.unavailable.shared_mailboxes])
+}
+
+violation contains msg if {
+	collected
+	unavailable.user_sign_in_state
+	msg := sprintf("CIS 1.2.2: whether sign-in to shared mailboxes is blocked could not be evaluated -- directory sign-in state is unavailable: %s (this is not a pass)", [unavailable.user_sign_in_state])
+}
+
 compliant if {
 	collected
 	count(violation) == 0
@@ -220,8 +307,8 @@ compliance_report := {
 	"section": "1",
 	"name": "Microsoft 365 admin center",
 	"section_total_controls": 15,
-	"controls_evaluated": 11,
-	"controls": ["1.1.1", "1.1.3", "1.1.4", "1.2.1", "1.3.1", "1.3.2", "1.3.4", "1.3.5", "1.3.6", "1.3.7", "1.3.9"],
+	"controls_evaluated": 13,
+	"controls": ["1.1.1", "1.2.1", "1.2.2", "1.1.3", "1.1.4", "1.3.1", "1.3.2", "1.3.3", "1.3.4", "1.3.5", "1.3.6", "1.3.7", "1.3.9"],
 	"facts_present": collected,
 	"unavailable_facts": unavailable,
 	"violations": violation,

--- a/benchmarks/cis/saas/m365_v7/attestation_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/attestation_validation.rego
@@ -69,35 +69,18 @@ UNRESOLVED := {
 
 # Automatable, but the collector does not make the call yet.
 #
+# EMPTY as of 2026-08-25. All six original entries -- 1.2.2, 1.3.3,
+# 2.4.1, 5.1.6.1, 5.3.4, 5.3.5 -- were built and moved into their section
+# modules. The bucket stays because the category is real and will recur:
+# the next control we know how to collect but have not built belongs
+# here, not in `unresolved`, which would understate what we know.
+#
 # Each entry names the audit path, so this reads as a work list rather
 # than a disclaimer. Subjects are paraphrased from the shipped keyword
 # digest -- CIS titles are not reproduced verbatim (see README).
-NOT_IMPLEMENTED := {
-	"1.2.2": {
-		"subject": "sign-in to shared mailboxes is blocked",
-		"collector": "Get-EXOMailbox -RecipientTypeDetails SharedMailbox, joined to the Entra accountEnabled flag; today the mailbox query selects only audit properties and /users selects only id and userPrincipalName",
-	},
-	"1.3.3": {
-		"subject": "external sharing of calendars is not available",
-		"collector": "Get-SharingPolicy via Exchange Online PowerShell; not among the nine cmdlets the collector runs",
-	},
-	"2.4.1": {
-		"subject": "priority account protection is enabled and configured",
-		"collector": "Defender priority-account configuration; the Defender collector reads only the anti-phish, anti-spam, malware, Safe Links and Safe Attachments policies",
-	},
-	"5.1.6.1": {
-		"subject": "collaboration invitations are sent only to allowed domains",
-		"collector": "the Graph B2B management policy carrying the invitation allow/block domain list; the Entra collector does not request it",
-	},
-	"5.3.4": {
-		"subject": "approval is required to activate the Global Administrator role",
-		"collector": "Graph PIM role-management policy rules; the Entra collector reads roleEligibilityScheduleInstances but not the policy rules that govern activation",
-	},
-	"5.3.5": {
-		"subject": "approval is required to activate the Privileged Role Administrator role",
-		"collector": "Graph PIM role-management policy rules, as for 5.3.4",
-	},
-}
+#
+#   "<id>": {"subject": "...", "collector": "the call that would close it"}
+NOT_IMPLEMENTED := {}
 
 attestations := object.get(input, "attestations", [])
 

--- a/benchmarks/cis/saas/m365_v7/defender_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/defender_validation.rego
@@ -218,6 +218,49 @@ DEFENDER_FACT_CONTROLS := {
 	"content_filter_policies": "2.1.14",
 	"eop_protection_rules": "2.4.2",
 	"teams_protection_policy": "2.4.4",
+	"email_tenant_settings": "2.4.1",
+	"priority_account_alerts": "2.4.1",
+}
+
+# ── CIS 2.4.1 -- priority account protection ──────────────────────────
+# The only compound control in this section. CIS requires all three:
+#
+#   EnablePriorityAccountProtection is true                (Exchange)
+#   a passing alert policy with ThreatType Phish           (Purview)
+#   a passing alert policy with ThreatType Malware         (Purview)
+#
+# "Passing" is CIS's own list: severity High, inbound mail direction,
+# tagged to priority accounts, notification enabled with a recipient, and
+# not disabled. A tenant with the toggle on and no alerts configured is
+# not compliant -- the toggle alone tags accounts, it does not watch them.
+
+violation contains msg if {
+	policy_available("email_tenant_settings")
+	input.defender.email_tenant_settings.EnablePriorityAccountProtection == false
+	msg := "CIS 2.4.1: priority account protection is not enabled for the tenant, so accounts tagged as priority receive no differentiated protection"
+}
+
+passing_alert(threat) if {
+	some a in input.defender.priority_account_alerts
+	a.ThreatType == threat
+	a.Severity == "High"
+	a.Disabled == false
+	a.NotificationEnabled == true
+	count(object.get(a, "NotifyUser", [])) > 0
+	contains(a.RecipientTags, "Priority account")
+	contains(a.Filter, "Inbound")
+}
+
+violation contains msg if {
+	policy_available("priority_account_alerts")
+	not passing_alert("Phish")
+	msg := "CIS 2.4.1: no alert policy monitors priority accounts for phishing email detected at delivery -- a high-severity, inbound, priority-tagged alert with a notification recipient is required"
+}
+
+violation contains msg if {
+	policy_available("priority_account_alerts")
+	not passing_alert("Malware")
+	msg := "CIS 2.4.1: no alert policy monitors priority accounts for detected malware in email -- a high-severity, inbound, priority-tagged alert with a notification recipient is required"
 }
 
 violation contains msg if {
@@ -242,11 +285,11 @@ compliance_report := {
 	"section": "2",
 	"name": "Microsoft Defender",
 	"section_total_controls": 21,
-	"controls_evaluated": 17,
+	"controls_evaluated": 18,
 	"controls": [
 		"2.1.1", "2.1.2", "2.1.3", "2.1.4", "2.1.5", "2.1.6", "2.1.7",
 		"2.1.8", "2.1.9", "2.1.10", "2.1.11", "2.1.12", "2.1.13",
-		"2.1.14", "2.1.15", "2.4.2", "2.4.4",
+		"2.1.14", "2.1.15", "2.4.1", "2.4.2", "2.4.4",
 	],
 	"facts_present": facts_present,
 	"violations": violation,

--- a/benchmarks/cis/saas/m365_v7/entra_validation.rego
+++ b/benchmarks/cis/saas/m365_v7/entra_validation.rego
@@ -2,22 +2,22 @@
 # Section 5 -- Microsoft Entra admin center
 #
 # Section 5 is the largest in the benchmark: 63 of its 160
-# recommendations, 39% of the whole. 50 are evaluated here.
+# recommendations, 39% of the whole. 53 are evaluated here.
 #
 # DROPPED FROM THE PRE-v7 LIBRARY: the "Security Defaults" check. v7.0.0
 # has no Security Defaults recommendation. The check was removed rather
 # than renumbered -- inventing an id is the defect this rewrite exists to
 # fix.
 #
-# NOT EVALUATED HERE. The other 13 of section 5 are carried by the ledger
+# NOT EVALUATED HERE. The other 10 of section 5 are carried by the ledger
 # in attestation_validation.rego:
 #
 #   5.1.2.4, 5.2.4.1-5   requires_attestation  no app-only read path
 #   5.1.2.5, 5.1.2.6,
 #   5.1.3.2, 5.1.3.3     unresolved            collectability unestablished
-#   5.1.6.1, 5.3.4,
-#   5.3.5                not_implemented       Graph exposes these; the
-#                                              collector does not ask
+#
+# 5.1.6.1, 5.3.4 and 5.3.5 were the third category -- known automatable,
+# never built. All three are evaluated here as of 2026-08-25.
 #
 # This comment previously asserted that 5.1.6.1 and 5.3.4 "are reported by
 # the attestation module as unresolved". They were not in any of its maps,
@@ -598,6 +598,9 @@ FACT_CONTROLS := {
 	"group_settings": "5.2.3.2",
 	"mfa_registration_report": "5.2.3.4",
 	"per_user_mfa": "5.1.2.1",
+	"b2b_management_policy": "5.1.6.1",
+	"pim_approval_62e90394-69f5-4237-9190-012177145e10": "5.3.4",
+	"pim_approval_e8611ab8-c189-46e8-94e1-60213ab1f814": "5.3.5",
 }
 
 violation contains msg if {
@@ -611,6 +614,72 @@ violation contains msg if {
 	msg := "CIS 5.1.2.2: Entra facts were not collected, so whether users can register applications could not be established -- section 5 was not evaluated (this is not a pass)"
 }
 
+# ── CIS 5.1.6.1 -- invitations only to allowed domains ────────────────
+# CIS reads the B2BManagementPolicy invitation domain policy. Compliant
+# means an AllowedDomains list is PRESENT and no BlockedDomains property.
+#
+# The empty case is the subtle one and CIS is explicit about it: an
+# AllowedDomains list with no entries is compliant, because it permits
+# nothing. Absent is not the same as empty, which is why the collector
+# reports presence separately from contents -- treating a missing list as
+# an empty one would turn "unrestricted" into "maximally restricted".
+
+b2b := object.get(input, ["entra", "b2b_management_policy"], {})
+
+violation contains msg if {
+	available("b2b_management_policy")
+	b2b.policy_present == false
+	msg := "CIS 5.1.6.1: no B2B collaboration domain policy exists, so invitations can be sent to any domain"
+}
+
+violation contains msg if {
+	available("b2b_management_policy")
+	b2b.policy_present == true
+	b2b.allowed_domains_present == false
+	msg := "CIS 5.1.6.1: collaboration invitations are not restricted to allowed domains -- the B2B policy specifies no AllowedDomains list, so any domain may be invited"
+}
+
+# A block list is an allow-everything-else posture, which CIS treats as
+# non-compliant even when an allow list is also present.
+violation contains msg if {
+	available("b2b_management_policy")
+	b2b.policy_present == true
+	b2b.blocked_domains_present == true
+	msg := "CIS 5.1.6.1: the B2B collaboration policy specifies BlockedDomains -- blocking named domains permits every other domain, where the benchmark requires an explicit allow list"
+}
+
+# ── CIS 5.3.4 / 5.3.5 -- approval to activate a privileged role ───────
+# Both controls have the same shape against different roles, so the map
+# drives the rules. CIS requires BOTH isApprovalRequired and at least one
+# primary approver: a policy that requires approval from nobody cannot
+# gate anything.
+
+PIM_APPROVAL_CONTROLS := {
+	"pim_approval_62e90394-69f5-4237-9190-012177145e10": {
+		"control": "5.3.4",
+		"role": "Global Administrator",
+	},
+	"pim_approval_e8611ab8-c189-46e8-94e1-60213ab1f814": {
+		"control": "5.3.5",
+		"role": "Privileged Role Administrator",
+	},
+}
+
+violation contains msg if {
+	some key, meta in PIM_APPROVAL_CONTROLS
+	available(key)
+	input.entra[key].is_approval_required == false
+	msg := sprintf("CIS %s: activating the %s role does not require approval, so an eligible principal can elevate unilaterally", [meta.control, meta.role])
+}
+
+violation contains msg if {
+	some key, meta in PIM_APPROVAL_CONTROLS
+	available(key)
+	input.entra[key].is_approval_required == true
+	input.entra[key].primary_approver_count == 0
+	msg := sprintf("CIS %s: activating the %s role requires approval but no approvers are assigned, so the requirement gates nothing", [meta.control, meta.role])
+}
+
 compliant if {
 	collected
 	count(violation) == 0
@@ -622,19 +691,19 @@ compliance_report := {
 	"section": "5",
 	"name": "Microsoft Entra admin center",
 	"section_total_controls": 63,
-	"controls_evaluated": 50,
+	"controls_evaluated": 53,
 	"controls": [
 		"5.1.2.1", "5.1.2.2", "5.1.2.3", "5.1.3.1", "5.1.3.4", "5.1.4.6",
 		"5.1.4.1", "5.1.4.2", "5.1.4.3", "5.1.4.4", "5.1.4.5",
 		"5.1.5.1", "5.1.5.2", "5.1.5.3", "5.1.5.4", "5.1.5.5", "5.1.5.6",
-		"5.1.6.2", "5.1.6.3", "5.1.8.1",
+		"5.1.6.1", "5.1.6.2", "5.1.6.3", "5.1.8.1",
 		"5.2.2.1", "5.2.2.2", "5.2.2.3", "5.2.2.4", "5.2.2.5",
 		"5.2.2.6", "5.2.2.7", "5.2.2.8", "5.2.2.9", "5.2.2.10",
 		"5.2.2.11", "5.2.2.12", "5.2.2.13", "5.2.2.14", "5.2.2.15",
 		"5.2.2.16", "5.2.2.17",
 		"5.2.3.1", "5.2.3.2", "5.2.3.3", "5.2.3.4", "5.2.3.5", "5.2.3.6",
 		"5.2.3.7", "5.2.3.8", "5.2.3.9", "5.2.3.10",
-		"5.3.1", "5.3.2", "5.3.3",
+		"5.3.1", "5.3.2", "5.3.3", "5.3.4", "5.3.5",
 	],
 	"facts_present": collected,
 	"unavailable_facts": unavailable,

--- a/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
+++ b/benchmarks/cis/saas/m365_v7/tests/test_m365_v7.rego
@@ -325,8 +325,8 @@ test_sharepoint_declares_the_cmdlet_deviation if {
 test_orchestrator_reports_partial_coverage_honestly if {
 	r := main.compliance_report with input as {}
 	r.benchmark_total_controls == 160
-	r.controls_evaluated == 138
-	r.controls_not_evaluated == 22
+	r.controls_evaluated == 144
+	r.controls_not_evaluated == 16
 	count(r.sections_not_evaluated) == 0
 }
 
@@ -443,50 +443,289 @@ test_uncollectable_controls_are_reported_not_omitted if {
 	r.compliant == false
 	r.requires_attestation_count == 6
 	r.unresolved_count == 10
-	r.not_implemented_count == 6
+	r.not_implemented_count == 0
 	# An omitted control is indistinguishable from a passing one.
-	count(r.violations) == 22
+	count(r.violations) == 16
 }
 
 # ── The 2026-08-25 accounting hole ────────────────────────────────────
 # Six controls were in no bucket: not evaluated, not attested, not
 # unresolved. They appeared nowhere in the report, so the assessment
-# described a 154-recommendation benchmark. These tests pin the
-# partition; scripts/check_cis_coverage.py enforces it against the
-# benchmark enumeration, which is the check that can actually see a
-# control nothing mentions.
+# described a 154-recommendation benchmark. All six are now evaluated by
+# their section modules; these tests pin the partition, and
+# scripts/check_cis_coverage.py enforces it against the benchmark
+# enumeration -- the check that can actually see a control nothing
+# mentions.
 
-test_not_implemented_controls_are_reported if {
-	r := att.compliance_report with input as {}
+test_the_six_gap_controls_are_evaluated_not_merely_listed if {
+	ids := {c | some c in main.compliance_report.evaluated_control_ids}
 	every cid in ["1.2.2", "1.3.3", "2.4.1", "5.1.6.1", "5.3.4", "5.3.5"] {
-		some v in r.violations
-		contains(v, sprintf("CIS %s:", [cid]))
+		cid in ids
 	}
 }
 
-test_not_implemented_is_stated_as_our_gap_not_a_limit if {
-	r := att.compliance_report with input as {}
+test_not_implemented_bucket_is_empty_but_retained if {
+	# The category is real and will recur. Removing the map would send the
+	# next "we know how to collect this, we have not built it" control into
+	# `unresolved`, which understates what we know.
+	count(att.NOT_IMPLEMENTED) == 0
+	is_object(att.NOT_IMPLEMENTED)
+}
+
+# ── 1.3.3 -- external calendar sharing ────────────────────────────────
+
+ex(extra) := {"exchange": object.union({"collected": true, "unavailable": {}}, extra)}
+
+test_1_3_3_enabled_sharing_policy_violates if {
+	r := ac.compliance_report with input as object.union(
+		ac_input({}),
+		ex({"sharing_policies": [{"Name": "Default Sharing Policy", "Enabled": true}]}),
+	)
 	some v in r.violations
-	contains(v, "CIS 5.3.4:")
-	# The distinction that matters: we can collect this, we just have not.
-	contains(v, "the collector does not make the call yet")
+	contains(v, "CIS 1.3.3:")
+	contains(v, "Default Sharing Policy")
+}
+
+test_1_3_3_checks_every_policy_not_just_the_default if {
+	# A non-default policy shares calendars just as effectively.
+	r := ac.compliance_report with input as object.union(ac_input({}), ex({"sharing_policies": [
+		{"Name": "Default Sharing Policy", "Enabled": false, "Default": true},
+		{"Name": "Partners", "Enabled": true, "Default": false},
+	]}))
+	some v in r.violations
+	contains(v, "CIS 1.3.3:")
+	contains(v, "Partners")
+}
+
+test_1_3_3_all_policies_disabled_passes if {
+	r := ac.compliance_report with input as object.union(ac_input({}), ex({"sharing_policies": [
+		{"Name": "Default Sharing Policy", "Enabled": false},
+	]}))
+	every v in r.violations { not contains(v, "CIS 1.3.3:") }
+}
+
+test_1_3_3_unavailable_is_not_a_pass if {
+	r := ac.compliance_report with input as object.union(ac_input({}), {"exchange": {
+		"collected": true,
+		"unavailable": {"sharing_policies": "insufficient permissions"},
+	}})
+	some v in r.violations
+	contains(v, "CIS 1.3.3:")
 	contains(v, "this is not a pass")
 }
 
-test_not_implemented_names_its_collector_path if {
-	# Each entry is a work item, not a disclaimer -- it must say what to build.
-	every cid in ["1.2.2", "1.3.3", "2.4.1", "5.1.6.1", "5.3.4", "5.3.5"] {
-		count(att.NOT_IMPLEMENTED[cid].collector) > 0
-	}
+# ── 1.2.2 -- shared mailbox sign-in, the cross-collector join ─────────
+
+test_1_2_2_enabled_shared_mailbox_violates if {
+	r := ac.compliance_report with input as object.union(
+		ac_input({"user_sign_in_state": {"obj-1": {"account_enabled": true}}}),
+		ex({"shared_mailboxes": [{"UserPrincipalName": "shared@x.com", "ExternalDirectoryObjectId": "obj-1"}]}),
+	)
+	some v in r.violations
+	contains(v, "CIS 1.2.2:")
+	contains(v, "shared@x.com")
 }
 
-test_not_implemented_can_be_closed_by_attestation if {
-	r := att.compliance_report with input as {"attestations": [{
-		"control_id": "1.3.3", "observed": "no sharing policy grants calendar sharing",
-		"attested_by": "operator@example.com", "attested_on": "2026-08-25",
-		"evidence_ref": "get-sharingpolicy-001.txt",
-	}]}
-	every v in r.violations { not contains(v, "CIS 1.3.3:") }
+test_1_2_2_blocked_shared_mailbox_passes if {
+	r := ac.compliance_report with input as object.union(
+		ac_input({"user_sign_in_state": {"obj-1": {"account_enabled": false}}}),
+		ex({"shared_mailboxes": [{"UserPrincipalName": "shared@x.com", "ExternalDirectoryObjectId": "obj-1"}]}),
+	)
+	every v in r.violations { not contains(v, "CIS 1.2.2:") }
+}
+
+test_1_2_2_unmatched_account_is_unevaluated_not_passed if {
+	# An account we could not find is not an account we established was
+	# blocked. This is the join's fail-closed edge.
+	r := ac.compliance_report with input as object.union(
+		ac_input({"user_sign_in_state": {"someone-else": {"account_enabled": false}}}),
+		ex({"shared_mailboxes": [{"UserPrincipalName": "orphan@x.com", "ExternalDirectoryObjectId": "obj-missing"}]}),
+	)
+	some v in r.violations
+	contains(v, "CIS 1.2.2:")
+	contains(v, "no directory account matched")
+}
+
+test_1_2_2_missing_sign_in_state_is_not_a_pass if {
+	r := ac.compliance_report with input as object.union(
+		{"admin_center": {"collected": true, "unavailable": {"user_sign_in_state": "Directory.Read.All not granted"}}},
+		ex({"shared_mailboxes": [{"UserPrincipalName": "shared@x.com", "ExternalDirectoryObjectId": "obj-1"}]}),
+	)
+	some v in r.violations
+	contains(v, "CIS 1.2.2:")
+	contains(v, "this is not a pass")
+}
+
+# ── 2.4.1 -- priority account protection (compound) ───────────────────
+
+def_in(extra) := {"defender": object.union({"collected": true, "unavailable": {}}, extra)}
+
+good_alert(threat) := {
+	"Name": threat, "ThreatType": threat, "Severity": "High",
+	"Disabled": false, "NotificationEnabled": true,
+	"NotifyUser": ["soc@x.com"], "RecipientTags": "Priority account",
+	"Filter": "Mail.Direction -eq 'Inbound'",
+}
+
+test_2_4_1_tenant_toggle_off_violates if {
+	r := defender.compliance_report with input as def_in({
+		"email_tenant_settings": {"EnablePriorityAccountProtection": false},
+		"priority_account_alerts": [good_alert("Phish"), good_alert("Malware")],
+	})
+	some v in r.violations
+	contains(v, "CIS 2.4.1:")
+	contains(v, "not enabled for the tenant")
+}
+
+test_2_4_1_toggle_on_but_no_alerts_still_violates if {
+	# The toggle tags accounts; it does not watch them. CIS requires both.
+	r := defender.compliance_report with input as def_in({
+		"email_tenant_settings": {"EnablePriorityAccountProtection": true},
+		"priority_account_alerts": [],
+	})
+	some v in r.violations
+	contains(v, "CIS 2.4.1:")
+	contains(v, "phishing")
+}
+
+test_2_4_1_requires_both_phish_and_malware_alerts if {
+	r := defender.compliance_report with input as def_in({
+		"email_tenant_settings": {"EnablePriorityAccountProtection": true},
+		"priority_account_alerts": [good_alert("Phish")],
+	})
+	some v in r.violations
+	contains(v, "CIS 2.4.1:")
+	contains(v, "malware")
+	every v in r.violations { not contains(v, "phishing email detected") }
+}
+
+test_2_4_1_fully_configured_passes if {
+	r := defender.compliance_report with input as def_in({
+		"email_tenant_settings": {"EnablePriorityAccountProtection": true},
+		"priority_account_alerts": [good_alert("Phish"), good_alert("Malware")],
+	})
+	every v in r.violations { not contains(v, "CIS 2.4.1:") }
+}
+
+test_2_4_1_disabled_alert_does_not_count_as_passing if {
+	disabled := object.union(good_alert("Phish"), {"Disabled": true})
+	r := defender.compliance_report with input as def_in({
+		"email_tenant_settings": {"EnablePriorityAccountProtection": true},
+		"priority_account_alerts": [disabled, good_alert("Malware")],
+	})
+	some v in r.violations
+	contains(v, "CIS 2.4.1:")
+	contains(v, "phishing")
+}
+
+test_2_4_1_low_severity_alert_does_not_count if {
+	low := object.union(good_alert("Malware"), {"Severity": "Low"})
+	r := defender.compliance_report with input as def_in({
+		"email_tenant_settings": {"EnablePriorityAccountProtection": true},
+		"priority_account_alerts": [good_alert("Phish"), low],
+	})
+	some v in r.violations
+	contains(v, "CIS 2.4.1:")
+	contains(v, "malware")
+}
+
+# ── 5.1.6.1 -- collaboration invitation domains ───────────────────────
+
+en(extra) := {"entra": object.union({"collected": true, "unavailable": {}}, extra)}
+
+test_5_1_6_1_no_policy_violates if {
+	r := entra.compliance_report with input as en({"b2b_management_policy": {"policy_present": false}})
+	some v in r.violations
+	contains(v, "CIS 5.1.6.1:")
+}
+
+test_5_1_6_1_allow_list_present_passes if {
+	r := entra.compliance_report with input as en({"b2b_management_policy": {
+		"policy_present": true, "allowed_domains": ["contoso.com"],
+		"allowed_domains_present": true, "blocked_domains_present": false,
+	}})
+	every v in r.violations { not contains(v, "CIS 5.1.6.1:") }
+}
+
+test_5_1_6_1_empty_allow_list_is_compliant if {
+	# CIS is explicit: an empty AllowedDomains permits nothing, and is
+	# compliant. Collapsing "absent" and "empty" would invert the control.
+	r := entra.compliance_report with input as en({"b2b_management_policy": {
+		"policy_present": true, "allowed_domains": [],
+		"allowed_domains_present": true, "blocked_domains_present": false,
+	}})
+	every v in r.violations { not contains(v, "CIS 5.1.6.1:") }
+}
+
+test_5_1_6_1_absent_allow_list_violates if {
+	r := entra.compliance_report with input as en({"b2b_management_policy": {
+		"policy_present": true, "allowed_domains_present": false,
+		"blocked_domains_present": false,
+	}})
+	some v in r.violations
+	contains(v, "CIS 5.1.6.1:")
+	contains(v, "no AllowedDomains")
+}
+
+test_5_1_6_1_block_list_violates_even_with_an_allow_list if {
+	r := entra.compliance_report with input as en({"b2b_management_policy": {
+		"policy_present": true, "allowed_domains": ["contoso.com"],
+		"allowed_domains_present": true, "blocked_domains_present": true,
+	}})
+	some v in r.violations
+	contains(v, "CIS 5.1.6.1:")
+	contains(v, "BlockedDomains")
+}
+
+# ── 5.3.4 / 5.3.5 -- PIM activation approval ──────────────────────────
+
+GA_KEY := "pim_approval_62e90394-69f5-4237-9190-012177145e10"
+
+PRA_KEY := "pim_approval_e8611ab8-c189-46e8-94e1-60213ab1f814"
+
+test_5_3_4_approval_not_required_violates if {
+	r := entra.compliance_report with input as en({GA_KEY: {
+		"is_approval_required": false, "primary_approver_count": 0,
+	}})
+	some v in r.violations
+	contains(v, "CIS 5.3.4:")
+	contains(v, "Global Administrator")
+}
+
+test_5_3_5_approval_not_required_violates if {
+	r := entra.compliance_report with input as en({PRA_KEY: {
+		"is_approval_required": false, "primary_approver_count": 0,
+	}})
+	some v in r.violations
+	contains(v, "CIS 5.3.5:")
+	contains(v, "Privileged Role Administrator")
+}
+
+test_5_3_4_approval_required_with_no_approvers_violates if {
+	# A requirement that nobody can satisfy gates nothing.
+	r := entra.compliance_report with input as en({GA_KEY: {
+		"is_approval_required": true, "primary_approver_count": 0,
+	}})
+	some v in r.violations
+	contains(v, "CIS 5.3.4:")
+	contains(v, "no approvers are assigned")
+}
+
+test_5_3_4_approval_required_with_approvers_passes if {
+	r := entra.compliance_report with input as en({GA_KEY: {
+		"is_approval_required": true, "primary_approver_count": 2,
+	}})
+	every v in r.violations { not contains(v, "CIS 5.3.4:") }
+}
+
+test_5_3_4_role_not_governed_by_pim_is_not_a_pass if {
+	r := entra.compliance_report with input as {"entra": {
+		"collected": true,
+		"unavailable": {GA_KEY: "no roleManagementPolicyAssignment for the Global Administrator role -- PIM does not govern its activation (blocks 5.3.4)"},
+	}}
+	some v in r.violations
+	contains(v, "CIS 5.3.4:")
+	contains(v, "this is not a pass")
 }
 
 test_buckets_do_not_overlap if {


### PR DESCRIPTION
Closes the `not_implemented` bucket opened in #65. Coverage goes **138/160 → 144/160 (86% → 90%)** — the ceiling `docs/m365/CIS_M365_V7_AUTOMATION_LIMITS.md` §8 states for this tenant model.

| Bucket | Before | After |
|---|---|---|
| Evaluated | 138 | **144** |
| Requires attestation | 6 | 6 |
| Unresolved | 10 | 10 |
| Not implemented | 6 | **0** |
| **Total** | 160 | 160 |

Nothing remains that we know how to collect and simply have not built.

## Written from the primary source

Every rule comes from the benchmark's own **Audit** procedure, read out of the v7.0.0 PDF, rather than inferred from the control title. Three places where that changed the implementation:

**`1.3.3`** — CIS audits `Get-SharingPolicy -Identity "Default Sharing Policy"`. This checks *every* policy instead. A second enabled policy shares calendars just as effectively; auditing only the default follows the benchmark's example rather than establishing the control.

**`5.1.6.1`** — an **empty** `AllowedDomains` list is compliant per CIS (it permits nothing); an **absent** one is not. The collector reports presence separately from contents so the two cannot collapse — treating a missing list as an empty one would invert the control into its opposite.

**`5.3.4` / `5.3.5`** — CIS requires `isApprovalRequired` **and** at least one approver. Approval required of nobody gates nothing, so both are checked.

## Two structurally new controls

**`1.2.2` is the first control whose evidence spans two collectors.** CIS's own procedure joins `Get-EXOMailbox` to `Get-MgUser` on the directory object id, so Exchange supplies the mailboxes, Graph the sign-in state, and the Rego joins on that key. A mailbox with no matching directory account is reported **unevaluated, never passed** — an account we could not find is not one we established was blocked.

**`2.4.1` is compound**: the tenant toggle *plus* a passing phishing alert *plus* a passing malware alert, "passing" being CIS's own list — high severity, inbound, priority-tagged, notification enabled with a recipient, not disabled. The toggle alone tags accounts; it does not watch them.

## `NOT_IMPLEMENTED` is kept as an empty map

The category is real and will recur. The next control we know how to collect but have not built belongs there, not in `unresolved` — which would understate what we know. Deleting the bucket would quietly re-merge the distinction #65 was opened to draw.

## Measurable, not yet measured

**Read this before quoting 90%.** Whether each new endpoint returns data under **app-only** credentials is established only against a live tenant — the same gate that keeps the 10 `unresolved` controls parked. Until that probe runs, every one of the six fails closed with *"could not be evaluated (this is not a pass)"*.

This raises what the library **can assess**. It does not raise what any tenant **has been assessed** against.

## Verification

| Check | Result |
|---|---|
| `opa test . --ignore .github` | **492/492** (was 470) |
| `check_cis_ids.py` | OK — 134 distinct cited ids, all exist and cohere |
| `check_cis_coverage.py` | OK — 144 + 6 + 10 + 0 = 160 |
| deprecated-tree guard | still correctly rejects `m365/` |

22 new Rego tests. Each control has a violating case, a passing case, and a fail-closed case; the join and compound controls additionally have their partial-evidence edges pinned (`1.2.2` unmatched account, `2.4.1` alert present but disabled or low-severity, `5.1.6.1` empty vs absent allow list).

## Companion PR

The collector calls live in the compliance repo: `feat/m365-coverage-gap-collectors` (24 unit tests, 50 passing in the m365 suite). **That one should merge first** — this branch's rules read facts it produces. Until then the six report as unavailable, which is the correct fail-closed behaviour rather than a break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNF5rAx6FGZi7TXtU2mJsf