### PR TITLE
feat(governance): security exception waivers (waived, never hidden)

### DIFF
--- a/governance/exceptions/waivers.rego
+++ b/governance/exceptions/waivers.rego
@@ -1,0 +1,100 @@
+# Security exception waivers — waived, never hidden.
+#
+# A waiver moves a finding from active violations to a waived set; it never
+# deletes it. Consumers must store and report the waived set alongside the
+# active one so an assessor sees a documented exception (justification,
+# approver, expiry), not an absence. Expired waivers stop matching
+# automatically — the finding reverts to an active violation with no
+# configuration change.
+#
+# Waiver entries are plain data, loaded at data.waivers.entries (e.g.
+# PUT /v1/data/waivers). Each entry:
+#
+#   {
+#     "host":       "web01.example.com",   # or "*" for any host
+#     "framework":  "cis_rhel9",           # or "*" for any framework
+#     "control_id": "5.2.1",               # substring matched against the violation text
+#     "reason":     "Compensating control: ...",
+#     "approver":   "security-officer@example.com",
+#     "expires":    "2026-12-31"           # YYYY-MM-DD; entries without a date never match.
+#                                          # Dates must be before year 2262 (int64 ns limit) —
+#                                          # a far-future date fails to parse and the entry
+#                                          # silently never matches (fails toward reporting).
+#   }
+#
+# Query: POST /v1/data/exceptions/decision with
+#   input: {"host": "...", "framework": "...", "violations": [...]}
+# Violations may be strings or objects; objects are matched against their
+# JSON serialization, so a control ID anywhere in the object matches.
+
+package exceptions
+
+import rego.v1
+
+# Narrow reference (never object.get(data, ...)) — depending on the whole data
+# document would include this package's own rules and trip recursion checks.
+default waiver_entries := []
+
+waiver_entries := data.waivers.entries
+
+input_violations := object.get(input, "violations", [])
+
+input_host := object.get(input, "host", "")
+
+input_framework := object.get(input, "framework", "")
+
+# ── Matching ──────────────────────────────────────────────────────────────────
+
+violation_text(v) := v if is_string(v)
+
+violation_text(v) := json.marshal(v) if not is_string(v)
+
+entry_active(entry) if {
+	exp := object.get(entry, "expires", "")
+	exp != ""
+	time.now_ns() < time.parse_ns("2006-01-02", exp)
+}
+
+entry_matches(entry, v) if {
+	object.get(entry, "host", "*") in {input_host, "*"}
+	object.get(entry, "framework", "*") in {input_framework, "*"}
+	cid := object.get(entry, "control_id", "")
+	cid != ""
+	contains(violation_text(v), cid)
+}
+
+# ── Decision sets ─────────────────────────────────────────────────────────────
+
+waived contains {"violation": v, "waiver": entry} if {
+	some v in input_violations
+	some entry in waiver_entries
+	entry_active(entry)
+	entry_matches(entry, v)
+}
+
+waived_violations contains v if {
+	some w in waived
+	v := w.violation
+}
+
+active_violations := [v |
+	some v in input_violations
+	not v in waived_violations
+]
+
+# Matching entries that no longer apply because their expiry passed — surfaced
+# so reports can flag findings that were waived and have silently reverted.
+expired_matches contains {"violation": v, "waiver": entry} if {
+	some v in input_violations
+	some entry in waiver_entries
+	not entry_active(entry)
+	entry_matches(entry, v)
+}
+
+decision := {
+	"active_violations": active_violations,
+	"waived": waived,
+	"waived_count": count(waived_violations),
+	"expired_matches": expired_matches,
+	"waiver_entries_loaded": count(waiver_entries),
+}

--- a/governance/exceptions/waivers_test.rego
+++ b/governance/exceptions/waivers_test.rego
@@ -1,0 +1,97 @@
+package exceptions_test
+
+import rego.v1
+
+import data.exceptions
+
+# Expiry dates deliberately far in the future / past so tests need no clock mocking.
+active_entry := {
+	"host": "web01",
+	"framework": "cis_rhel9",
+	"control_id": "5.2.1",
+	"reason": "Compensating control in place",
+	"approver": "sec-officer@example.com",
+	"expires": "2200-01-01",
+}
+
+expired_entry := object.union(active_entry, {"expires": "2000-01-01"})
+
+wildcard_entry := object.union(active_entry, {"host": "*", "framework": "*"})
+
+violations_in := [
+	"CIS 5.2.1: SSH PermitRootLogin must be disabled",
+	"CIS 1.1.1: cramfs must be disabled",
+]
+
+test_active_waiver_filters_matching_violation if {
+	d := exceptions.decision with data.waivers as {"entries": [active_entry]}
+		with input as {"host": "web01", "framework": "cis_rhel9", "violations": violations_in}
+	d.waived_count == 1
+	d.active_violations == ["CIS 1.1.1: cramfs must be disabled"]
+	count(d.waived) == 1
+}
+
+test_waived_set_carries_full_waiver_record if {
+	d := exceptions.decision with data.waivers as {"entries": [active_entry]}
+		with input as {"host": "web01", "framework": "cis_rhel9", "violations": violations_in}
+	some w in d.waived
+	w.waiver.approver == "sec-officer@example.com"
+	w.waiver.reason == "Compensating control in place"
+}
+
+test_expired_waiver_does_not_filter_and_is_surfaced if {
+	d := exceptions.decision with data.waivers as {"entries": [expired_entry]}
+		with input as {"host": "web01", "framework": "cis_rhel9", "violations": violations_in}
+	d.waived_count == 0
+	count(d.active_violations) == 2
+	count(d.expired_matches) == 1
+}
+
+test_wrong_host_does_not_match if {
+	d := exceptions.decision with data.waivers as {"entries": [active_entry]}
+		with input as {"host": "db01", "framework": "cis_rhel9", "violations": violations_in}
+	d.waived_count == 0
+	count(d.active_violations) == 2
+}
+
+test_wrong_framework_does_not_match if {
+	d := exceptions.decision with data.waivers as {"entries": [active_entry]}
+		with input as {"host": "web01", "framework": "nerc_cip", "violations": violations_in}
+	d.waived_count == 0
+}
+
+test_wildcard_host_and_framework_match if {
+	d := exceptions.decision with data.waivers as {"entries": [wildcard_entry]}
+		with input as {"host": "anything", "framework": "nerc_cip", "violations": violations_in}
+	d.waived_count == 1
+}
+
+test_object_violations_match_on_serialized_content if {
+	obj_violations := [{"control": "CIS 5.2.1", "detail": "PermitRootLogin yes"}]
+	d := exceptions.decision with data.waivers as {"entries": [active_entry]}
+		with input as {"host": "web01", "framework": "cis_rhel9", "violations": obj_violations}
+	d.waived_count == 1
+	d.active_violations == []
+}
+
+test_no_waiver_data_loaded_is_a_noop if {
+	d := exceptions.decision with data.waivers as {}
+		with input as {"host": "web01", "framework": "cis_rhel9", "violations": violations_in}
+	d.waived_count == 0
+	count(d.active_violations) == 2
+	d.waiver_entries_loaded == 0
+}
+
+test_entry_without_expiry_never_matches if {
+	no_expiry := object.remove(active_entry, ["expires"])
+	d := exceptions.decision with data.waivers as {"entries": [no_expiry]}
+		with input as {"host": "web01", "framework": "cis_rhel9", "violations": violations_in}
+	d.waived_count == 0
+}
+
+test_empty_violations_yields_empty_decision if {
+	d := exceptions.decision with data.waivers as {"entries": [active_entry]}
+		with input as {"host": "web01", "framework": "cis_rhel9", "violations": []}
+	d.waived_count == 0
+	d.active_violations == []
+}


### PR DESCRIPTION
Generic exception-waiver module for any framework consumer. Waiver entries load as OPA data (`data.waivers.entries`); `POST /v1/data/exceptions/decision` splits violations into active vs waived, carrying each waiver's justification/approver/expiry into the result, and surfaces expired matches so silently-reverted waivers stay visible. Expiry is mandatory — an entry without one never matches, and every failure mode fails toward reporting the violation. 10/10 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNF5rAx6FGZi7TXtU2mJsf