### PR TITLE
fix(ci): GHCR publish auth — PAT with GITHUB_TOKEN fallback

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -63,7 +63,13 @@ jobs:
 
       - name: Login to GHCR
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io \
+          # GHCR_PAT preferred: the package predates this workflow (created
+          # by a manual push), and GitHub offers no API to grant a package
+          # Actions write access — GITHUB_TOKEN gets permission_denied even
+          # with packages:write (every run since 2026-08-29 failed this way).
+          # Falls back to GITHUB_TOKEN once the package access is fixed in
+          # the UI (package settings -> Manage Actions access -> add repo).
+          echo "${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}" | oras login ghcr.io \
             -u "${{ github.actor }}" \
             --password-stdin
 


### PR DESCRIPTION
Chronic since 2026-08-29 (every push): `permission_denied: write_package`. The package was created by a manual push, so the workflow's `GITHUB_TOKEN` has no write access and GitHub exposes no API to grant it (UI-only toggle). Push now authenticates with the `GHCR_PAT` secret (set), falling back to `GITHUB_TOKEN` for the day the package access is fixed in the UI.

Optional permanent cleanup for Tim: package settings → Manage Actions access → add this repo with write — then the secret can be retired.

Approved-By: ynotbha@aisle-five.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNF5rAx6FGZi7TXtU2mJsf