### PR TITLE
feat(crosswalk): framework-inheritance overlay — one assessment, many frameworks

### DIFF
--- a/crosswalk/framework_maps/data.json
+++ b/crosswalk/framework_maps/data.json
@@ -1,0 +1,1 @@
+{"meta":{"note":"Framework 800-53 inheritance maps. Only status:authoritative entries are scored by crosswalk.framework_overlay; each carries a source. Seeded empty pending authoritative fetch — see docs/CONTROL_CORRELATION_PATTERN.md §7."},"maps":{}}

--- a/crosswalk/framework_overlay.rego
+++ b/crosswalk/framework_overlay.rego
@@ -1,0 +1,91 @@
+package crosswalk.framework_overlay
+
+import rego.v1
+
+# Framework inheritance overlay — "report against many."
+#
+# Sits on top of crosswalk.correlation (the 800-53 control spine) and
+# answers, from a SINGLE assessment: for each framework that declares its
+# 800-53 inheritance, which of its controls are discharged, which have gaps,
+# and which are not covered by the spine at all.
+#
+# HONESTY RULES (match the rest of the library):
+#   - Only frameworks with an AUTHORITATIVELY-SOURCED mapping are reported.
+#     Each framework map in data.crosswalk.framework_maps carries a `source`
+#     and `status` ("authoritative" | "pending"). Maps marked "pending" (no
+#     grounded source yet) are listed under `frameworks_pending`, never scored.
+#   - A framework control is "satisfied" only if it maps to ≥1 evaluated
+#     spine control AND all of them are satisfied.
+#   - A framework control whose 800-53 controls were not evaluated is
+#     "not_covered" — explicit, never counted as a pass.
+#
+# Data contract (data.crosswalk.framework_maps):
+#   {
+#     "<framework_key>": {
+#       "name": "...", "source": "URL/citation", "status": "authoritative",
+#       "map": { "<framework_control_id>": ["AC-17", "SC-28", ...], ... }
+#     }, ...
+#   }
+#
+# Input: same as crosswalk.correlation (input.findings).
+
+import data.crosswalk.correlation
+
+default _maps := {}
+
+_maps := data.crosswalk.framework_maps.maps
+
+_control_status := correlation.control_status
+
+# Per-framework coverage, authoritative maps only.
+coverage[fw] := result if {
+	some fw, spec in _maps
+	spec.status == "authoritative"
+	result := _coverage_for(spec.map)
+}
+
+_coverage_for(fwmap) := {
+	"satisfied": sat,
+	"gaps": gaps,
+	"not_covered": notcov,
+	"controls_total": count(fwmap),
+	"controls_satisfied": count(sat),
+} if {
+	sat := sort([fc |
+		some fc, ctrls in fwmap
+		count(ctrls) > 0
+		every c in ctrls {_control_status[c] == "satisfied"}
+		some c in ctrls
+		_control_status[c] # at least one actually evaluated
+	])
+	gaps := sort([fc |
+		some fc, ctrls in fwmap
+		some c in ctrls
+		_control_status[c] == "gap"
+	])
+	# not_covered: framework controls whose spine controls were never evaluated
+	notcov := sort([fc |
+		some fc, ctrls in fwmap
+		not _any_evaluated(ctrls)
+	])
+}
+
+_any_evaluated(ctrls) if {
+	some c in ctrls
+	_control_status[c]
+}
+
+frameworks_reported := sort([fw | some fw, _ in coverage])
+
+frameworks_pending := sort([fw |
+	some fw, spec in _maps
+	spec.status == "pending"
+])
+
+# One-assessment summary: what this run discharged, across all frameworks.
+summary := {
+	"spine": correlation.summary,
+	"frameworks_reported": frameworks_reported,
+	"frameworks_pending": frameworks_pending,
+	"coverage": coverage,
+}

--- a/crosswalk/tests/test_framework_overlay.rego
+++ b/crosswalk/tests/test_framework_overlay.rego
@@ -1,0 +1,73 @@
+package crosswalk.framework_overlay_test
+
+import rego.v1
+
+import data.crosswalk.framework_overlay
+
+# Deterministic test doubles for both the spine crosswalk and the framework
+# maps, so the test is independent of shipped data volume.
+sample_stig_map := {
+	"RULE-A": ["AC-17", "SC-28"],
+	"RULE-B": ["AC-17"],
+	"RULE-C": ["AU-3"],
+}
+
+sample_fw_maps := {
+	"demo_authoritative": {
+		"name": "Demo FW",
+		"source": "test",
+		"status": "authoritative",
+		"map": {
+			"REQ-1": ["SC-28"], # only satisfied spine control → satisfied
+			"REQ-2": ["AC-17"], # AC-17 is a gap (RULE-B open) → gap
+			"REQ-3": ["CP-9"], # never evaluated → not_covered
+		},
+	},
+	"demo_pending": {
+		"name": "Pending FW",
+		"source": "none yet",
+		"status": "pending",
+		"map": {"X": ["AC-17"]},
+	},
+}
+
+findings := [
+	{"stig_id": "RULE-A", "status": "Not_a_Finding"},
+	{"stig_id": "RULE-B", "status": "Open"},
+	{"stig_id": "RULE-C", "status": "Not_a_Finding"},
+]
+
+_with := {
+	"input": {"findings": findings},
+}
+
+test_authoritative_framework_scored if {
+	cov := framework_overlay.coverage["demo_authoritative"]
+		with input as {"findings": findings}
+		with data.crosswalk.stig_800_53.map as sample_stig_map
+		with data.crosswalk.framework_maps.maps as sample_fw_maps
+	cov.satisfied == ["REQ-1"]
+	cov.gaps == ["REQ-2"]
+	cov.not_covered == ["REQ-3"]
+	cov.controls_total == 3
+	cov.controls_satisfied == 1
+}
+
+test_pending_framework_never_scored if {
+	s := framework_overlay.summary
+		with input as {"findings": findings}
+		with data.crosswalk.stig_800_53.map as sample_stig_map
+		with data.crosswalk.framework_maps.maps as sample_fw_maps
+	s.frameworks_reported == ["demo_authoritative"]
+	s.frameworks_pending == ["demo_pending"]
+	not s.coverage["demo_pending"]
+}
+
+test_no_framework_maps_is_safe if {
+	s := framework_overlay.summary
+		with input as {"findings": findings}
+		with data.crosswalk.stig_800_53.map as sample_stig_map
+		with data.crosswalk.framework_maps.maps as {}
+	s.frameworks_reported == []
+	count(s.spine.satisfied) > 0 # spine still works with no overlays
+}


### PR DESCRIPTION
Builds on the 800-53 spine (#108): the overlay engine that reports per-framework coverage from a single assessment.

`crosswalk/framework_overlay.rego` reads `data.crosswalk.framework_maps.maps` and emits, per framework, `satisfied / gaps / not_covered`. **Honesty enforced in code + tests**: only `status:"authoritative"` maps are scored; `status:"pending"` maps are listed but never scored; a framework control whose spine controls weren't evaluated is `not_covered`, never a silent pass.

Ships with **empty maps** — the engine and its guarantees are the deliverable. Authoritative 800-53 crosswalks (800-53B baselines, 800-171, CSF, ISO 27001, CIS Controls v8) drop into `crosswalk/framework_maps/` as they're sourced (per pattern doc §7). No mapping is invented — a research pass to fetch the authoritative sources is in flight.

Full library 638/638 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNF5rAx6FGZi7TXtU2mJsf