### PR TITLE
fix(enforcement/repo): three ways AAC-CFG-004 was too loose

### DIFF
--- a/enforcement/repo/install_hygiene.rego
+++ b/enforcement/repo/install_hygiene.rego
@@ -105,8 +105,14 @@ violation contains msg if {
 # which parses a password-AGING policy and holds no credential at all. A rule
 # that flags password policy alongside real passwords trains people to ignore
 # it, so the target is matched specifically.
+# The keyword must END the identifier. Allowing a trailing `\w*` matched
+# `password_authentication` and `permit_empty_passwords` -- sshd CONFIG FIELDS,
+# not credentials. Acting on those replaced `| default('not set')` with
+# `| mandatory` and broke fact collection on every host that relies on sshd
+# defaults, which is most of them. A name that merely CONTAINS "password" is
+# usually a setting about passwords; a name that ENDS with it is the secret.
 secret_assignment(text) if {
-	regex.match(`(?i)^\s*[-\s]*["']?[\w.]*(password|passwd|secret|token|api_?key)\w*["']?\s*[:=]`, text)
+	regex.match(`(?i)^\s*[-\s]*["']?[\w.]*?(password|passwd|secret|token|api_?key)["']?\s*[:=]`, text)
 }
 
 # A purely numeric fallback is a duration, port or retry count, never a
@@ -134,11 +140,21 @@ violation contains msg if {
 violation contains msg if {
 	not allowlisted
 	some line in lines
-	some m in regex.find_n(`\$\{[A-Za-z_][A-Za-z0-9_]*:-[^}]*\}`, line.text, -1)
+	# `[^}]+` not `[^}]*`: an EMPTY default (`${VAR:-}`) is not a fallback
+	# credential, it is the standard `set -u`-safe way to read a maybe-unset
+	# variable so the next line can check it and print real guidance. Flagging
+	# it pushed scripts toward `${VAR:?}`, which aborts with bash's terse
+	# message BEFORE the script's own error text can run -- strictly worse.
+	# Only a non-empty fallback is a shipped credential.
+	some m in regex.find_n(`\$\{[A-Za-z_][A-Za-z0-9_]*:-[^}]+\}`, line.text, -1)
 	# Shell names abbreviate (GRAFANA_PASS, DB_PASSWD), so match on an
 	# underscore-delimited SEGMENT rather than a substring. Substring matching
 	# would also catch BYPASS_CHECK and PASSED_COUNT; segment matching does not.
-	regex.match(`(?i)\$\{(\w+_)?(password|passwd|pass|secret|token|api_?key|credential)(_\w+)*:-`, m)
+	# Same rule as above: the keyword must be the LAST segment. Allowing
+	# trailing segments matched `${TOKEN_NOTE:-}` -- a display string, not a
+	# credential -- and turning it into `${TOKEN_NOTE:?}` aborted the script on
+	# its normal path, because that note is only set on a fallback branch.
+	regex.match(`(?i)\$\{(\w+_)?(password|passwd|pass|secret|token|api_?key|credential):-`, m)
 	msg := sprintf(
 		"AAC-CFG-004: %s:%v: secret has a shell fallback default (%s) — this fails open. Use ${VAR:?message} so a missing credential stops the run",
 		[path_label, line.n, m],

--- a/enforcement/repo/tests/test_install_hygiene.rego
+++ b/enforcement/repo/tests/test_install_hygiene.rego
@@ -226,3 +226,68 @@ test_bypass_is_not_a_password if {
 	v := ih.violation with input as file("scripts/x.sh", ["MODE=\"${BYPASS:-off}\""])
 	not has(v, "AAC-CFG-004")
 }
+
+# ── Regressions from acting on these rules too loosely ───────────────────────
+# Each of these was flagged as a secret, "fixed", and broke something.
+
+# sshd config FIELDS, not credentials. `| mandatory` on these failed fact
+# collection on any host using sshd defaults.
+test_password_authentication_is_a_setting_not_a_secret if {
+	v := ih.violation with input as file("roles/ssh/tasks/main.yml", [
+		"        password_authentication: \"{{ d.passwordauthentication | default('not set') }}\"",
+	])
+	not has(v, "AAC-CFG-004")
+}
+
+test_permit_empty_passwords_is_a_setting_not_a_secret if {
+	v := ih.violation with input as file("roles/ssh/tasks/main.yml", [
+		"        permit_empty_passwords: \"{{ d.permitemptypasswords | default('not set') }}\"",
+	])
+	not has(v, "AAC-CFG-004")
+}
+
+# A display note that happens to start with TOKEN. Requiring it aborted the
+# script on the path where the note is legitimately unset.
+test_token_note_is_not_a_secret if {
+	v := ih.violation with input as file("install/seed.sh", [
+		"echo \"Controller token ID: ${TOKEN_ID}${TOKEN_NOTE:-}\"",
+	])
+	not has(v, "AAC-CFG-004")
+}
+
+# The real ones must still be caught after tightening.
+test_real_secret_assignment_still_caught if {
+	v := ih.violation with input as file("playbooks/x.yml", [
+		"    compliance_db_password: \"{{ compliance_db_password | default('hunter2') }}\"",
+	])
+	has(v, "AAC-CFG-004")
+}
+
+test_real_shell_secret_still_caught if {
+	v := ih.violation with input as file("scripts/x.sh", ["GRAFANA_PASS=\"${GRAFANA_PASS:-hunter2}\""])
+	has(v, "AAC-CFG-004")
+}
+
+# A path derived from a secret name is not itself a secret.
+test_password_file_path_is_not_a_secret if {
+	v := ih.violation with input as file("scripts/x.sh", ["F=\"${DB_PASSWORD_FILE:-/etc/pw}\""])
+	not has(v, "AAC-CFG-004")
+}
+
+# `${VAR:-}` reads a maybe-unset variable safely so the NEXT line can check it
+# and print real guidance. That is fail-closed. Flagging it pushed scripts to
+# `${VAR:?}`, which aborts with bash's terse message before the script's own
+# error text runs.
+test_empty_shell_default_is_a_guard_not_a_fallback if {
+	v := ih.violation with input as file("scripts/x.sh", [
+		"if [[ -z \"${GRAFANA_PASS:-}\" ]]; then",
+		"    echo 'GRAFANA_PASS is not set — export it first.' >&2; exit 1",
+		"fi",
+	])
+	not has(v, "AAC-CFG-004")
+}
+
+test_nonempty_shell_default_is_still_a_fallback if {
+	v := ih.violation with input as file("scripts/x.sh", ["P=\"${GRAFANA_PASS:-hunter2}\""])
+	has(v, "AAC-CFG-004")
+}


### PR DESCRIPTION
Found by acting on the rule against a real repository and breaking things. The rule had the right shape and the wrong boundary.

| # | Too loose | What it broke |
|---|---|---|
| 1 | Keyword matched anywhere in the name | `password_authentication` / `permit_empty_passwords` are sshd **config fields**. `| mandatory` on them broke fact collection on any host using sshd defaults. |
| 2 | Shell keyword allowed trailing segments | `${TOKEN_NOTE:-}` is a display string; `:?` aborted the script on its normal path. |
| 3 | Empty default treated as a fallback | `${VAR:-}` is a **guard** — the next line checks it and prints guidance. Pushing it to `${VAR:?}` replaced good errors with bash's terse one. |

Now: the keyword must **end** the identifier (or be the last shell segment), and only a **non-empty** fallback counts.

32 tests, 6 of them these exact regressions.