### PR TITLE
fix(ai_governance): default the two approval flags so the report stops collapsing

### DIFF
--- a/governance/ai/action_classification.rego
+++ b/governance/ai/action_classification.rego
@@ -99,11 +99,19 @@ critical_actions := {
 }
 
 # Helper to check if action requires approval
+# `default` is required: this rule only fires for medium/high/critical, so for a
+# read_only or low action it would otherwise be undefined — and one undefined
+# field collapses the whole classification_report object to {}.
+default requires_approval := false
+
 requires_approval if {
     action_risk_level in ["medium", "high", "critical"]
 }
 
 # Helper to check if action requires justification
+# Same reason as above: undefined for anything below high risk without this.
+default requires_justification := false
+
 requires_justification if {
     action_risk_level in ["high", "critical"]
 }

--- a/governance/ai/tests/test_ai_governance_smoke.rego
+++ b/governance/ai/tests/test_ai_governance_smoke.rego
@@ -13,3 +13,35 @@ test_report_wellformed_on_empty_input if {
 	count(result) > 0
 	is_string(result.decision)
 }
+
+# Regression: empty input is NOT sufficient coverage.
+#
+# `requires_approval` and `requires_justification` only fire for medium/high and
+# high/critical respectively. On empty input `action_risk_level` defaults to
+# "high", so both fired and the object resolved — the test above passed while a
+# realistic low-risk request collapsed classification_report, and with it the
+# whole governance_response, to {}. Exercise a genuinely low-risk action too.
+test_report_wellformed_on_read_only_action if {
+	result := ai_governance.governance_response with input as {
+		"action": "view_compliance_report",
+		"ai_system": {"id": "claude-code-v1", "role": "ai_reader", "enabled": true},
+		"context": {"environment": "development"},
+	}
+	is_object(result)
+	count(result) > 0
+	is_string(result.decision)
+	is_object(result.classification)
+	count(result.classification) > 0
+}
+
+# The defaults must not weaken the control: a critical action still demands
+# approval and justification.
+test_critical_action_still_requires_approval if {
+	report := ai_governance.classification.classification_report with input as {
+		"action": "delete_project",
+		"ai_system": {"id": "c", "role": "ai_operator", "enabled": true},
+		"context": {"environment": "production"},
+	}
+	report.requires_approval == true
+	report.requires_justification == true
+}


### PR DESCRIPTION
## The defect

`requires_approval` and `requires_justification` in `governance/ai/action_classification.rego` were bare conditional rules with **no `default`**:

```rego
requires_approval if { action_risk_level in ["medium","high","critical"] }
requires_justification if { action_risk_level in ["high","critical"] }
```

For a `read_only` or `low` action neither fires, so both are **undefined** — and one undefined field collapses the entire `classification_report` object literal, which collapses `ai_governance.governance_response` to `{}`.

**Production effect:** every low-risk AI action request returned `{}` from `/v1/data/ai_governance/governance_response`. The consuming playbook received no decision while the job stayed green — silent failure.

Bisected live against the lab OPA with the exact body the playbook sends: `decision`=allow, `action_risk_level`=read_only, `authorized`=true, `context_valid`=true all resolved — only `classification_report` was `{}`.

## Why the test suite missed it

The existing smoke test only exercised **empty** input. On empty input `action_risk_level` defaults to `"high"`, so both rules fired and the object resolved. **The test passed while realistic traffic collapsed** — the inversion of the usual `{}` trap, which is what made it durable.

Two tests added:
- `test_report_wellformed_on_read_only_action` — **fails without this fix** (verified by reverting)
- `test_critical_action_still_requires_approval` — pins the fail-closed behaviour

```
PASS: 3/3        (with fix)
FAIL: 1/3        (fix reverted — the new read_only test)
```

## This does not weaken the control

`action_risk_level` already defaults to `"high"` and both rules fire `true` at high, so an unclassified action still requires approval and justification. The defaults apply only where the rules deliberately do not fire. Mirrors the existing `default requires_multi_approval := false` in the same file.

Verified: `delete_project` → `requires_approval: true, requires_justification: true, requires_multi_approval: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXWv3LSdQbUxvPBfLBtUFP