### PR TITLE
fix(cis): four aggregate reports collapsed to {} on missing system_info

### DIFF
--- a/benchmarks/cis/debian_11/cis_debian_11_complete.rego
+++ b/benchmarks/cis/debian_11/cis_debian_11_complete.rego
@@ -148,13 +148,15 @@ compliance_assessment := {
 		"benchmark": "DERIVED from CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0 — applied to Debian 11 (see README)",
 		"target_platform": "Debian 11 LTS",
 		"assessment_time": time.now_ns(),
-		"hostname": input.system_info.hostname,
+		# Defaulted: a bare dereference here collapsed the whole report to {}
+		# on any input missing system_info (library rule #5).
+		"hostname": object.get(input, ["system_info", "hostname"], "unknown"),
 	},
 	"system_info": {
-		"distribution": input.system_info.distribution,
-		"distribution_version": input.system_info.distribution_version,
-		"kernel": input.system_info.kernel,
-		"architecture": input.system_info.architecture,
+		"distribution": object.get(input, ["system_info", "distribution"], "unknown"),
+		"distribution_version": object.get(input, ["system_info", "distribution_version"], "unknown"),
+		"kernel": object.get(input, ["system_info", "kernel"], "unknown"),
+		"architecture": object.get(input, ["system_info", "architecture"], "unknown"),
 	},
 	"compliance_summary": compliance_summary,
 	"module_status": module_status,

--- a/benchmarks/cis/ubuntu_20_04/cis_ubuntu_20_04_complete.rego
+++ b/benchmarks/cis/ubuntu_20_04/cis_ubuntu_20_04_complete.rego
@@ -148,13 +148,15 @@ compliance_assessment := {
 		"benchmark": "CIS Ubuntu Linux 20.04 LTS Benchmark v3.0.0",
 		"target_platform": "Ubuntu 20.04 LTS",
 		"assessment_time": time.now_ns(),
-		"hostname": input.system_info.hostname,
+		# Defaulted: a bare dereference here collapsed the whole report to {}
+		# on any input missing system_info (library rule #5).
+		"hostname": object.get(input, ["system_info", "hostname"], "unknown"),
 	},
 	"system_info": {
-		"distribution": input.system_info.distribution,
-		"distribution_version": input.system_info.distribution_version,
-		"kernel": input.system_info.kernel,
-		"architecture": input.system_info.architecture,
+		"distribution": object.get(input, ["system_info", "distribution"], "unknown"),
+		"distribution_version": object.get(input, ["system_info", "distribution_version"], "unknown"),
+		"kernel": object.get(input, ["system_info", "kernel"], "unknown"),
+		"architecture": object.get(input, ["system_info", "architecture"], "unknown"),
 	},
 	"compliance_summary": compliance_summary,
 	"module_status": module_status,

--- a/benchmarks/cis/ubuntu_22_04/cis_ubuntu_22_04_complete.rego
+++ b/benchmarks/cis/ubuntu_22_04/cis_ubuntu_22_04_complete.rego
@@ -152,13 +152,20 @@ compliance_assessment := {
 		"benchmark": "CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0",
 		"target_platform": "Ubuntu 22.04 LTS",
 		"assessment_time": time.now_ns(),
-		"hostname": input.system_info.hostname,
+		# Every input-sourced field is defaulted. These were bare dereferences,
+		# and one undefined field collapses the whole object to {} at the
+		# endpoint (library rule #5) -- so the report this file exists to
+		# produce vanished on any input missing system_info, and the caller
+		# stored the empty result while its job stayed green. The smoke test
+		# knew: it tested compliance_summary instead and called the collapse
+		# "by design". Fail-closed means saying "unknown", not saying nothing.
+		"hostname": object.get(input, ["system_info", "hostname"], "unknown"),
 	},
 	"system_info": {
-		"distribution": input.system_info.distribution,
-		"distribution_version": input.system_info.distribution_version,
-		"kernel": input.system_info.kernel,
-		"architecture": input.system_info.architecture,
+		"distribution": object.get(input, ["system_info", "distribution"], "unknown"),
+		"distribution_version": object.get(input, ["system_info", "distribution_version"], "unknown"),
+		"kernel": object.get(input, ["system_info", "kernel"], "unknown"),
+		"architecture": object.get(input, ["system_info", "architecture"], "unknown"),
 	},
 	"compliance_summary": compliance_summary,
 	"module_status": module_status,

--- a/benchmarks/cis/ubuntu_22_04/tests/test_cis_ubuntu_2204_smoke.rego
+++ b/benchmarks/cis/ubuntu_22_04/tests/test_cis_ubuntu_2204_smoke.rego
@@ -7,11 +7,21 @@ import data.cis_ubuntu_22_04
 # Phase 1 contract smoke test.
 # Proves a well-formed report object is returned on empty input, never the
 # `undefined -> {}` collapse.
-# Entrypoint: data.cis_ubuntu_22_04.compliance_summary
-# (The primary top-level report data.cis_ubuntu_22_04.compliance_assessment is
-#  undefined on empty input — it dereferences input.system_info and requires
-#  real input by design; see broken-endpoint notes.)
+#
+# This now tests the PRIMARY endpoint, compliance_assessment — the one the
+# assessment playbook actually queries. It used to test compliance_summary
+# instead, with a comment explaining that the primary endpoint collapses on
+# empty input "by design". That was testing around the defect rather than
+# pinning it: any caller whose facts lacked system_info got {} stored as its
+# assessment while the job stayed green.
 test_report_wellformed_on_empty_input if {
+	report := cis_ubuntu_22_04.compliance_assessment with input as {}
+	is_object(report)
+	count(report) > 0
+	report.system_info.distribution == "unknown"
+}
+
+test_summary_wellformed_on_empty_input if {
 	report := cis_ubuntu_22_04.compliance_summary with input as {}
 	is_object(report)
 	count(report) > 0

--- a/benchmarks/cis/ubuntu_24_04/cis_ubuntu_24_04_complete.rego
+++ b/benchmarks/cis/ubuntu_24_04/cis_ubuntu_24_04_complete.rego
@@ -152,13 +152,15 @@ compliance_assessment := {
 		"benchmark": "DERIVED from CIS Ubuntu Linux 22.04 LTS Benchmark v3.0.0 — applied to Ubuntu 24.04 LTS (see README)",
 		"target_platform": "Ubuntu 24.04 LTS",
 		"assessment_time": time.now_ns(),
-		"hostname": input.system_info.hostname,
+		# Defaulted: a bare dereference here collapsed the whole report to {}
+		# on any input missing system_info (library rule #5).
+		"hostname": object.get(input, ["system_info", "hostname"], "unknown"),
 	},
 	"system_info": {
-		"distribution": input.system_info.distribution,
-		"distribution_version": input.system_info.distribution_version,
-		"kernel": input.system_info.kernel,
-		"architecture": input.system_info.architecture,
+		"distribution": object.get(input, ["system_info", "distribution"], "unknown"),
+		"distribution_version": object.get(input, ["system_info", "distribution_version"], "unknown"),
+		"kernel": object.get(input, ["system_info", "kernel"], "unknown"),
+		"architecture": object.get(input, ["system_info", "architecture"], "unknown"),
 	},
 	"compliance_summary": compliance_summary,
 	"module_status": module_status,


### PR DESCRIPTION
`compliance_assessment` in **ubuntu_22_04, ubuntu_20_04, ubuntu_24_04 and debian_11** dereferenced `input.system_info.*` bare — one undefined field collapses the whole object (library rule #5), so the report vanished on any input lacking `system_info`, and the caller stored `{}` while its job stayed green. Found probing the endpoint before tonight's Ubuntu audit.

**The smoke test knew.** It tested `compliance_summary` instead of the primary endpoint, with a comment calling the collapse *"by design"*. That's testing around a defect, not pinning it.

All input-sourced fields now default via `object.get` → `"unknown"`. Smoke test repointed at the primary endpoint. Verified with `opa eval` on empty input for all four: populated object, never `{}`. 5/5 tests.