### PR TITLE
fix: 14 aggregate reports were undefined on missing input — now zero

### DIFF
--- a/benchmarks/cis/rhel_9/authorized_keys_validation.rego
+++ b/benchmarks/cis/rhel_9/authorized_keys_validation.rego
@@ -183,11 +183,11 @@ compliance_report := {
 	"standards": ["CIS RHEL 9 5.2", "STIG RHEL-09-255xxx", "NIST SP 800-53 IA-3", "NIST SP 800-53 SC-13"],
 	"violations": violations,
 	"compliant": compliant,
-	"files_checked": count(object.get(input.authorized_keys, "files", [])),
-	"total_keys": count([k | some e in input.authorized_keys.files; some k in e.keys]),
+	"files_checked": count(object.get(input, ["authorized_keys", "files"], [])),
+	"total_keys": count([k | some e in object.get(input, ["authorized_keys", "files"], []); some k in e.keys]),
 	"unapproved_keys": count([k |
-		count(input.authorized_keys.approved_fingerprints) > 0
-		some e in input.authorized_keys.files
+		count(object.get(input, ["authorized_keys", "approved_fingerprints"], [])) > 0
+		some e in object.get(input, ["authorized_keys", "files"], [])
 		some k in e.keys
 		not approved_fingerprint(k.fingerprint)
 	]),

--- a/benchmarks/cis/rhel_9/certificate_validation.rego
+++ b/benchmarks/cis/rhel_9/certificate_validation.rego
@@ -148,18 +148,18 @@ compliance_report := {
 	"standards": ["NIST SP 800-53 SC-17", "NIST SP 800-53 IA-5", "NIST SP 800-53 SC-13", "CIS 1.8"],
 	"violations": violations,
 	"compliant": compliant,
-	"total_certs": count(object.get(input.certificates, "system_certs", [])),
+	"total_certs": count(object.get(input, ["certificates", "system_certs"], [])),
 	"expired": count([c |
-		some c in input.certificates.system_certs
+		some c in object.get(input, ["certificates", "system_certs"], [])
 		c.days_until_expiry < 0
 	]),
 	"expiring_critical": count([c |
-		some c in input.certificates.system_certs
+		some c in object.get(input, ["certificates", "system_certs"], [])
 		c.days_until_expiry >= 0
 		c.days_until_expiry <= expiry_critical_days
 	]),
 	"expiring_warning": count([c |
-		some c in input.certificates.system_certs
+		some c in object.get(input, ["certificates", "system_certs"], [])
 		c.days_until_expiry > expiry_critical_days
 		c.days_until_expiry <= expiry_warning_days
 	]),

--- a/benchmarks/cis/rhel_9/storage_encryption_validation.rego
+++ b/benchmarks/cis/rhel_9/storage_encryption_validation.rego
@@ -170,7 +170,7 @@ compliance_report := {
 	"standards": ["STIG RHEL-09-231xxx", "STIG RHEL-09-672xxx", "NIST SP 800-53 SC-28", "NIST SP 800-53 SC-13"],
 	"violations": violations,
 	"compliant": compliant,
-	"fips_enabled": object.get(input.storage_encryption, "fips_enabled", false),
-	"crypto_policy": object.get(input.storage_encryption, "crypto_policy", "unknown"),
-	"luks_volume_count": count(object.get(input.storage_encryption, "luks_volumes", [])),
+	"fips_enabled": object.get(input, ["storage_encryption", "fips_enabled"], false),
+	"crypto_policy": object.get(input, ["storage_encryption", "crypto_policy"], "unknown"),
+	"luks_volume_count": count(object.get(input, ["storage_encryption", "luks_volumes"], [])),
 }

--- a/enforcement/ansible/repo_hygiene.rego
+++ b/enforcement/ansible/repo_hygiene.rego
@@ -154,7 +154,7 @@ compliant if count(violation) == 0
 compliance_report := {
 	"policy": "AAC repository hygiene",
 	"path": path_label,
-	"plays_evaluated": count(input.plays),
+	"plays_evaluated": count(object.get(input, "plays", [])),
 	"violations": violation,
 	"violation_count": count(violation),
 	"compliant": compliant,

--- a/frameworks/compliance/cra/foss_exclusion/cra_foss_exclusion.rego
+++ b/frameworks/compliance/cra/foss_exclusion/cra_foss_exclusion.rego
@@ -94,7 +94,7 @@ compliant if { count(violation) == 0 }
 
 # Useful auxiliary field for downstream consumers.
 exemption_status := {
-    "claimed":  input.foss.claimed_exemption,
+    "claimed":  object.get(input, ["foss", "claimed_exemption"], false),
     "valid":    exempt,
     "misclaim": count(violation) > 0,
 }

--- a/frameworks/critical_infrastructure/iec_62443/part2_service_provider.rego
+++ b/frameworks/critical_infrastructure/iec_62443/part2_service_provider.rego
@@ -185,7 +185,7 @@ compliance_report := {
     "part":                     "IEC 62443-2-4",
     "title":                    "Security Program Requirements for IACS Service Providers",
     "standard":                 "IEC 62443-2-4",
-    "is_iacs_service_provider": input.is_iacs_service_provider,
+    "is_iacs_service_provider": object.get(input, "is_iacs_service_provider", false),
     "compliant":                compliant,
     "violations":               violations,
 }

--- a/frameworks/critical_infrastructure/iec_62443/part3_risk_assessment.rego
+++ b/frameworks/critical_infrastructure/iec_62443/part3_risk_assessment.rego
@@ -182,7 +182,7 @@ compliance_report := {
     "part":       "IEC 62443-3-2",
     "title":      "Security Risk Assessment for System Design",
     "standard":   "IEC 62443-3-2",
-    "target_sl":  input.target_sl,
+    "target_sl":  object.get(input, "target_sl", 0),
     "compliant":  compliant,
     "violations": violations,
 }

--- a/frameworks/federal/cmmc/cmmc_access_control.rego
+++ b/frameworks/federal/cmmc/cmmc_access_control.rego
@@ -205,11 +205,17 @@ violations contains msg if {
     some msg in level_2_violations
 }
 
+# `default` is mandatory (library rule): the fail-closed violations above FIRE
+# on missing input, so count(violations) != 0 and this rule never evaluates --
+# without the default, `compliant` is undefined and the whole report collapses
+# to {} at the endpoint. This file was the only CMMC module missing it.
+default compliant := false
+
 compliant if { count(violations) == 0 }
 
 compliance_report := {
     "domain":          "Access Control (AC)",
-    "cmmc_level":      input.cmmc_level,
+    "cmmc_level":      object.get(input, "cmmc_level", 0),
     "compliant":       compliant,
     "violation_count": count(violations),
     "violations":      violations,

--- a/frameworks/federal/cmmc/cmmc_configuration_management.rego
+++ b/frameworks/federal/cmmc/cmmc_configuration_management.rego
@@ -118,7 +118,7 @@ compliant if { count(violations) == 0 }
 
 compliance_report := {
     "domain":          "Configuration Management (CM)",
-    "cmmc_level":      input.cmmc_level,
+    "cmmc_level":      object.get(input, "cmmc_level", 0),
     "compliant":       compliant,
     "violation_count": count(violations),
     "violations":      violations,

--- a/frameworks/federal/cmmc/cmmc_incident_response.rego
+++ b/frameworks/federal/cmmc/cmmc_incident_response.rego
@@ -63,7 +63,7 @@ compliant if { count(violations) == 0 }
 
 compliance_report := {
     "domain":          "Incident Response (IR)",
-    "cmmc_level":      input.cmmc_level,
+    "cmmc_level":      object.get(input, "cmmc_level", 0),
     "compliant":       compliant,
     "violation_count": count(violations),
     "violations":      violations,

--- a/governance/geisa/geisa_adm.rego
+++ b/governance/geisa/geisa_adm.rego
@@ -96,8 +96,8 @@ compliance_report := {
 	"compliant": compliant,
 	"violation_count": count(violations),
 	"violations": violations,
-	"lwm2m_version": _lwm2m.version,
-	"registered": _lwm2m.registered,
-	"registered_objects": _lwm2m.registered_objects,
-	"object9": _obj9,
+	"lwm2m_version": object.get(input, ["lwm2m", "version"], "unknown"),
+	"registered": object.get(input, ["lwm2m", "registered"], false),
+	"registered_objects": object.get(input, ["lwm2m", "registered_objects"], []),
+	"object9": object.get(input, ["lwm2m", "object9"], {}),
 }

--- a/governance/geisa/geisa_api.rego
+++ b/governance/geisa/geisa_api.rego
@@ -95,7 +95,7 @@ compliance_report := {
 	"compliant": compliant,
 	"violation_count": count(violations),
 	"violations": violations,
-	"app_id": _app_id,
-	"geisa_version": _discovery.geisa_version,
-	"platform_discovery_status": _discovery.status_code,
+	"app_id": object.get(input, ["manifest", "applicationId"], "unknown"),
+	"geisa_version": object.get(input, ["discovery_response", "geisa_version"], "unknown"),
+	"platform_discovery_status": object.get(input, ["discovery_response", "status_code"], 0),
 }

--- a/governance/geisa/geisa_compliance.rego
+++ b/governance/geisa/geisa_compliance.rego
@@ -79,8 +79,8 @@ _pillars := [
 
 compliance_report := {
 	"compliant": compliant,
-	"app_id": input.manifest.applicationId,
-	"app_version": input.manifest.version,
+	"app_id": object.get(input, ["manifest", "applicationId"], "unknown"),
+	"app_version": object.get(input, ["manifest", "version"], "unknown"),
 	"total_violations": count(all_violations),
 	"pillars": _pillars,
 	"violations": all_violations,

--- a/governance/geisa/geisa_lee.rego
+++ b/governance/geisa/geisa_lee.rego
@@ -67,8 +67,8 @@ compliance_report := {
 	"compliant": compliant,
 	"violation_count": count(violations),
 	"violations": violations,
-	"runtime": _container.runtime,
-	"runtime_version": _container.runtime_version,
-	"isolated": _container.isolated,
-	"network_mode": _container.network_mode,
+	"runtime": object.get(input, ["container", "runtime"], "unknown"),
+	"runtime_version": object.get(input, ["container", "runtime_version"], "unknown"),
+	"isolated": object.get(input, ["container", "isolated"], false),
+	"network_mode": object.get(input, ["container", "network_mode"], "unknown"),
 }


### PR DESCRIPTION
Systematic sweep: evaluate `data` once with empty input, compare against every package declaring `compliance_report`/`compliance_assessment` in source. **260 declared, 14 collapsed. All fixed; sweep now returns 0.**

Five distinct causes — each a different way to write the same defect:

| Cause | Files |
|---|---|
| Bare `input.*` in the report body | cmmc ×3, iec_62443 ×2, geisa_compliance |
| **The half-defaulted trap** — `object.get(input.x, "y", [])` defaults the leaf but derefs the undefined base | cis_rhel9 ×3 (these *looked* defensive) |
| Fields sourced from undefaulted helpers (`_lwm2m := input.lwm2m`) | geisa adm/api/lee |
| Helper object with one bare field | cra foss_exclusion |
| **Missing `default compliant := false`** — the library's own mandatory rule; fail-closed violations fire on empty input so `compliant if count==0` never evaluates | cmmc_access_control (only CMMC module missing it) |

Also clean: `opa check`, 548/548 tests, `import rego.v1` in all 644 files, no lab identifiers, **all 18 m365 aggregates populated**.

One of the 14 was `repo_hygiene.rego` — added two days ago by me. The rule that catches this class catches its own policeman.