### PR TITLE
feat(enforcement/repo): policy for install-configuration hygiene

### DIFF
--- a/enforcement/repo/install_hygiene.rego
+++ b/enforcement/repo/install_hygiene.rego
@@ -1,0 +1,185 @@
+# Install-configuration hygiene — keep one environment's addresses and
+# credentials out of another environment's install.
+#
+# WHAT THIS IS FOR
+#
+# A repository that ships an installer accumulates the maintainer's own
+# addresses and passwords: a hostname in a README, a fallback password in a
+# playbook, a checked-in config file pointing at the lab. Each one is harmless
+# where it was written and none of them are harmless when a customer clones the
+# repository and runs it. This encodes the four ways it happens.
+#
+# GENERIC BY CONSTRUCTION
+#
+# Nothing here names a specific site. The addresses, the credential literals,
+# the protected paths and the allowlist all arrive as input, so any project can
+# use this by supplying its own. That is deliberate: this library is consumed
+# by more than one product and must not carry any one deployment's specifics.
+#
+# THE FOURTH RULE IS THE ONE THAT MATTERS
+#
+# AAC-CFG-003 checks whether a file is TRACKED, not what is in it. The defect
+# that motivated this policy was a config file listed in .gitignore AND tracked
+# by git — and git ignores .gitignore for files it already tracks, so the entry
+# did nothing. The file kept shipping with the maintainer's addresses, every
+# clone inherited them, and every local edit was a staged lab value waiting to
+# be committed. A content scan cannot see that; only a tracked-ness check can.
+#
+# INPUT — two shapes, two entry points
+#
+#   Per-file content scan (AAC-CFG-001/002/004):
+#     input.path                string   repo-relative path
+#     input.lines[]             array    [{"n": <int>, "text": <string>}, ...]
+#     input.lab_addresses[]     array    addresses that belong to one site only
+#     input.banned_credentials[] array   credential literals that must not ship
+#     input.allowlist[]         array    path prefixes exempt from 001/002
+#
+#   Repository-wide tracked-file check (AAC-CFG-003):
+#     input.tracked_files[]     array    every path git currently tracks
+#     input.must_be_untracked[] array    operator-owned config paths
+#
+# OPA query paths:
+#   /v1/data/aac/repo/install_hygiene/violation
+#   /v1/data/aac/repo/install_hygiene/tracking_violation
+
+package aac.repo.install_hygiene
+
+import rego.v1
+
+path_label := input.path
+
+default path_label := "<file>"
+
+lab_addresses := object.get(input, "lab_addresses", [])
+
+banned_credentials := object.get(input, "banned_credentials", [])
+
+allowlist := object.get(input, "allowlist", [])
+
+# A file is exempt when its path starts with an allowlisted prefix. Prefixes are
+# supplied explicitly rather than inferred: an allowlist that guesses is an
+# allowlist nobody can audit.
+allowlisted if {
+	some prefix in allowlist
+	startswith(path_label, prefix)
+}
+
+lines := object.get(input, "lines", [])
+
+# ── AAC-CFG-001 — no site-specific address in a shipped file ────────────────
+violation contains msg if {
+	not allowlisted
+	some line in lines
+	some addr in lab_addresses
+	contains(line.text, addr)
+	msg := sprintf(
+		"AAC-CFG-001: %s:%v: address %s belongs to one environment — resolve it through the install inventory instead of naming it here",
+		[path_label, line.n, addr],
+	)
+}
+
+# ── AAC-CFG-002 — no working credential in a shipped file ──────────────────
+# Applies to templates and documentation as much as to code. A password in a
+# README is a password a customer will paste, and an "e.g." in an .example file
+# is still the real credential.
+violation contains msg if {
+	not allowlisted
+	some line in lines
+	some cred in banned_credentials
+	contains(line.text, cred)
+	msg := sprintf(
+		"AAC-CFG-002: %s:%v: credential literal %q must not ship — use a placeholder and source the real value from an AAP credential or an encrypted vault file",
+		[path_label, line.n, cred],
+	)
+}
+
+# ── AAC-CFG-004 — a secret must not have a fallback default ────────────────
+# `password | default('something')` fails OPEN: when the credential is missing
+# the run does not stop, it proceeds with whatever was baked in. That is how a
+# customer's install ends up authenticating with the maintainer's password.
+# Matches Ansible/Jinja `default(...)` and shell `${VAR:-...}` on a name that
+# looks like a secret.
+# The name being ASSIGNED must look like a secret — not merely some word on the
+# line. Scanning the whole line flagged
+#     max_days: "{{ ... 'PASS_MAX_DAYS' ... | default('99999') }}"
+# which parses a password-AGING policy and holds no credential at all. A rule
+# that flags password policy alongside real passwords trains people to ignore
+# it, so the target is matched specifically.
+secret_assignment(text) if {
+	regex.match(`(?i)^\s*[-\s]*["']?[\w.]*(password|passwd|secret|token|api_?key)\w*["']?\s*[:=]`, text)
+}
+
+# A purely numeric fallback is a duration, port or retry count, never a
+# credential. Excluded so the rule stays believable.
+numeric_default(text) if regex.match(`\|\s*default\(\s*['"][0-9]+['"][^)]*\)`, text)
+
+violation contains msg if {
+	not allowlisted
+	some line in lines
+	secret_assignment(line.text)
+	# `[^)]*` after the literal so the two-argument form — default('x', true),
+	# which is how Ansible spells "treat empty as unset" — is caught too. A
+	# pattern requiring `)` immediately after the quote missed every one of them.
+	regex.match(`\|\s*default\(\s*['"][^'"]+['"][^)]*\)`, line.text)
+	not numeric_default(line.text)
+	msg := sprintf(
+		"AAC-CFG-004: %s:%v: secret has a fallback default — this fails open. Use `| mandatory` so a missing credential stops the run instead of silently authenticating with a value baked into the repository",
+		[path_label, line.n],
+	)
+}
+
+# For shell, the secret-ness is in the variable name inside ${NAME:-...}, which
+# is often mid-line (`... PASSWORD '${READER_PASSWORD:-hunter2}'`), so the
+# assignment-target test above does not apply.
+violation contains msg if {
+	not allowlisted
+	some line in lines
+	some m in regex.find_n(`\$\{[A-Za-z_][A-Za-z0-9_]*:-[^}]*\}`, line.text, -1)
+	# Shell names abbreviate (GRAFANA_PASS, DB_PASSWD), so match on an
+	# underscore-delimited SEGMENT rather than a substring. Substring matching
+	# would also catch BYPASS_CHECK and PASSED_COUNT; segment matching does not.
+	regex.match(`(?i)\$\{(\w+_)?(password|passwd|pass|secret|token|api_?key|credential)(_\w+)*:-`, m)
+	msg := sprintf(
+		"AAC-CFG-004: %s:%v: secret has a shell fallback default (%s) — this fails open. Use ${VAR:?message} so a missing credential stops the run",
+		[path_label, line.n, m],
+	)
+}
+
+# ── AAC-CFG-003 — operator config must not be tracked ───────────────────────
+# The rule a content scan cannot express. Checked once for the repository.
+tracking_violation contains msg if {
+	some p in object.get(input, "must_be_untracked", [])
+	some tracked in object.get(input, "tracked_files", [])
+	tracked == p
+	msg := sprintf(
+		"AAC-CFG-003: %s is tracked by git but holds one environment's values. Untrack it (`git rm --cached %s`) and ship only the .example — a .gitignore entry has NO effect on an already-tracked file, which is exactly how this was missed before",
+		[p, p],
+	)
+}
+
+# ── Reports ─────────────────────────────────────────────────────────────────
+
+default compliant := false
+
+compliant if count(violation) == 0
+
+compliance_report := {
+	"policy": "Install configuration hygiene",
+	"path": path_label,
+	"lines_scanned": count(lines),
+	"violations": violation,
+	"violation_count": count(violation),
+	"compliant": compliant,
+}
+
+default tracking_compliant := false
+
+tracking_compliant if count(tracking_violation) == 0
+
+tracking_report := {
+	"policy": "Install configuration hygiene — tracked files",
+	"tracked_count": count(object.get(input, "tracked_files", [])),
+	"violations": tracking_violation,
+	"violation_count": count(tracking_violation),
+	"compliant": tracking_compliant,
+}

--- a/enforcement/repo/tests/test_install_hygiene.rego
+++ b/enforcement/repo/tests/test_install_hygiene.rego
@@ -1,0 +1,228 @@
+# Tests for install-configuration hygiene.
+#
+# The fixtures are the actual defects this policy was written after, not
+# invented ones: a lab address in an install README, the maintainer's Grafana
+# password used as a fallback default, a credential left in an .example file as
+# "e.g.", and a config file that was gitignored and tracked at the same time.
+
+package aac.repo.install_hygiene_test
+
+import data.aac.repo.install_hygiene as ih
+import rego.v1
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+LAB := ["192.0.2.10", "192.0.2.11"]
+
+CREDS := ["Sup3rSecret", "admin123"]
+
+file(path, texts) := {
+	"path": path,
+	"lines": [line | some i, t in texts; line := {"n": i + 1, "text": t}],
+	"lab_addresses": LAB,
+	"banned_credentials": CREDS,
+	"allowlist": ["config/profiles/lab.yml", "tooling/local/"],
+}
+
+has(violations, code) if {
+	some v in violations
+	contains(v, code)
+}
+
+# ── AAC-CFG-001 — site-specific addresses ────────────────────────────────────
+
+test_lab_address_in_a_readme_violates if {
+	v := ih.violation with input as file("install/README.md", [
+		"# Install",
+		"Point the controller at 192.0.2.10 and run the playbook.",
+	])
+	has(v, "AAC-CFG-001")
+}
+
+# The message must carry the line number — a reviewer needs to find it.
+test_address_violation_names_the_line if {
+	v := ih.violation with input as file("install/README.md", [
+		"first",
+		"second",
+		"host: 192.0.2.10",
+	])
+	some m in v
+	contains(m, "install/README.md:3")
+}
+
+test_placeholder_host_passes if {
+	v := ih.violation with input as file("install/README.md", ["host: <aac-host>"])
+	not has(v, "AAC-CFG-001")
+}
+
+# The lab's own profile is where these addresses legitimately live.
+test_allowlisted_path_is_exempt if {
+	v := ih.violation with input as file("config/profiles/lab.yml", ["host: 192.0.2.10"])
+	not has(v, "AAC-CFG-001")
+}
+
+# A prefix allowlist must cover the whole subtree, not just an exact path.
+test_allowlist_covers_a_subtree if {
+	v := ih.violation with input as file("tooling/local/scripts/reset.sh", ["ssh me@192.0.2.11"])
+	not has(v, "AAC-CFG-001")
+}
+
+# ── AAC-CFG-002 — shipped credentials ────────────────────────────────────────
+
+test_credential_in_a_readme_violates if {
+	v := ih.violation with input as file("install/README.md", ["Login: admin / Sup3rSecret"])
+	has(v, "AAC-CFG-002")
+}
+
+# An .example file is the most tempting place to leave a real value and the
+# worst, because it reads as authoritative. "e.g. <real password>" still ships
+# the password.
+test_credential_as_an_example_still_violates if {
+	v := ih.violation with input as file("config/secrets.yml.example", [
+		"grafana_admin_password:   <admin password — e.g. Sup3rSecret>",
+	])
+	has(v, "AAC-CFG-002")
+}
+
+test_placeholder_credential_passes if {
+	v := ih.violation with input as file("config/secrets.yml.example", [
+		"grafana_admin_password: PLACEHOLDER",
+	])
+	not has(v, "AAC-CFG-002")
+}
+
+# ── AAC-CFG-004 — fail-open secret defaults ──────────────────────────────────
+
+test_jinja_default_on_a_password_violates if {
+	v := ih.violation with input as file("playbooks/deploy.yml", [
+		"    grafana_admin_password: \"{{ grafana_admin_password | default('Sup3rSecret') }}\"",
+	])
+	has(v, "AAC-CFG-004")
+}
+
+test_mandatory_instead_of_default_passes if {
+	v := ih.violation with input as file("playbooks/deploy.yml", [
+		"    grafana_admin_password: \"{{ grafana_admin_password | mandatory }}\"",
+	])
+	not has(v, "AAC-CFG-004")
+}
+
+test_shell_fallback_on_a_password_violates if {
+	v := ih.violation with input as file("scripts/check.sh", [
+		"GRAFANA_PASS=\"${GRAFANA_PASS:-Sup3rSecret}\"",
+	])
+	has(v, "AAC-CFG-004")
+}
+
+test_shell_required_form_passes if {
+	v := ih.violation with input as file("scripts/check.sh", [
+		"GRAFANA_PASS=\"${GRAFANA_PASS:?set GRAFANA_PASS}\"",
+	])
+	not has(v, "AAC-CFG-004")
+}
+
+# A default on something that is not a secret is ordinary good practice and
+# must not be flagged — a rule that cries wolf gets switched off.
+test_default_on_a_non_secret_passes if {
+	v := ih.violation with input as file("playbooks/deploy.yml", [
+		"    listen_port: \"{{ listen_port | default('8080') }}\"",
+	])
+	not has(v, "AAC-CFG-004")
+}
+
+# ── AAC-CFG-003 — tracked operator config ────────────────────────────────────
+# The defect a content scan structurally cannot catch.
+
+test_tracked_operator_config_violates if {
+	v := ih.tracking_violation with input as {
+		"tracked_files": ["README.md", "config/site_config.yml"],
+		"must_be_untracked": ["config/site_config.yml"],
+	}
+	has(v, "AAC-CFG-003")
+}
+
+test_untracked_operator_config_passes if {
+	v := ih.tracking_violation with input as {
+		"tracked_files": ["README.md", "config/site_config.yml.example"],
+		"must_be_untracked": ["config/site_config.yml"],
+	}
+	count(v) == 0
+}
+
+# The .example must stay tracked — untracking it would leave an operator with
+# no template at all, so the rule must match exactly and not by prefix.
+test_example_file_is_not_confused_with_the_real_one if {
+	v := ih.tracking_violation with input as {
+		"tracked_files": ["config/site_config.yml.example"],
+		"must_be_untracked": ["config/site_config.yml"],
+	}
+	count(v) == 0
+}
+
+# ── reports ──────────────────────────────────────────────────────────────────
+
+test_clean_file_is_compliant if {
+	r := ih.compliance_report with input as file("install/README.md", ["host: <aac-host>"])
+	r.compliant == true
+	r.violation_count == 0
+	r.lines_scanned == 1
+}
+
+# A caller that omits `path` must still get a usable report rather than the
+# empty object an undefined field collapses to.
+test_report_survives_a_missing_path if {
+	r := ih.compliance_report with input as {"lines": [{"n": 1, "text": "ok"}]}
+	r.path == "<file>"
+	count(r) > 0
+}
+
+test_tracking_report_is_populated if {
+	r := ih.tracking_report with input as {
+		"tracked_files": ["a", "b"],
+		"must_be_untracked": ["c"],
+	}
+	r.tracked_count == 2
+	r.compliant == true
+}
+
+# Password *policy* is not a password. This line parses PASS_MAX_DAYS from
+# /etc/login.defs; scanning the whole line for the word "password" flagged it,
+# and a rule that flags password policy next to real passwords is a rule people
+# learn to ignore.
+test_password_aging_policy_is_not_a_secret if {
+	v := ih.violation with input as file("roles/facts/tasks/users.yml", [
+		"    max_days: \"{{ raw.stdout | regex_search('PASS_MAX_DAYS\\\\s+(\\\\d+)') | default('99999') }}\"",
+	])
+	not has(v, "AAC-CFG-004")
+}
+
+# A numeric fallback is a timeout, port or retry count.
+test_numeric_default_on_a_secretish_name_passes if {
+	v := ih.violation with input as file("playbooks/x.yml", [
+		"    token_ttl_seconds: \"{{ token_ttl_seconds | default('3600') }}\"",
+	])
+	not has(v, "AAC-CFG-004")
+}
+
+# The shell form is usually mid-line, so the secret-ness must come from the
+# variable name inside ${...} rather than from the assignment target.
+test_shell_secret_default_midline_violates if {
+	v := ih.violation with input as file("scripts/install.sh", [
+		"    CREATE ROLE reader LOGIN PASSWORD '${READER_PASSWORD:-changeme}';",
+	])
+	has(v, "AAC-CFG-004")
+}
+
+test_shell_non_secret_default_passes if {
+	v := ih.violation with input as file("scripts/install.sh", [
+		"    PORT=\"${PORT:-5432}\"",
+	])
+	not has(v, "AAC-CFG-004")
+}
+
+# Substring matching on the variable name would flag these; segment matching
+# must not.
+test_bypass_is_not_a_password if {
+	v := ih.violation with input as file("scripts/x.sh", ["MODE=\"${BYPASS:-off}\""])
+	not has(v, "AAC-CFG-004")
+}


### PR DESCRIPTION
Four rules that keep one environment's addresses and credentials out of another environment's install. Written after finding lab IPs in five install READMEs, one credential in twenty files, and a config file that was gitignored *and* tracked — where the gitignore entry did nothing.

`AAC-CFG-003` checks **tracked-ness**, not content. That is the defect a content scan structurally cannot catch, and it was the root cause.

Generic by construction — addresses, credentials, paths and allowlist all come from input, so the library stays vendor-neutral.

24 unit tests, all passing. Two rules were tightened after running against a real tree (password-*aging* policy was being flagged as a secret; the shell matcher missed `GRAFANA_PASS` while it would have caught `BYPASS`).